### PR TITLE
Bug datafeeds not storing envrionment configs when module same as brokerage

### DIFF
--- a/lean/commands/live.py
+++ b/lean/commands/live.py
@@ -130,11 +130,14 @@ def _configure_lean_config_interactively(lean_config: Dict[str, Any], environmen
     ], multiple= True)
     for data_feed in data_feeds:
         if brokerage._id == data_feed._id:
-            # update essential properties from brokerage to datafeed
+            # update essential properties, so that other dependent values can be fetched.
             essential_properties_value = {config._id : config._value for config in brokerage.get_essential_configs()}
             data_feed.update_configs(essential_properties_value)
+            # now required properties can be fetched as per data/filter provider from esssential properties
+            required_properties_value = {config._id : config._value for config in brokerage.get_required_configs([InternalInputUserInput])}
+            data_feed.update_configs(required_properties_value)
             # mark configs are updated
-            #TODO: create a setter method to set the property instead. 
+            #TODO: create a setter method to set the property instead.
             setattr(data_feed, '_is_installed_and_build', True)
         data_feed.build(lean_config, logger).configure(lean_config, environment_name)
 

--- a/lean/components/util/logger.py
+++ b/lean/components/util/logger.py
@@ -116,7 +116,7 @@ class Logger:
                     return user_selected_value
             else:
                 user_selected_values = []
-                user_inputs = click.prompt("To enter multiple options, seprate them with comma.", type=str, default=default, show_default=True)
+                user_inputs = click.prompt("To enter multiple options, separate them with comma.", type=str, default=default, show_default=True)
                 user_inputs = str(user_inputs).strip(",").split(",")
                 expected_outputs = len(user_inputs)
                 for user_input in user_inputs:

--- a/lean/models/lean_config_configurer.py
+++ b/lean/models/lean_config_configurer.py
@@ -39,10 +39,7 @@ class LeanConfigConfigurer(JsonModule, abc.ABC):
         :param lean_config: the Lean configuration dict to write to
         :param environment_name: the name of the environment to update
         """
-        if self._is_installed_and_build:
-            return
         self.ensure_module_installed()
-
         for environment_config in self.get_configurations_env_values_from_name(environment_name):
             environment_config_name = environment_config["name"]
             if self.__class__.__name__ == 'DataFeed':
@@ -62,8 +59,6 @@ class LeanConfigConfigurer(JsonModule, abc.ABC):
         """Configures the credentials in the Lean config for this brokerage and saves them persistently to disk.
         :param lean_config: the Lean configuration dict to write to
         """
-        if self._is_installed_and_build:
-            return
         if self._installs:
             lean_config["job-organization-id"] = self.get_organzation_id()
         for configuration in self._lean_configs:


### PR DESCRIPTION
This PR allows data-feeds modules to update environment configurations in lean-config for cases where data-feeds modules and brokerage modules are the same.