### PR TITLE
Fix configurations order and add custom data feed to all brokerages

### DIFF
--- a/lean/models/brokerages/local/__init__.py
+++ b/lean/models/brokerages/local/__init__.py
@@ -35,7 +35,4 @@ if not [container.platform_manager().is_host_windows() or os.environ.get("__READ
         data_feed for data_feed in all_local_data_feeds if data_feed._id != "IQFeed"]
 
 for local_brokerage in all_local_brokerages:
-    data_feeds_for_brokerage = all_local_data_feeds
-    if local_brokerage._id == "AtreyuBrokerage":
-        data_feeds_for_brokerage = [data_feed for data_feed in all_local_data_feeds if data_feed._id != "Custom data only"]
-    local_brokerage_data_feeds[local_brokerage] = data_feeds_for_brokerage
+    local_brokerage_data_feeds[local_brokerage] = all_local_data_feeds

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -47,7 +47,7 @@ class JsonModule(abc.ABC):
                 organization_config.append(config)
             else:
                 sorted_configs.append(config)
-        return brokerage_configs + organization_config + sorted_configs
+        return organization_config + brokerage_configs + sorted_configs
 
     def get_name(self) -> str:
         """Returns the user-friendly name which users can identify this object by.


### PR DESCRIPTION
This PR address the following issues:
 - User should get asked for the organization id before any other details.
 - `Custom data only` Datafeed missing when choosing Atrety as brokerage.