### PR TITLE
use common object store directory for research and algorithms

### DIFF
--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -11,15 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from pathlib import Path
-
 import click
-
 from lean.click import LeanCommand
 from lean.container import container
 from lean.models.api import QCLanguage
 from lean.models.errors import MoreInfoError
+from lean.components.util.name_extraction import convert_to_class_name
 
 DEFAULT_PYTHON_MAIN = '''
 from AlgorithmImports import *
@@ -262,17 +260,6 @@ DEFAULT_CSHARP_NOTEBOOK = """
 """.strip() + "\n"
 
 
-def _capitalize(word: str) -> str:
-    """Capitalizes the given word.
-
-    :param word: the word to capitalize
-    :return: the word with the first letter capitalized (any other uppercase characters are preserved)
-    """
-    if word == "":
-        return word
-    return word[0].upper() + word[1:]
-
-
 @click.command(cls=LeanCommand)
 @click.argument("name", type=str)
 @click.option("--language", "-l",
@@ -317,8 +304,7 @@ def create_project(name: str, language: str) -> None:
         project_manager = container.project_manager()
         project_manager.create_new_project(full_path, QCLanguage.Python if language == "python" else QCLanguage.CSharp)
 
-    # Convert the project name into a valid class name by removing all non-alphanumeric characters
-    class_name = re.sub(f"[^a-zA-Z0-9]", "", "".join(map(_capitalize, full_path.name.split(" "))))
+    class_name = convert_to_class_name(full_path)
 
     if language == "python":
         main_name = "main.py"

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -14,15 +14,14 @@
 import webbrowser
 from pathlib import Path
 from typing import Optional
-
 import click
 from docker.errors import APIError
 from docker.types import Mount
-
 from lean.click import LeanCommand, PathParameter
 from lean.constants import DEFAULT_RESEARCH_IMAGE, GUI_PRODUCT_INSTALL_ID
 from lean.container import container
 from lean.models.data_providers import QuantConnectDataProvider, all_data_providers
+from lean.components.util.name_extraction import convert_to_class_name
 
 def _check_docker_output(chunk: str, port: int) -> None:
     """Checks the output of the Docker container and opens the browser if Jupyter Lab has started.
@@ -77,10 +76,12 @@ def research(project: Path,
     """
     project_manager = container.project_manager()
     algorithm_file = project_manager.find_algorithm_file(project)
+    algorithm_name = convert_to_class_name(project)
 
     lean_config_manager = container.lean_config_manager()
     lean_config = lean_config_manager.get_complete_lean_config("backtesting", algorithm_file, None)
     lean_config["composer-dll-directory"] = "/Lean/Launcher/bin/Debug"
+    lean_config["research-object-store-name"] = algorithm_name
 
     if download_data:
         data_provider = QuantConnectDataProvider.get_name()

--- a/lean/components/util/name_extraction.py
+++ b/lean/components/util/name_extraction.py
@@ -1,0 +1,34 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from pathlib import Path
+
+def _capitalize(word: str) -> str:
+    """Capitalizes the given word.
+
+    :param word: the word to capitalize
+    :return: the word with the first letter capitalized (any other uppercase characters are preserved)
+    """
+    if word == "":
+        return word
+    return word[0].upper() + word[1:]
+
+
+def convert_to_class_name(file_path: Path):
+    """Converts the project name into a valid class name by removing all non-alphanumeric characters
+
+    :param file_path: Path to the root project
+    :return: returns a valid class name
+    """
+    return re.sub(f"[^a-zA-Z0-9]", "", "".join(map(_capitalize, file_path.name.split(" "))))


### PR DESCRIPTION
- The aim of the PR is to allow users to access the same object-store keys for both research and algorithms 
- This PR assumes that the user will have only one algorithm per project and therefore uses the algorithm's object-store-location for research as well.
- The directory name is derived the same way `lean create-project` derives algorithm class name