### PR TITLE
downgrade pydantic dependency to 1.8.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     "docker~=5.0.3",
     "rich~=9.10.0",
     "dependency-injector~=4.39.1",
-    "pydantic~=1.9.1",
+    "pydantic~=1.8.2",
     "python-dateutil~=2.8.2",
     "lxml~=4.9.0",
     "maskpass==0.3.6",

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -229,3 +229,13 @@ bulk_datasource="""
 	]
 }
 """
+
+def test_validate_datafile() -> None:
+
+	try:
+		value = "/^equity\\/usa\\/(factor_files|map_files)\\/[^\\/]+.zip$/m"	
+		target = re.compile(value[value.index("/") + 1:value.rindex("/")])
+		vendor = QCDataVendor(vendorName="Algoseek", regex=target)
+		DataFile(file='equity/usa/daily/aal.zip', vendor=vendor)
+	except Exception as err:
+		pytest.fail(f"{err}")


### PR DESCRIPTION
This PR fixes a bug introduced when `pydantic` was upgraded to `1.9.1`. Which caused `lean data download` to crash for systems with python environment `3.6`

- This PR downgrade `pydantic` to `1.8.2`.
- A test has also been added to validate `DataFile` creation via `pydantic`

Closes https://github.com/QuantConnect/lean-cli/issues/102