### PR TITLE
Get Logs of a Project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Vscode
+settings.json

--- a/lean/commands/__init__.py
+++ b/lean/commands/__init__.py
@@ -29,6 +29,7 @@ from lean.commands.optimize import optimize
 from lean.commands.report import report
 from lean.commands.research import research
 from lean.commands.whoami import whoami
+from lean.commands.logs import logs
 
 
 @click.group()
@@ -56,3 +57,4 @@ lean.add_command(research)
 lean.add_command(report)
 lean.add_command(live)
 lean.add_command(build)
+lean.add_command(logs)

--- a/lean/commands/logs.py
+++ b/lean/commands/logs.py
@@ -1,0 +1,77 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from pathlib import Path
+from lean.click import LeanCommand,PathParameter
+from lean.container import container
+
+logger = container.logger()
+
+
+@click.command(cls=LeanCommand)
+@click.option("--live",'mode',flag_value="live",help="get latest live log")
+@click.option("--backtest",'mode',flag_value="backtests",help="get latest backtests log")
+@click.option("--optimization",'mode',flag_value="optimizations",help="get latest optimization log")
+@click.option("--project_path",type=PathParameter(exists=True,dir_okay=True,file_okay=False),
+help="get log from project path Ex: <Project>/<mode>/<datetime> :: 'Python Project/live/2020-01-01_00-00-00'")
+@click.option("--project",type=str,help="get latest log from Project Name")
+def logs(mode:str,project_path:Path,project:str,print_n_lines=5):
+    """Logs command that ouputs log based on the type such as Live / Backtesting / Optimizations
+
+    Args:
+        mode (str): [description]
+        project_path (PathParameter): [description]
+    """
+    if mode is None and project_path is None:
+        logger.info("--live or --backtest or --optimization flags are not provided. Defaulting to backtest.")
+        mode="backtests"
+    if project_path is None:
+        if project is None:
+            mode_log_files = list(Path.cwd().rglob(f"{mode}/*/log.txt"))
+        else:
+            if Path(project).exists():
+                mode_log_files = list(Path.cwd().rglob(f"{project}/{mode}/*/log.txt"))
+            else:
+                raise NotADirectoryError(f"{project} Project not created. Please create using lean create-project {project}.")
+        if len(mode_log_files) == 0:
+                raise ValueError(
+                    f"Could not find a recent {mode} log file, see if you have run project in {mode} mode"
+                )
+        mode_log_file = sorted(mode_log_files, key=lambda f: f.stat().st_mtime, reverse=True)[0]
+        project_path = mode_log_file.parent
+    else:
+        mode_log_file = project_path/"log.txt"
+    if not mode_log_file.exists():
+        raise FileNotFoundError(f"Cannot find log file for {project_path}. Please rerun the project with {mode} mode.")
+    with open(mode_log_file) as file:
+        buffer = []
+        full_flag=False
+        for line in file.readlines():
+            if full_flag!=True:
+                buffer.append(line)
+                if len(buffer)>=print_n_lines:
+                    print("".join(buffer),end="")
+                    buffer.clear()
+                    input_char = input("Press Enter to print next set of lines or Press a and Enter for printing full log file.")
+                    if input_char=="a":
+                        full_flag=True
+            else:
+                print(line,end="")
+
+        print("".join(buffer))
+        logger.info("End of the Log!")
+
+            
+    
+    

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -46,11 +46,11 @@ def _create_add_text(file_data):
 def setup_log_results() -> None:
     """A pytest fixture which creates a backtest results file before every test."""
     create_fake_lean_cli_directory()
-    logs_backtest_1_path_data_old = [Path.cwd() / "Python Project 1" / "backtests" / "2020-01-01_00-00-00" /"log.txt", BACKTEST_SAMPLE_OLD_LOG]
-    logs_backtest_1_path_data_new = [Path.cwd() / "Python Project 1" / "backtests" / "2020-01-02_00-00-00" / "log.txt",BACKTEST_SAMPLE_NEW_LOG]
-    logs_backtest_path_data_old = [Path.cwd() / "Python Project" / "backtests" / "2020-01-01_00-00-00" /"log.txt", BACKTEST_SAMPLE_OLD_LOG]
-    logs_backtest_path_data_new = [Path.cwd() / "Python Project" / "backtests" / "2020-01-02_00-00-00" / "log.txt",BACKTEST_SAMPLE_NEW_LOG]
-    logs_live_path_data = [Path.cwd() / "Python Project" / "live" / "2020-01-01_00-00-00" / "log.txt",LIVE_SAMPLE_LOG]
+    logs_backtest_1_path_data_old = [Path.cwd() / "Python Project 1" / "backtests" / "2020-01-01_00-00-00" /"log.txt", "Python Project 1"+BACKTEST_SAMPLE_OLD_LOG]
+    logs_backtest_1_path_data_new = [Path.cwd() / "Python Project 1" / "backtests" / "2020-01-02_00-00-00" / "log.txt","Python Project 1"+BACKTEST_SAMPLE_NEW_LOG]
+    logs_backtest_path_data_old = [Path.cwd() / "Python Project" / "backtests" / "2020-01-01_00-00-00" /"log.txt", "Python Project"+BACKTEST_SAMPLE_OLD_LOG]
+    logs_backtest_path_data_new = [Path.cwd() / "Python Project" / "backtests" / "2020-01-02_00-00-00" / "log.txt","Python Project"+BACKTEST_SAMPLE_NEW_LOG]
+    logs_live_path_data = [Path.cwd() / "Python Project" / "live" / "2020-01-01_00-00-00" / "log.txt","Python Project"+LIVE_SAMPLE_LOG]
     list(map(_create_add_text,[logs_backtest_1_path_data_old,logs_backtest_1_path_data_new,logs_backtest_path_data_old,logs_backtest_path_data_new,logs_live_path_data]))
     return True
     
@@ -77,7 +77,7 @@ def test_logs_project_latest() -> None:
     result = CliRunner().invoke(lean,["logs","--backtest","--project",'Python Project 1'],input="\n")
 
     assert result.exit_code == 0
-    assert BACKTEST_SAMPLE_NEW_LOG in result.output
+    assert "Python Project 1"+BACKTEST_SAMPLE_NEW_LOG in result.output
 
 def test_logs_path()->None:
     result = CliRunner().invoke(lean,["logs","--project_path",'Python Project/live/2020-01-01_00-00-00'],input="\n")
@@ -94,5 +94,8 @@ def test_logs_project_not_exist() -> None:
     assert result.exit_code == 1
     assert type(result.exception) == NotADirectoryError
 
-
+def test_logs_mode_project()->None:
+    result = CliRunner().invoke(lean,["logs","--live","--project","Python Project",])
+    assert result.exit_code == 0
+    assert "Python Project"+LIVE_SAMPLE_LOG in result.output
 

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -1,0 +1,98 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+from dependency_injector import providers
+
+from lean.commands import lean
+from lean.container import container
+from tests.test_helpers import create_fake_lean_cli_directory
+
+
+BACKTEST_SAMPLE_OLD_LOG = "oldbacktest\n"
+BACKTEST_SAMPLE_NEW_LOG = "1\n2\nnewbacktest\n"
+OPTIMIZATION_SAMPLE_LOG="optimization\n"
+LIVE_SAMPLE_LOG="live\n"
+UNKNOWN_MODE_ERROR= "Error: no such option: --wrongmode"
+@pytest.fixture(autouse=True)
+def update_manager_mock() -> mock.Mock:
+    """A pytest fixture which mocks the update manager before every test."""
+    update_manager = mock.Mock()
+    container.update_manager.override(providers.Object(update_manager))
+    return update_manager
+
+def _create_add_text(file_data):
+    file_data[0].parent.mkdir(parents=True, exist_ok=True)
+    with file_data[0].open("w+", encoding="utf-8") as file:
+        file.write(file_data[1])
+
+
+@pytest.fixture(autouse=True)
+def setup_log_results() -> None:
+    """A pytest fixture which creates a backtest results file before every test."""
+    create_fake_lean_cli_directory()
+    logs_backtest_1_path_data_old = [Path.cwd() / "Python Project 1" / "backtests" / "2020-01-01_00-00-00" /"log.txt", BACKTEST_SAMPLE_OLD_LOG]
+    logs_backtest_1_path_data_new = [Path.cwd() / "Python Project 1" / "backtests" / "2020-01-02_00-00-00" / "log.txt",BACKTEST_SAMPLE_NEW_LOG]
+    logs_backtest_path_data_old = [Path.cwd() / "Python Project" / "backtests" / "2020-01-01_00-00-00" /"log.txt", BACKTEST_SAMPLE_OLD_LOG]
+    logs_backtest_path_data_new = [Path.cwd() / "Python Project" / "backtests" / "2020-01-02_00-00-00" / "log.txt",BACKTEST_SAMPLE_NEW_LOG]
+    logs_live_path_data = [Path.cwd() / "Python Project" / "live" / "2020-01-01_00-00-00" / "log.txt",LIVE_SAMPLE_LOG]
+    list(map(_create_add_text,[logs_backtest_1_path_data_old,logs_backtest_1_path_data_new,logs_backtest_path_data_old,logs_backtest_path_data_new,logs_live_path_data]))
+    return True
+    
+
+def test_logs_no_mode() -> None:
+    result = CliRunner().invoke(lean, ["logs"])
+
+    assert result.exit_code == 0
+    assert "Defaulting to" in result.output
+
+def test_logs_mode_not_present() -> None:
+    result = CliRunner().invoke(lean, ["logs","--optimization"])
+
+    assert result.exit_code == 1
+    assert type(result.exception) == ValueError
+
+def test_logs_no_project_latest() -> None:
+    result = CliRunner().invoke(lean,["logs","--backtest"],input="\n")
+
+    assert result.exit_code == 0
+    assert BACKTEST_SAMPLE_NEW_LOG in result.output
+
+def test_logs_project_latest() -> None:
+    result = CliRunner().invoke(lean,["logs","--backtest","--project",'Python Project 1'],input="\n")
+
+    assert result.exit_code == 0
+    assert BACKTEST_SAMPLE_NEW_LOG in result.output
+
+def test_logs_path()->None:
+    result = CliRunner().invoke(lean,["logs","--project_path",'Python Project/live/2020-01-01_00-00-00'],input="\n")
+
+    assert LIVE_SAMPLE_LOG in result.output
+
+def test_logs_unknown_mode() -> None:
+    result = CliRunner().invoke(lean,["logs","--wrongmode"])
+    assert result.exit_code==2
+    assert UNKNOWN_MODE_ERROR in result.output
+
+def test_logs_project_not_exist() -> None:
+    result = CliRunner().invoke(lean,["logs","--project","notExist"])
+    assert result.exit_code == 1
+    assert type(result.exception) == NotADirectoryError
+
+
+


### PR DESCRIPTION
This tries to solve: https://github.com/QuantConnect/lean-cli/issues/24

This P.R contains following features:

- Get latest logs for different modes (flags) => live, backtest, optimization.
`lean logs --live`
`lean logs --backtest`
`lean logs --optimization`

- User also has the option to get latest log from a project.
`lean logs --project myProject --live`

- User can also get the log by giving path to the project.
`lean logs --project_path myProject/backtests/2020-01-01_00-00-00`

- Logs are displayed in chunks i.e, 5 lines at once. User can traverse by pressing Enter or retrieve whole list by pressing char 'a'.
- User is also directed under failure conditions such as when project doesn't exist, giving a different mode other than (live, backtest, optimization)
- Contains test cases.
