### PR TITLE
Bug issue #86 handle project references

### DIFF
--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -483,8 +483,9 @@ class LeanRunner:
         run_options["commands"].append(f'dotnet build "/LeanCLI/{relative_project_file}" "-p:{msbuild_properties}"')
 
         # Copy over the algorithm DLL
-        run_options["commands"].append(
-            f'cp "/Compile/bin/{project_file.stem}.dll" "/Lean/Launcher/bin/Debug/{project_file.stem}.dll"')
+        # Copy over the project reference DLLs'
+        # Copy over all output DLLs that don't already exist in /Lean/Launcher/bin/Debug
+        run_options["commands"].append("cp -R -n /Compile/bin/. /Lean/Launcher/bin/Debug/")
 
         # Copy over all library DLLs that don't already exist in /Lean/Launcher/bin/Debug
         # CopyLocalLockFileAssemblies does not copy the OS-specific DLLs to the output directory


### PR DESCRIPTION
Currently, adding project references to allow  
- Related https://github.com/QuantConnect/lean-cli/issues/86
- Does not addresses support library referencing in cloud from CLI
- Adds project references DLLs' to output directory