### PR TITLE
Add local compiler utility method

### DIFF
--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -79,6 +79,9 @@ class DockerManager:
         If kwargs contains an "on_output" property, it is removed before passing it on to docker.containers.run
         and the given lambda is ran whenever the Docker container prints anything.
 
+        If kwargs contains an "format_output" property, it is removed before passing it on to docker.containers.run
+        and the given lambda is ran after the Docker container completes running.
+
         If kwargs contains a "commands" property, it is removed before passing it on to docker.containers.run
         and the Docker container is configured to run the given commands.
         This property causes the "entrypoint" property to be overwritten if it exists.
@@ -94,6 +97,7 @@ class DockerManager:
             self.pull_image(image)
 
         on_output = kwargs.pop("on_output", lambda chunk: None)
+        format_output = kwargs.pop("format_output", lambda chunk: None)
         commands = kwargs.pop("commands", None)
 
         if commands is not None:
@@ -204,12 +208,13 @@ class DockerManager:
         def print_logs() -> None:
             chunk_buffer = bytes()
             is_first_time = True
+            log_dump = ""
 
             try:
                 while True:
                     container.reload()
                     if container.status != "running":
-                        return
+                        return log_dump
 
                     if is_first_time:
                         tail = "all"
@@ -230,6 +235,7 @@ class DockerManager:
                         if on_output is not None:
                             on_output(chunk)
 
+                        log_dump = log_dump + chunk
                         self._logger.info(chunk.rstrip())
 
                         if not is_tty:
@@ -248,7 +254,12 @@ class DockerManager:
                 # This will crash when the container exits, ignore the exception
                 pass
 
-        logs_thread = threading.Thread(target=print_logs)
+        def print_and_format_logs():
+            log_dump = print_logs()
+            if format_output is not None:
+                format_output(log_dump)
+
+        logs_thread = threading.Thread(target=print_and_format_logs)
         logs_thread.daemon = True
         logs_thread.start()
 

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -138,13 +138,13 @@ class LeanRunner:
         # Run as a subprocess to capture the output before logging it
         success, stdout = compiler.redirect_stdout_of_subprocess(self._docker_manager.run_image, image, **run_options)
         
-        # Format error messages for clearer output logs
+        # Format error messages for cleaner output logs
         if not success:
             algorithm_type = "python" if algorithm_file.name.endswith(".py") else "csharp"
             errors = compiler.process_error(algorithm_type, stdout)
+            for error in errors["aErrors"]:
+                self._logger.error(error)
         self._logger.info(stdout)
