### PR TITLE
Adjust default C# research notebook

### DIFF
--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -190,19 +190,19 @@ DEFAULT_CSHARP_NOTEBOOK = """
             "source": []
         }
     ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "C#",
-            "language": "csharp",
-            "name": "csharp"
-        },
-        "language_info": {
-            "file_extension": ".cs",
-            "mimetype": "text/x-csharp",
-            "name": "C#",
-            "pygments_lexer": "c#",
-            "version": "4.0.30319"
-        }
+     "metadata": {
+      "kernelspec": {
+       "display_name": ".NET (C#)",
+       "language": "C#",
+       "name": ".net-csharp"
+      },
+      "language_info": {
+       "file_extension": ".cs",
+       "mimetype": "text/x-csharp",
+       "name": "C#",
+       "pygments_lexer": "csharp",
+       "version": "9.0"
+      }
     },
     "nbformat": 4,
     "nbformat_minor": 2

--- a/tests/commands/test_create_project.py
+++ b/tests/commands/test_create_project.py
@@ -52,7 +52,7 @@ def assert_csharp_project_exists() -> None:
         assert "class MyFirstProject : QCAlgorithm" in file.read()
 
     with open(project_dir / "research.ipynb") as file:
-        assert json.load(file)["metadata"]["kernelspec"]["language"] == "csharp"
+        assert json.load(file)["metadata"]["kernelspec"]["language"] == "C#"
 
     with open(project_dir / "config.json") as file:
         assert json.load(file)["algorithm-language"] == "CSharp"


### PR DESCRIPTION
Adjust default C# research notebook which caused issues running under windows

Was getting the following errror
```
Lean\Launcher\bin\Debug\QuantConnect.csx(56,14): error CS0012: The type 'MarshalByRefObject' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
   at Microsoft.CodeAnalysis.Scripting.Script.CompilationError(DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.Scripting.Script.GetExecutor(CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Scripting.Script.TryRunFrom(ScriptState state, ScriptExecutionState& executionState, Object& value)
   at Microsoft.CodeAnalysis.Scripting.Script.Run(Object globals)
   at Microsoft.CodeAnalysis.Scripting.Script.Run(Object globals)
   at Microsoft.CodeAnalysis.Scripting.CSharp.CSharpScript.Run(String code, ScriptOptions options, Object globals)
   at ScriptCs.Engine.Roslyn.CSharpScriptEngine.GetScriptState(String code, Object globals) in D:\QuantConnect\MyLean\icsharp\Engine\src\ScriptCs.Engine.Roslyn\CSharpScriptEngine.cs:line 18
   at ScriptCs.Engine.Roslyn.CommonScriptEngine.Execute(String code, Object globals, SessionState`1 sessionState) in D:\QuantConnect\MyLean\icsharp\Engine\src\ScriptCs.Engine.Roslyn\CommonScriptEngine.cs:line 158

```

Tested locally and under `lean research` environment 