### PR TITLE
consider date while rendering template for hour and daily resolutions

### DIFF
--- a/lean/models/data.py
+++ b/lean/models/data.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import List, Any, Optional, Dict, Set, Tuple, Pattern
 
 import click
-from dateutil.rrule import rrule, DAILY, YEARLY
+from dateutil.rrule import rrule, DAILY
 from joblib import Parallel, delayed
 from pydantic import validator
 
@@ -423,20 +423,12 @@ class Product(WrappedBaseModel):
 
             if has_start_end and start is not None and end is not None:
                 variables_to_use = {**variables}
-                if variables_to_use["resolution"] not in ["hour", "daily"]:
-                    for date in rrule(DAILY, dtstart=start, until=end):
-                        variables_to_use["date"] = date
-                        variables_to_use["year"] = date.strftime("%Y")
-                        variables_to_use["month"] = date.strftime("%m")
-                        variables_to_use["day"] = date.strftime("%d")
-                        possible_files.add(self._render_template(template, variables_to_use))
-                else:
-                    for date in rrule(YEARLY, dtstart=start, until=end):
-                        variables_to_use["date"] = date
-                        variables_to_use["year"] = date.strftime("%Y")
-                        variables_to_use["month"] = date.strftime("%m")
-                        variables_to_use["day"] = date.strftime("%d")
-                        possible_files.add(self._render_template(template, variables_to_use))
+                for date in rrule(DAILY, dtstart=start, until=end):
+                    variables_to_use["date"] = date
+                    variables_to_use["year"] = date.strftime("%Y")
+                    variables_to_use["month"] = date.strftime("%m")
+                    variables_to_use["day"] = date.strftime("%d")
+                    possible_files.add(self._render_template(template, variables_to_use))
 
             prefix = self._get_common_prefix(list(possible_files))
 

--- a/lean/models/data.py
+++ b/lean/models/data.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import List, Any, Optional, Dict, Set, Tuple, Pattern
 
 import click
-from dateutil.rrule import rrule, DAILY
+from dateutil.rrule import rrule, DAILY, YEARLY
 from joblib import Parallel, delayed
 from pydantic import validator
 
@@ -423,14 +423,20 @@ class Product(WrappedBaseModel):
 
             if has_start_end and start is not None and end is not None:
                 variables_to_use = {**variables}
-                for date in rrule(DAILY, dtstart=start, until=end):
-                    variables_to_use["date"] = date
-                    variables_to_use["year"] = date.strftime("%Y")
-                    variables_to_use["month"] = date.strftime("%m")
-                    variables_to_use["day"] = date.strftime("%d")
-                    possible_files.add(self._render_template(template, variables_to_use))
-            else:
-                possible_files.add(self._render_template(template, variables))
+                if variables_to_use["resolution"] not in ["hour", "daily"]:
+                    for date in rrule(DAILY, dtstart=start, until=end):
+                        variables_to_use["date"] = date
+                        variables_to_use["year"] = date.strftime("%Y")
+                        variables_to_use["month"] = date.strftime("%m")
+                        variables_to_use["day"] = date.strftime("%d")
+                        possible_files.add(self._render_template(template, variables_to_use))
+                else:
+                    for date in rrule(YEARLY, dtstart=start, until=end):
+                        variables_to_use["date"] = date
+                        variables_to_use["year"] = date.strftime("%Y")
+                        variables_to_use["month"] = date.strftime("%m")
+                        variables_to_use["day"] = date.strftime("%d")
+                        possible_files.add(self._render_template(template, variables_to_use))
 
             prefix = self._get_common_prefix(list(possible_files))
 


### PR DESCRIPTION
Currently, the `_get_data_file_groups` misses considering date values for the template rendering in cases of resolution equal to hour or daily because `has_start_end` is false for them.
This PR fixes that issue. Also the `datasets.json` for `usa-equity-options` has been updated to prompt user to `start-date` and `end-date`  for both hour and daily resolutions.