-        for error in errors["aErrors"]:
-            self._logger.error(error)
 
         cli_root_dir = self._lean_config_manager.get_cli_root_directory()
         relative_project_dir = project_dir.relative_to(cli_root_dir)

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -338,6 +338,16 @@ class LeanRunner:
         :param project_dir: the path to the project directory
         :param run_options: the dictionary to append run options to
         """
+
+        # Compile python files
+        source_files = self._project_manager.get_source_files(project_dir)
+        source_files = [file.relative_to(
+            project_dir).as_posix() for file in source_files]
+        source_files = [f'"/LeanCLI/{file}"' for file in source_files]
+
+        run_options["commands"].append(
+            f"python -m compileall {' '.join(source_files)}")
+            
         # Mount the project directory
         run_options["volumes"][str(project_dir)] = {
             "bind": "/LeanCLI",

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -141,7 +141,8 @@ class LeanRunner:
         # Format error messages for cleaner output logs
         if not success:
             algorithm_type = "python" if algorithm_file.name.endswith(".py") else "csharp"
-            errors = compiler.process_error(algorithm_type, stdout)
+            jsonString = compiler.create_error(algorithm_type, stdout)
+            errors = json.loads(jsonString)
             for error in errors["aErrors"]:
                 self._logger.error(error)
         self._logger.info(stdout)

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -302,12 +302,8 @@ class LeanRunner:
                 "python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
 
         # Set up language-specific run options
-        if algorithm_file.name.endswith(".py"):
-            self.set_up_python_options(project_dir, run_options)
-        else:
-            if not set_up_common_csharp_options_called:
-                self.set_up_common_csharp_options(run_options)
-            self.set_up_csharp_options(project_dir, run_options, release)
+        self.setup_language_specific_run_options(run_options, project_dir, algorithm_file,
+                                            set_up_common_csharp_options_called, release)
 
         # Save the final Lean config to a temporary file so we can mount it into the container
         config_path = self._temp_manager.create_temporary_directory() / "config.json"
@@ -695,3 +691,13 @@ for library_id, library_data in project_assets["targets"][project_target].items(
 
         if len(zip_names) == 0 or (datetime.now() - datetime.strptime(zip_names[0], "%Y%m%d")).days > 7:
             lean_config[config_key] = disk_provider
+
+    def setup_language_specific_run_options(self, run_options, project_dir, algorithm_file,
+                                            set_up_common_csharp_options_called, release) -> None:
+        # Set up language-specific run options
+        if algorithm_file.name.endswith(".py"):
+            self.set_up_python_options(project_dir, run_options)
+        else:
+            if not set_up_common_csharp_options_called:
+                self.set_up_common_csharp_options(run_options)
+            self.set_up_csharp_options(project_dir, run_options, release)

--- a/lean/components/util/compiler.py
+++ b/lean/components/util/compiler.py
@@ -1,8 +1,11 @@
 import hashlib
 import uuid
 from typing import Dict, Any
-from xmlrpc.client import boolean
 from lean.container import container
+import sys
+import io
+from contextlib import redirect_stdout
+import re
 
 docker_manager = container.docker_manager()
 project_manager = container.project_manager()
@@ -12,24 +15,20 @@ project_config_manager = container.project_config_manager()
 cli_config_manager = container.cli_config_manager()
 logger = container.logger()
 
+def _compile() -> bool:
+    message = {
+        "result": False,
+        "algorithmType": "",
+    }
 
-def compile_create(project_id: int) -> boolean:
+    project_id = int(sys.argv[-1])
     project_dir = project_manager.get_project_by_id(project_id)
 
     compile_id = uuid.uuid4().hex
 
-    source_files = project_manager.get_source_files(project_dir)
-
-    signature_content = ""
-    for file in sorted(source_files):
-        if not file.name.endswith(".ipynb"):
-            signature_content += file.read_text(encoding="utf-8")
-    signature = hashlib.md5(signature_content.encode("utf-8")).hexdigest()
-
     # The dict containing all options passed to `docker run`
     # See all available options at https://docker-py.readthedocs.io/en/stable/containers.html
     run_options: Dict[str, Any] = {
-        "detach": True,
         "name": f"lean_cli_compile_{project_id}_{compile_id}",
         "commands": [],
         "environment": {},
@@ -38,33 +37,90 @@ def compile_create(project_id: int) -> boolean:
     }
 
     algorithm_file = project_manager.find_algorithm_file(project_dir)
+
     if algorithm_file.name.endswith(".py"):
         lean_runner.set_up_python_options(project_dir, run_options)
-
-        source_files = [file.relative_to(
-            project_dir).as_posix() for file in source_files]
-        source_files = [f'"/LeanCLI/{file}"' for file in source_files]
-
-        run_options["commands"].append(
-            f"python -m compileall {' '.join(source_files)} > /output-python.txt")
+        message["algorithmType"] = "python"
     else:
         lean_runner.set_up_common_csharp_options(run_options)
-        lean_runner.set_up_csharp_options(project_dir, run_options, False)
-
-        dotnet_build_index = next(i for i, v in enumerate(
-            run_options["commands"]) if v.startswith("dotnet build"))
-        run_options["commands"][dotnet_build_index] += " > /output-csharp.txt"
+        lean_runner.set_up_csharp_options(project_dir, run_options, True)
+        message["algorithmType"] = "csharp"
 
     project_config = project_config_manager.get_project_config(project_dir)
     engine_image = cli_config_manager.get_engine_image(
         project_config.get("engine-image", None))
 
     try:
-        docker_manager.run_image(engine_image, **run_options)
-        result = True
+        message["result"] = docker_manager.run_image(engine_image, **run_options)
     except Exception as e:
-        logger.error(f"Something went wrong while compiling: {e}")
-        result = False
-
+        pass
     temp_manager.delete_temporary_directories_when_done = False
-    return result
+    return message
+
+def broadcast_success():
+    return {
+        "eType": "BuildSuccess",
+    }
+
+def parse_csharp_errors(csharp_output):
+    errors = []
+
+    relevant_output = csharp_output[csharp_output.index("Build FAILED."):]
+    for match in re.findall(r"(.*)\((\d+),(\d+)\): (error|warning) ([a-zA-Z0-9]+): ([^[]+) ", relevant_output):
+        errors.append({
+            "iLine": int(match[1]),
+            "iColumn": int(match[2]),
+            "sType": match[3],
+            "sErrorText": match[5],
+            "sErrorFilename": match[0].split("/")[-1]
+        })
+
+    return errors
+
+def parse_python_errors(python_output):
+    errors = []
+
+    for match in re.findall(r'\*\*\*   File "/LeanCLI/([^"]+)", line (\d+)\n.*\n(.*)\^.*\n(.*)', python_output):
+        errors.append({
+            "iLine": int(match[1]),
+            "iColumn": len(match[2]),
+            "sType": "error",
+            "sErrorText": match[3],
+            "sErrorFilename": match[0]
+        })
+
+    for match in re.findall(r"\*\*\* Sorry: ([^(]+) \(([^,]+), line (\d+)\)", python_output):
+        errors.append({
+            "iLine": int(match[2]),
+            "iColumn": 0,
+            "sType": "error",
+            "sErrorText": match[0],
+            "sErrorFilename": match[1]
+        })
+
+    return errors
+
+def broadcast_error(algorithm_type, output):
+
+    errors = []
+    if algorithm_type is "csharp":
+        errors.extend(parse_csharp_errors(output))
+    elif algorithm_type is "python":
+        errors.extend(parse_python_errors(output))
+
+    return {
+        "eType": "BuildError",
+        "aErrors": errors,
+    }
+
+
+def compile_create():
+    f = io.StringIO()
+    with redirect_stdout(f):
+        compile_data = _compile()
+    stdout = f.getvalue()
+    if compile_data["result"]:
+        processed_output = broadcast_success()
+    else:
+        processed_output = broadcast_error(compile_data["algorithmType"], stdout)
+    logger.info(processed_output) 

--- a/lean/components/util/compiler.py
+++ b/lean/components/util/compiler.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, Any
 from lean.container import container
 import sys
@@ -46,10 +47,10 @@ def _compile() -> Dict[str, Any]:
     temp_manager.delete_temporary_directories_when_done = False
     return message
 
-def process_success() -> Dict[str, Any]:
-    return {
+def create_success() -> Dict[str, Any]:
+    return json.dumps({
         "eType": "BuildSuccess",
-    }
+    })
 
 def parse_csharp_errors(csharp_output) -> list:
     errors = []
@@ -71,7 +72,7 @@ def parse_python_errors(python_output) -> list:
 
     return errors
 
-def process_error(algorithm_type, message) -> Dict[str, Any]:
+def create_error(algorithm_type, message) -> Dict[str, Any]:
 
     errors = []
     if algorithm_type == "csharp":
@@ -79,10 +80,10 @@ def process_error(algorithm_type, message) -> Dict[str, Any]:
     elif algorithm_type == "python":
         errors.extend(parse_python_errors(message))
 
-    return {
+    return json.dumps({
         "eType": "BuildError",
         "aErrors": errors,
-    }
+    })
 
 def redirect_stdout_of_subprocess(method_name_to_run, *args, **kwargs) -> tuple:
     """ It captures the stdout of the method given to run.
