### PR TITLE
Fix spelling of "zerodha" in live.py

### DIFF
--- a/lean/commands/live.py
+++ b/lean/commands/live.py
@@ -37,7 +37,7 @@ _required_brokerage_properties = {
     "BitfinexBrokerage": ["bitfinex-api-secret", "bitfinex-api-key"],
     "BinanceBrokerage": ["binance-api-secret", "binance-api-key"],
     "ZerodhaBrokerage": ["zerodha-access-token", "zerodha-api-key",
-                         "zerodha-product-type", "zeroda-trading-segment", "zerodha-history-subscription"]
+                         "zerodha-product-type", "zerodha-trading-segment", "zerodha-history-subscription"]
 }
 
 # Data queue handler -> required configuration properties


### PR DESCRIPTION
zeroda-trading-segment => zerodha-trading-segment

**Error Message Before Change:**

Error: Please configure the following missing property in C:\Users\Rjra2611\Desktop\All Projects Codes\QuantConnect\lean.json:
 zeroda-trading-segment
Go to the following url for documentation on this property:
https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading
