### PR TITLE
Add utility methods for local vscode plugin

### DIFF
--- a/lean/components/config/output_config_manager.py
+++ b/lean/components/config/output_config_manager.py
@@ -45,6 +45,32 @@ class OutputConfigManager:
         """
         return self._get_id(backtest_directory, 1)
 
+    def get_backtest_name(self, backtest_directory: Path) -> int:
+        """Returns the name of a backtest.
+
+        :param backtest_directory: the path to the backtest to retrieve the id of
+        :return: the name of the given backtest
+        """
+        config = self.get_output_config(backtest_directory)
+
+        if config.has("backtest-name"):
+            return config.get("backtest-name")
+
+        raise ValueError("Backtest name is not set")
+
+    def get_container_name(self, backtest_directory: Path) -> int:
+        """Returns the name of a the docker container lean is running in.
+
+        :param backtest_directory: the path to the backtest to retrieve the id of
+        :return: the name of the docker container lean is running in.
+        """
+        config = self.get_output_config(backtest_directory)
+
+        if config.has("container"):
+            return config.get("container")
+
+        raise ValueError("Container name is not set")
+
     def get_backtest_by_id(self, backtest_id: int, root_directory: Optional[Path] = None) -> Path:
         """Finds the directory of a backtest by its id.
 

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -323,6 +323,8 @@ class LeanRunner:
         run_options["name"] = f"lean_cli_{str(uuid.uuid4()).replace('-', '')}"
         output_config = self._output_config_manager.get_output_config(output_dir)
         output_config.set("container", run_options["name"])
+        if "backtest-name" in lean_config:
+            output_config.set("backtest-name", lean_config["backtest-name"])
 
         if "environment" in lean_config and "environments" in lean_config:
             environment = lean_config["environments"][lean_config["environment"]]


### PR DESCRIPTION
This PR adds the following features to be used by vscode plugin project:
- Add `backtest-name` property in backtest config
- `get_backtest_name`
- `get_container_name`