@@ -101,7 +102,7 @@ def compile() -> None:
     """
     compile_result, stdout = redirect_stdout_of_subprocess(_compile)
     if compile_result["result"]:
-        processed_output = process_success()
+        processed_output = create_success()
     else:
-        processed_output = process_error(compile_result["algorithmType"], stdout)
-    logger.info(str(processed_output))
+        processed_output = create_error(compile_result["algorithmType"], stdout)
+    logger.info(processed_output)

--- a/lean/components/util/compiler.py
+++ b/lean/components/util/compiler.py
@@ -1,0 +1,70 @@
+import hashlib
+import uuid
+from typing import Dict, Any
+from xmlrpc.client import boolean
+from lean.container import container
+
+docker_manager = container.docker_manager()
+project_manager = container.project_manager()
+lean_runner = container.lean_runner()
+temp_manager = container.temp_manager()
+project_config_manager = container.project_config_manager()
+cli_config_manager = container.cli_config_manager()
+logger = container.logger()
+
+
+def compile_create(project_id: int) -> boolean:
+    project_dir = project_manager.get_project_by_id(project_id)
+
+    compile_id = uuid.uuid4().hex
+
+    source_files = project_manager.get_source_files(project_dir)
+
+    signature_content = ""
+    for file in sorted(source_files):
+        if not file.name.endswith(".ipynb"):
+            signature_content += file.read_text(encoding="utf-8")
+    signature = hashlib.md5(signature_content.encode("utf-8")).hexdigest()
+
+    # The dict containing all options passed to `docker run`
+    # See all available options at https://docker-py.readthedocs.io/en/stable/containers.html
+    run_options: Dict[str, Any] = {
+        "detach": True,
+        "name": f"lean_cli_compile_{project_id}_{compile_id}",
+        "commands": [],
+        "environment": {},
+        "mounts": [],
+        "volumes": {}
+    }
+
+    algorithm_file = project_manager.find_algorithm_file(project_dir)
+    if algorithm_file.name.endswith(".py"):
+        lean_runner.set_up_python_options(project_dir, run_options)
+
+        source_files = [file.relative_to(
+            project_dir).as_posix() for file in source_files]
+        source_files = [f'"/LeanCLI/{file}"' for file in source_files]
+
+        run_options["commands"].append(
+            f"python -m compileall {' '.join(source_files)} > /output-python.txt")
+    else:
+        lean_runner.set_up_common_csharp_options(run_options)
+        lean_runner.set_up_csharp_options(project_dir, run_options, False)
+
+        dotnet_build_index = next(i for i, v in enumerate(
+            run_options["commands"]) if v.startswith("dotnet build"))
+        run_options["commands"][dotnet_build_index] += " > /output-csharp.txt"
+
+    project_config = project_config_manager.get_project_config(project_dir)
+    engine_image = cli_config_manager.get_engine_image(
+        project_config.get("engine-image", None))
+
+    try:
+        docker_manager.run_image(engine_image, **run_options)
+        result = True
+    except Exception as e:
+        logger.error(f"Something went wrong while compiling: {e}")
+        result = False
+
+    temp_manager.delete_temporary_directories_when_done = False
+    return result

--- a/tests/commands/test_optimize.py
+++ b/tests/commands/test_optimize.py
@@ -208,6 +208,7 @@ def test_optimize_copies_code_to_output_directory() -> None:
 
     project_manager = mock.Mock()
     project_manager.find_algorithm_file.return_value = Path.cwd() / "Python Project" / "main.py"
+    project_manager.get_source_files.return_value = [Path.cwd() / "Python Project" / "main.py"]
     container.project_manager.override(providers.Object(project_manager))
 
     Storage(str(Path.cwd() / "Python Project" / "config.json")).set("parameters", {"param1": "1"})

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -286,6 +286,29 @@ def test_lean_runner_copies_code_to_output_directory() -> None:
     assert source_content == copied_content
 
 
+def test_run_lean_compiles_python_project() -> None:
+    create_fake_lean_cli_directory()
+
+    docker_manager = mock.Mock()
+    docker_manager.run_image.return_value = True
+
+    lean_runner = create_lean_runner(docker_manager)
+
+    lean_runner.run_lean({},
+                         "backtesting",
+                         Path.cwd() / "Python Project" / "main.py",
+                         Path.cwd() / "output",
+                         ENGINE_IMAGE,
+                         None,
+                         False,
+                         False)
+
+    docker_manager.run_image.assert_called_once()
+    args, kwargs = docker_manager.run_image.call_args
+
+    build_command = next((cmd for cmd in kwargs["commands"] if cmd.startswith("python -m compileall")), None)
+    assert build_command is not None
+
 def test_run_lean_mounts_project_directory_when_running_python_algorithm() -> None:
     create_fake_lean_cli_directory()
 


### PR DESCRIPTION
This PR aims to add functionality for local compilation for both csharp and python projects so, that they don't fail at runtime. This functionality is to be re-used by the local vscode plugin project.

This PR adds the following functionality:
- Adds `compiler.compile` for local vscode compilation support.
- Adds python project compilation using `python -m compileall`
- Format compilation errors for both csharp and python projects so that they are user-friendly. Also, add different colors to logs as per their severity. To achieve this, `format_output` lambda has been added in docker manager which gets all the logs at the end of the docker container run and then formats and re-prints the required information. 
- Adds required mocking in tests.
- Adds a unit test to validate python project compilation.