### PR TITLE
Bug issue #55 update docs to mention tkinter requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ The CLI can be installed and updated by running `pip install --upgrade lean`.
 
 Note that many commands in the CLI require Docker to run. See [Get Docker](https://docs.docker.com/get-docker/) for instructions on how to install Docker for your operating system.
 
+**Note:** Some Linux users may need to install `tkinter` using the following commands:
+
+``` 
+For Python 3
+
+sudo apt-get install python3-tk
+
+For Python 2.7
+
+sudo apt-get install python-tk
+```
 After installing the CLI, open a terminal in an empty directory and run `lean init`. This command downloads the latest configuration file and sample data from the [QuantConnect/Lean](https://github.com/QuantConnect/Lean) repository. We recommend running all Lean CLI commands in the same directory `lean init` was ran in.
 
 ## Usage

--- a/lean/models/__init__.py
+++ b/lean/models/__init__.py
@@ -17,7 +17,7 @@ import requests
 from pathlib import Path
 
 json_modules = {}
-file_name = "modules-1.1.json"
+file_name = "modules-1.2.json"
 dirname = os.path.dirname(__file__)
 file_path = os.path.join(dirname, f'../{file_name}')
 


### PR DESCRIPTION
- closes https://github.com/QuantConnect/lean-cli/issues/55
- `tkinter` package is a dependency for Lean-GUI and is available with python for windows and mac but isn't available for some Linux machines.
- This PR updates docs with the same information