### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@
 
 The Lean CLI is a cross-platform CLI aimed at making it easier to develop with the LEAN engine locally and in the cloud.
 
-Visit the [documentation website](https://www.lean.io/docs/lean-cli/getting-started/lean-cli) for comprehensive and up-to-date documentation.
+Visit the [documentation website](https://www.lean.io/docs/lean-cli/key-concepts/getting-started) for comprehensive and up-to-date documentation.
 
 ## Highlights
 
-- [Project scaffolding](https://www.lean.io/docs/lean-cli/tutorials/project-management)
-- [Local autocomplete](https://www.lean.io/docs/lean-cli/tutorials/local-autocomplete)
-- [Local data downloading](https://www.lean.io/docs/lean-cli/tutorials/local-data/downloading-from-quantconnect)
-- [Local backtesting](https://www.lean.io/docs/lean-cli/tutorials/backtesting/running-backtests#02-Running-local-backtests)
-- [Local debugging](https://www.lean.io/docs/lean-cli/tutorials/backtesting/debugging-local-backtests)
-- [Local research environment](https://www.lean.io/docs/lean-cli/tutorials/research)
-- [Local optimization](https://www.lean.io/docs/lean-cli/tutorials/optimization/local-optimizations)
-- [Local live trading](https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading)
-- [Local backtest report creation](https://www.lean.io/docs/lean-cli/tutorials/generating-reports)
-- [Cloud synchronization](https://www.lean.io/docs/lean-cli/tutorials/cloud-synchronization)
-- [Cloud backtesting](https://www.lean.io/docs/lean-cli/tutorials/backtesting/running-backtests#03-Running-cloud-backtests)
-- [Cloud optimization](https://www.lean.io/docs/lean-cli/tutorials/optimization/cloud-optimizations)
-- [Cloud live trading](https://www.lean.io/docs/lean-cli/tutorials/live-trading/cloud-live-trading)
+- [Project scaffolding](https://www.lean.io/docs/lean-cli/projects/project-management)
+- [Local autocomplete](https://www.lean.io/docs/lean-cli/projects/autocomplete)
+- [Local data downloading](https://www.lean.io/docs/lean-cli/datasets/downloading-quantconnect-data)
+- [Local backtesting](https://www.lean.io/docs/lean-cli/backtesting/deployment#02-Run-Local-Backtests)
+- [Local debugging](https://www.lean.io/docs/lean-cli/tutorials/backtesting/debugging)
+- [Local research environment](https://www.lean.io/docs/lean-cli/research)
+- [Local optimization](https://www.lean.io/docs/lean-cli/optimization/deployment#02-Run-Local-Optimizations)
+- [Local live trading](https://www.lean.io/docs/lean-cli/live-trading/quantconnect-paper-trading#02-Deploy-Local-Algorithms)
+- [Local backtest report creation](https://www.lean.io/docs/lean-cli/backtesting/report#02-Generate-a-Report)
+- [Cloud synchronization](https://www.lean.io/docs/lean-cli/projects/cloud-synchronization)
+- [Cloud backtesting](https://www.lean.io/docs/lean-cli/backtesting/deployment#03-Run-Cloud-Backtests)
+- [Cloud optimization](https://www.lean.io/docs/lean-cli/optimization/deployment#03-Run-Cloud-Optimizations)
+- [Cloud live trading](https://www.lean.io/docs/lean-cli/live-trading/quantconnect-paper-trading#03-Deploy-Cloud-Algorithms)
 
 ## Installation
 
@@ -54,7 +54,7 @@ A locally-focused workflow (local development, local execution) with the CLI may
 
 ## Commands
 
-*Note: the readme only contains the `--help` text of all commands. Visit the [documentation website](https://www.lean.io/docs/lean-cli/getting-started/lean-cli) for more comprehensive documentation.*
+*Note: the readme only contains the `--help` text of all commands. Visit the [documentation website](https://www.lean.io/docs/lean-cli/key-concepts/getting-started) for more comprehensive documentation.*
 
 <!-- commands start -->
 - [`lean backtest`](#lean-backtest)
@@ -101,7 +101,7 @@ Usage: lean backtest [OPTIONS] PROJECT
   If PROJECT is a file, the algorithm in the specified file will be executed.
 
   Go to the following url to learn how to debug backtests locally using the Lean CLI:
-  https://www.lean.io/docs/lean-cli/tutorials/backtesting/debugging-local-backtests
+  https://www.lean.io/docs/lean-cli/backtesting/debugging
 
   By default the official LEAN engine image is used. You can override this using the --image option. Alternatively you
   can set the default engine image for all commands using `lean config set engine-image <image>`.

--- a/lean/click.py
+++ b/lean/click.py
@@ -76,7 +76,7 @@ class LeanCommand(click.Command):
                     # Abort with a display-friendly error message if the command requires a Lean config and none found
                     raise MoreInfoError(
                         "This command requires a Lean configuration file, run `lean init` in an empty directory to create one, or specify the file to use with --lean-config",
-                        "https://www.lean.io/docs/lean-cli/user-guides/troubleshooting#02-Common-errors"
+                        "https://www.lean.io/docs/lean-cli/key-concepts/troubleshooting#02-Common-Errors"
                     )
 
         if self._requires_docker and "pytest" not in sys.modules:

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -159,7 +159,7 @@ def _migrate_csharp_rider(project_dir: Path) -> None:
         logger.warn("Your run configuration has been updated to work with the .NET 5 version of LEAN")
         logger.warn("Please restart Rider and start debugging again")
         logger.warn(
-            "See https://www.lean.io/docs/lean-cli/tutorials/backtesting/debugging-local-backtests#05-C-and-Rider for the updated instructions")
+            "See https://www.lean.io/docs/lean-cli/backtesting/debugging#05-C-and-Rider for the updated instructions")
 
         raise click.Abort()
 
@@ -289,7 +289,7 @@ def backtest(project: Path,
 
     \b
     Go to the following url to learn how to debug backtests locally using the Lean CLI:
-    https://www.lean.io/docs/lean-cli/tutorials/backtesting/debugging-local-backtests
+    https://www.lean.io/docs/lean-cli/tutorials/backtesting/debugging
 
     By default the official LEAN engine image is used.
     You can override this using the --image option.

--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -159,7 +159,7 @@ namespace QuantConnect
     {
         /*
          * To use this library, first add it to a solution and create a project reference in your algorithm project:
-         * https://www.lean.io/docs/lean-cli/tutorials/code-sharing#02-C-code-sharing
+         * https://www.lean.io/docs/lean-cli/projects/libraries/project-libraries#02-C-Libraries
          *
          * Then add its namespace at the top of the page:
          * using QuantConnect;
@@ -291,13 +291,13 @@ def create_project(name: str, language: str) -> None:
     if language is None:
         raise MoreInfoError(
             "Please specify a language with --language or set the default language using `lean config set default-language python/csharp`",
-            "https://www.lean.io/docs/lean-cli/tutorials/project-management")
+            "https://www.lean.io/docs/lean-cli/projects/project-management")
 
     full_path = Path.cwd() / name
 
     if not container.path_manager().is_path_valid(full_path):
         raise MoreInfoError(f"'{name}' is not a valid path",
-                            "https://www.lean.io/docs/lean-cli/user-guides/troubleshooting#02-Common-errors")
+                            "https://www.lean.io/docs/lean-cli/key-concepts/troubleshooting#02-Common-Errors")
 
     is_library_project = False
     try:

--- a/lean/commands/init.py
+++ b/lean/commands/init.py
@@ -76,7 +76,7 @@ def init() -> None:
         if path.exists():
             relative_path = path.relative_to(current_dir)
             raise MoreInfoError(f"{relative_path} already exists, please run this command in an empty directory",
-                                "https://www.lean.io/docs/lean-cli/user-guides/directory-structure#02-lean-init")
+                                "https://www.lean.io/docs/lean-cli/initialization/directory-structure#02-lean-init")
 
     logger = container.logger()
 
@@ -121,8 +121,8 @@ The following objects have been created:
 - {DEFAULT_DATA_DIRECTORY_NAME}/ contains the data that is used when running the LEAN engine locally
 
 The following documentation pages may be useful:
-- Setting up local autocomplete: https://www.lean.io/docs/lean-cli/tutorials/local-autocomplete
-- Synchronizing projects with the cloud: https://www.lean.io/docs/lean-cli/tutorials/cloud-synchronization
+- Setting up local autocomplete: https://www.lean.io/docs/lean-cli/projects/autocomplete
+- Synchronizing projects with the cloud: https://www.lean.io/docs/lean-cli/projects/cloud-synchronization
 
 Here are some commands to get you going:
 - Run `lean create-project "My Project"` to create a new project with starter code

--- a/lean/commands/library/add.py
+++ b/lean/commands/library/add.py
@@ -298,7 +298,7 @@ def add(project: Path, name: str, version: Optional[str], no_local: bool) -> Non
 
     if project_language is None:
         raise MoreInfoError(f"{project} is not a Lean CLI project",
-                            "https://www.lean.io/docs/lean-cli/tutorials/project-management#02-Creating-new-projects")
+                            "https://www.lean.io/docs/lean-cli/projects/project-management#02-Create-Projects")
 
     if project_language == "CSharp":
         _add_csharp(project, name, version, no_local)

--- a/lean/commands/library/remove.py
+++ b/lean/commands/library/remove.py
@@ -119,7 +119,7 @@ def remove(project: Path, name: str, no_local: bool) -> None:
 
     if project_language is None:
         raise MoreInfoError(f"{project} is not a Lean CLI project",
-                            "https://www.lean.io/docs/lean-cli/tutorials/project-management#02-Creating-new-projects")
+                            "https://www.lean.io/docs/lean-cli/projects/project-management#02-Create-Projects")
 
     if project_language == "CSharp":
         _remove_csharp(project, name, no_local)

--- a/lean/commands/live.py
+++ b/lean/commands/live.py
@@ -106,7 +106,7 @@ def _raise_for_missing_properties(lean_config: Dict[str, Any], environment_name:
     for key in ["live-mode-brokerage", "data-queue-handler"]:
         if key not in environment:
             raise MoreInfoError(f"The '{environment_name}' environment does not specify a {key}",
-                                "https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading")
+                                "https://www.lean.io/docs/lean-cli/live-trading")
 
     brokerage = environment["live-mode-brokerage"]
     data_queue_handler = environment["data-queue-handler"]
@@ -129,7 +129,7 @@ def _raise_for_missing_properties(lean_config: Dict[str, Any], environment_name:
 Please configure the following missing {properties_str} in {lean_config_path}:
 {missing_properties}
 Go to the following url for documentation on {these_str} {properties_str}:
-https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading
+https://www.lean.io/docs/lean-cli/live-trading
     """.strip())
 
 
@@ -1041,11 +1041,11 @@ def live(project: Path,
     if "environments" not in lean_config or environment_name not in lean_config["environments"]:
         lean_config_path = lean_config_manager.get_lean_config_path()
         raise MoreInfoError(f"{lean_config_path} does not contain an environment named '{environment_name}'",
-                            "https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading")
+                            "https://www.lean.io/docs/lean-cli/live-trading")
 
     if not lean_config["environments"][environment_name]["live-mode"]:
         raise MoreInfoError(f"The '{environment_name}' is not a live trading environment (live-mode is set to false)",
-                            "https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading")
+                            "https://www.lean.io/docs/lean-cli/live-trading")
 
     _raise_for_missing_properties(lean_config, environment_name, lean_config_manager.get_lean_config_path())
 

--- a/lean/commands/login.py
+++ b/lean/commands/login.py
@@ -47,7 +47,7 @@ def login(user_id: Optional[str], api_token: Optional[str]) -> None:
     api_client = container.api_client(user_id=user_id, api_token=api_token)
     if not api_client.is_authenticated():
         raise MoreInfoError("Credentials are invalid",
-                            "https://www.lean.io/docs/lean-cli/tutorials/authentication#02-Logging-in")
+                            "https://www.lean.io/docs/lean-cli/initialization/authenticating-accounts#02-Log-In")
 
     cli_config_manager = container.cli_config_manager()
     cli_config_manager.user_id.set_value(user_id)

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -146,7 +146,7 @@ def optimize(project: Path,
 
         if len(project_parameters) == 0:
             raise MoreInfoError("The given project has no parameters to optimize",
-                                "https://www.lean.io/docs/lean-cli/tutorials/optimization/project-parameters")
+                                "https://www.lean.io/docs/lean-cli/optimization/parameters")
 
         optimization_strategy = optimizer_config_manager.configure_strategy(cloud=False)
         optimization_target = optimizer_config_manager.configure_target()

--- a/lean/commands/report.py
+++ b/lean/commands/report.py
@@ -114,7 +114,7 @@ def report(backtest_results: Optional[Path],
         if len(result_json_files) == 0:
             raise MoreInfoError(
                 "Could not find a recent backtest result file, please use the --backtest-results option",
-                "https://www.lean.io/docs/lean-cli/tutorials/generating-reports"
+                "https://www.lean.io/docs/lean-cli/backtesting/report#02-Generate-a-Report"
             )
 
         backtest_results = sorted(result_json_files, key=lambda f: f.stat().st_mtime, reverse=True)[0]

--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -80,7 +80,7 @@ class LeanConfigManager:
             # If the parent directory is the same as the current directory we can't go up any more
             if current_dir.parent == current_dir:
                 raise MoreInfoError(f"'{DEFAULT_LEAN_CONFIG_FILE_NAME}' not found",
-                                    "https://www.lean.io/docs/lean-cli/user-guides/configuration#03-Lean-configuration")
+                                    "https://www.lean.io/docs/lean-cli/initialization/configuration#03-Lean-Configuration")
 
             current_dir = current_dir.parent
 

--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -421,7 +421,7 @@ class DockerManager:
         :return: a DockerClient instance which responds to requests
         """
         error = MoreInfoError("Please make sure Docker is installed and running",
-                              "https://www.lean.io/docs/lean-cli/user-guides/troubleshooting#02-Common-errors")
+                              "https://www.lean.io/docs/lean-cli/key-concepts/troubleshooting#02-Common-Errors")
 
         try:
             docker_client = docker.from_env()

--- a/lean/main.py
+++ b/lean/main.py
@@ -73,7 +73,7 @@ def _ensure_win32_available() -> None:
         print("It looks like you're using the Python distribution from the Microsoft Store")
         print("This distribution is not supported by the CLI, we recommend using the Anaconda distribution instead")
         print(
-            "See https://www.lean.io/docs/lean-cli/tutorials/installation/installing-pip#02-Installation-on-Windows for more information")
+            "See https://www.lean.io/docs/lean-cli/installation/installing-pip#02-Install-on-Windows for more information")
         sys.exit(1)
 
     print("pywin32 has not been installed completely, which may lead to errors")
@@ -123,7 +123,7 @@ def main() -> None:
             exception_str = io.getvalue().strip()
             exception_str = exception_str.replace("Try 'lean", "\nTry 'lean")
             exception_str = exception_str.replace("for help.",
-                                                  "for help or go to the following url for a list of common errors:\nhttps://www.lean.io/docs/lean-cli/user-guides/troubleshooting")
+                                                  "for help or go to the following url for a list of common errors:\nhttps://www.lean.io/docs/lean-cli/key-concepts/troubleshooting#02-Common-Errors")
 
             container.update_manager().warn_if_cli_outdated(force=True)
 

--- a/lean/models/brokerages/cloud/interactive_brokers.py
+++ b/lean/models/brokerages/cloud/interactive_brokers.py
@@ -52,7 +52,7 @@ class InteractiveBrokersBrokerage(CloudBrokerage):
 
         if self._environment is None:
             raise MoreInfoError(f"Account id '{account_id}' does not look like a valid account name",
-                                "https://www.lean.io/docs/lean-cli/tutorials/live-trading/cloud-live-trading#03-Interactive-Brokers")
+                                "https://www.lean.io/docs/lean-cli/live-trading/interactive-brokers#03-Deploy-Cloud-Algorithms")
 
     @classmethod
     def get_id(cls) -> str:

--- a/lean/models/brokerages/local/interactive_brokers.py
+++ b/lean/models/brokerages/local/interactive_brokers.py
@@ -56,7 +56,7 @@ class InteractiveBrokersBrokerage(LocalBrokerage):
         if self._trading_mode is None:
             raise MoreInfoError(
                 f"Account id '{account_id}' does not look like a valid account id",
-                "https://www.lean.io/docs/lean-cli/tutorials/live-trading/local-live-trading#03-Interactive-Brokers"
+                "https://www.lean.io/docs/lean-cli/live-trading/interactive-brokers#02-Deploy-Local-Algorithms"
             )
 
     @classmethod

--- a/lean/models/errors.py
+++ b/lean/models/errors.py
@@ -54,4 +54,4 @@ class AuthenticationError(MoreInfoError):
     def __init__(self) -> None:
         """Creates a new AuthenticationError instance."""
         super().__init__("Invalid credentials, please log in using `lean login`",
-                         "https://www.lean.io/docs/lean-cli/tutorials/authentication#02-Logging-in")
+                         "https://www.lean.io/docs/lean-cli/initialization/authenticating-accounts#02-Log-In")

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "Programming Language :: Python :: 3.9"
     ],
     project_urls={
-        "Documentation": "https://www.lean.io/docs/lean-cli/getting-started/lean-cli",
+        "Documentation": "https://www.lean.io/docs/lean-cli/key-concepts/getting-started",
         "Source": "https://github.com/QuantConnect/lean-cli"
     },
 )

--- a/tests/components/util/test_update_manager.py
+++ b/tests/components/util/test_update_manager.py
@@ -210,7 +210,7 @@ def test_show_announcements_logs_when_announcements_have_never_been_shown(reques
                           "announcements": [
                               {
                                   "date": "2021-06-04",
-                                  "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/user-guides/local-data"
+                                  "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/datasets/local-data"
                               }
                           ]
                       }))
@@ -229,7 +229,7 @@ def test_show_announcements_logs_when_announcements_have_been_updated(requests_m
                           "announcements": [
                               {
                                   "date": "2021-06-04",
-                                  "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/user-guides/local-data"
+                                  "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/datasets/local-data"
                               }
                           ]
                       }))
@@ -254,7 +254,7 @@ def test_show_announcements_only_checks_once_every_day(requests_mock: RequestsMo
                               "announcements": [
                                   {
                                       "date": "2021-06-04",
-                                      "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/user-guides/local-data"
+                                      "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/datasets/local-data"
                                   }
                               ]
                           }))
@@ -275,7 +275,7 @@ def test_show_announcements_does_nothing_when_latest_announcements_shown_before(
         "announcements": [
             {
                 "date": "2021-06-04",
-                "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/user-guides/local-data"
+                "message": "Downloading data for local usage is now a lot easier:\nhttps://www.lean.io/docs/lean-cli/datasets/local-data"
             }
         ]
     })


### PR DESCRIPTION
The old links have broken since we restructured the documentation to not have User Guides & Tutorials.