### PR TITLE
Feature add lean live commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ A locally-focused workflow (local development, local execution) with the CLI may
 - [`lean backtest`](#lean-backtest)
 - [`lean build`](#lean-build)
 - [`lean cloud backtest`](#lean-cloud-backtest)
-- [`lean cloud live`](#lean-cloud-live)
+- [`lean cloud live deploy`](#lean-cloud-live-deploy)
+- [`lean cloud live liquidate`](#lean-cloud-live-liquidate)
+- [`lean cloud live stop`](#lean-cloud-live-stop)
 - [`lean cloud optimize`](#lean-cloud-optimize)
 - [`lean cloud pull`](#lean-cloud-pull)
 - [`lean cloud push`](#lean-cloud-push)
@@ -86,7 +88,13 @@ A locally-focused workflow (local development, local execution) with the CLI may
 - [`lean init`](#lean-init)
 - [`lean library add`](#lean-library-add)
 - [`lean library remove`](#lean-library-remove)
-- [`lean live`](#lean-live)
+- [`lean live add-security`](#lean-live-add-security)
+- [`lean live cancel-order`](#lean-live-cancel-order)
+- [`lean live deploy`](#lean-live-deploy)
+- [`lean live liquidate`](#lean-live-liquidate)
+- [`lean live stop`](#lean-live-stop)
+- [`lean live submit-order`](#lean-live-submit-order)
+- [`lean live update-order`](#lean-live-update-order)
 - [`lean login`](#lean-login)
 - [`lean logout`](#lean-logout)
 - [`lean logs`](#lean-logs)
@@ -193,12 +201,12 @@ Options:
 
 _See code: [lean/commands/cloud/backtest.py](lean/commands/cloud/backtest.py)_
 
-### `lean cloud live`
+### `lean cloud live deploy`
 
 Start live trading for a project in the cloud.
 
 ```
-Usage: lean cloud live [OPTIONS] PROJECT
+Usage: lean cloud live deploy [OPTIONS] PROJECT
 
   Start live trading for a project in the cloud.
 
@@ -242,19 +250,21 @@ Options:
   --binanceus-api-secret TEXT     Your Binance API secret
   --zerodha-api-key TEXT          Your Kite Connect API key
   --zerodha-access-token TEXT     Your Kite Connect access token
-  --zerodha-product-type [MIS|CNC|NRML]
+  --zerodha-product-type [mis|cnc|nrml]
                                   MIS if you are targeting intraday products, CNC if you are targeting delivery
                                   products, NRML if you are targeting carry forward products
-  --zerodha-trading-segment [EQUITY|COMMODITY]
+  --zerodha-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
+  --zerodha-history-subscription [true|false]
+                                  Whether you have a history API subscription for Zerodha
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
-  --samco-product-type [MIS|CNC|NRML]
+  --samco-product-type [mis|cnc|nrml]
                                   MIS if you are targeting intraday products, CNC if you are targeting delivery
                                   products, NRML if you are targeting carry forward products
-  --samco-trading-segment [EQUITY|COMMODITY]
+  --samco-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
   --kraken-api-key TEXT           Your Kraken API key
@@ -285,7 +295,39 @@ Options:
   --help                          Show this message and exit.
 ```
 
-_See code: [lean/commands/cloud/live.py](lean/commands/cloud/live.py)_
+_See code: [lean/commands/cloud/live/deploy.py](lean/commands/cloud/live/deploy.py)_
+
+### `lean cloud live liquidate`
+
+Stops live trading and liquidates existing positions for a certain project.
+
+```
+Usage: lean cloud live liquidate [OPTIONS] PROJECT
+
+  Stops live trading and liquidates existing positions for a certain project.
+
+Options:
+  --verbose  Enable debug logging
+  --help     Show this message and exit.
+```
+
+_See code: [lean/commands/cloud/live/liquidate.py](lean/commands/cloud/live/liquidate.py)_
+
+### `lean cloud live stop`
+
+Stops live trading for a certain project without liquidating existing positions.
+
+```
+Usage: lean cloud live stop [OPTIONS] PROJECT
+
+  Stops live trading for a certain project without liquidating existing positions.
+
+Options:
+  --verbose  Enable debug logging
+  --help     Show this message and exit.
+```
+
+_See code: [lean/commands/cloud/live/stop.py](lean/commands/cloud/live/stop.py)_
 
 ### `lean cloud optimize`
 
@@ -657,12 +699,56 @@ Options:
 
 _See code: [lean/commands/library/remove.py](lean/commands/library/remove.py)_
 
-### `lean live`
+### `lean live add-security`
+
+Represents a command to add a security to the algorithm.
+
+```
+Usage: lean live add-security [OPTIONS] PROJECT
+
+  Represents a command to add a security to the algorithm.
+
+Options:
+  --ticker TEXT            The ticker of the symbol to added  [required]
+  --market TEXT            The market of the symbol to added  [required]
+  --security-type TEXT     The security type of the symbol to added  [required]
+  --resolution TEXT        The resolution of the symbol to added
+  --fill-data-forward      The fill forward behavior, true to fill forward, false otherwise - defaults to true
+  --leverage FLOAT         The leverage for the security, defaults to 2 for equity, 50 for forex, and 1 for everything
+                           else
+  --extended-market-hours  The extended market hours flag, true to allow pre/post market data, false for only in market
+                           data
+  --lean-config FILE       The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose                Enable debug logging
+  --help                   Show this message and exit.
+```
+
+_See code: [lean/commands/live/add_security.py](lean/commands/live/add_security.py)_
+
+### `lean live cancel-order`
+
+Represents a command to cancel a specific order by id.
+
+```
+Usage: lean live cancel-order [OPTIONS] PROJECT
+
+  Represents a command to cancel a specific order by id.
+
+Options:
+  --order-id INTEGER  The order id to be cancelled  [required]
+  --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose           Enable debug logging
+  --help              Show this message and exit.
+```
+
+_See code: [lean/commands/live/cancel_order.py](lean/commands/live/cancel_order.py)_
+
+### `lean live deploy`
 
 Start live trading a project locally using Docker.
 
 ```
-Usage: lean live [OPTIONS] PROJECT
+Usage: lean live deploy [OPTIONS] PROJECT
 
   Start live trading a project locally using Docker.
 
@@ -730,22 +816,22 @@ Options:
   --zerodha-organization TEXT     The name or id of the organization with the zerodha module subscription
   --zerodha-api-key TEXT          Your Kite Connect API key
   --zerodha-access-token TEXT     Your Kite Connect access token
-  --zerodha-product-type [MIS|CNC|NRML]
+  --zerodha-product-type [mis|cnc|nrml]
                                   MIS if you are targeting intraday products, CNC if you are targeting delivery
                                   products, NRML if you are targeting carry forward products
-  --zerodha-trading-segment [EQUITY|COMMODITY]
+  --zerodha-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
-  --zerodha-history-subscription BOOLEAN
+  --zerodha-history-subscription [true|false]
                                   Whether you have a history API subscription for Zerodha
   --samco-organization TEXT       The name or id of the organization with the samco module subscription
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
-  --samco-product-type [MIS|CNC|NRML]
+  --samco-product-type [mis|cnc|nrml]
                                   MIS if you are targeting intraday products, CNC if you are targeting delivery
                                   products, NRML if you are targeting carry forward products
-  --samco-trading-segment [EQUITY|COMMODITY]
+  --samco-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
   --terminal-link-organization TEXT
@@ -827,7 +913,91 @@ Options:
   --help                          Show this message and exit.
 ```
 
-_See code: [lean/commands/live.py](lean/commands/live.py)_
+_See code: [lean/commands/live/deploy.py](lean/commands/live/deploy.py)_
+
+### `lean live liquidate`
+
+Liquidate the given symbol from the latest deployment of the given project.
+
+```
+Usage: lean live liquidate [OPTIONS] PROJECT
+
+  Liquidate the given symbol from the latest deployment of the given project.
+
+Options:
+  --ticker TEXT         The ticker of the symbol to liquidate
+  --market TEXT         The market of the symbol to liquidate
+  --security-type TEXT  The security type of the symbol to liquidate
+  --lean-config FILE    The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose             Enable debug logging
+  --help                Show this message and exit.
+```
+
+_See code: [lean/commands/live/liquidate.py](lean/commands/live/liquidate.py)_
+
+### `lean live stop`
+
+Stop an already running local live trading a project.
+
+```
+Usage: lean live stop [OPTIONS] PROJECT
+
+  Stop an already running local live trading a project.
+
+Options:
+  --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose           Enable debug logging
+  --help              Show this message and exit.
+```
+
+_See code: [lean/commands/live/stop.py](lean/commands/live/stop.py)_
+
+### `lean live submit-order`
+
+Represents a command to submit an order to the algorithm.
+
+```
+Usage: lean live submit-order [OPTIONS] PROJECT
+
+  Represents a command to submit an order to the algorithm.
+
+Options:
+  --ticker TEXT         The ticker of the symbol to submitted  [required]
+  --market TEXT         The market of the symbol to submitted  [required]
+  --security-type TEXT  The security type of the symbol to submitted  [required]
+  --order-type TEXT     The order type to be submitted  [required]
+  --quantity FLOAT      the number of units to be ordered (directional)  [required]
+  --limit-price FLOAT   The limit price of the order to submitted
+  --stop-price FLOAT    The stop price of the order to be submitted
+  --tag TEXT            The tag to be attached to the order
+  --lean-config FILE    The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose             Enable debug logging
+  --help                Show this message and exit.
+```
+
+_See code: [lean/commands/live/submit_order.py](lean/commands/live/submit_order.py)_
+
+### `lean live update-order`
+
+Represents a command to update a specific order by id.
+
+```
+Usage: lean live update-order [OPTIONS] PROJECT
+
+  Represents a command to update a specific order by id.
+
+Options:
+  --order-id INTEGER   The order id to be updated  [required]
+  --quantity FLOAT     the number of units to be ordered (directional)
+  --limit-price FLOAT  The limit price of the order to updated
+  --stop-price FLOAT   The stop price of the order to be updated
+  --tag TEXT           The tag to be attached to the order
+  --lean-config FILE   The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose            Enable debug logging
+  --help               Show this message and exit.
+```
+
+_See code: [lean/commands/live/update_order.py](lean/commands/live/update_order.py)_
 
 ### `lean login`
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A locally-focused workflow (local development, local execution) with the CLI may
 - [`lean backtest`](#lean-backtest)
 - [`lean build`](#lean-build)
 - [`lean cloud backtest`](#lean-cloud-backtest)
+- [`lean cloud live`](#lean-cloud-live)
 - [`lean cloud live deploy`](#lean-cloud-live-deploy)
 - [`lean cloud live liquidate`](#lean-cloud-live-liquidate)
 - [`lean cloud live stop`](#lean-cloud-live-stop)
@@ -88,6 +89,7 @@ A locally-focused workflow (local development, local execution) with the CLI may
 - [`lean init`](#lean-init)
 - [`lean library add`](#lean-library-add)
 - [`lean library remove`](#lean-library-remove)
+- [`lean live`](#lean-live)
 - [`lean live add-security`](#lean-live-add-security)
 - [`lean live cancel-order`](#lean-live-cancel-order)
 - [`lean live deploy`](#lean-live-deploy)
@@ -200,6 +202,26 @@ Options:
 ```
 
 _See code: [lean/commands/cloud/backtest.py](lean/commands/cloud/backtest.py)_
+
+### `lean cloud live`
+
+Interact with the QuantConnect cloud live deployments.
+
+```
+Usage: lean cloud live [OPTIONS] COMMAND [ARGS]...
+
+  Interact with the QuantConnect cloud live deployments.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  deploy     Start live trading for a project in the cloud.
+  liquidate  Stops live trading and liquidates existing positions for a certain project.
+  stop       Stops live trading for a certain project without liquidating existing positions.
+```
+
+_See code: [lean/commands/cloud/live.py](lean/commands/cloud/live.py)_
 
 ### `lean cloud live deploy`
 
@@ -699,6 +721,30 @@ Options:
 
 _See code: [lean/commands/library/remove.py](lean/commands/library/remove.py)_
 
+### `lean live`
+
+Interact with the local machine.
+
+```
+Usage: lean live [OPTIONS] COMMAND [ARGS]...
+
+  Interact with the local machine.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  add-security  Represents a command to add a security to the algorithm.
+  cancel-order  Represents a command to cancel a specific order by id.
+  deploy        Start live trading a project locally using Docker.
+  liquidate     Liquidate the given symbol from the latest deployment of the given project.
+  stop          Stop an already running local live trading project.
+  submit-order  Represents a command to submit an order to the algorithm.
+  update-order  Represents a command to update a specific order by id.
+```
+
+_See code: [lean/commands/live.py](lean/commands/live.py)_
+
 ### `lean live add-security`
 
 Represents a command to add a security to the algorithm.
@@ -709,10 +755,10 @@ Usage: lean live add-security [OPTIONS] PROJECT
   Represents a command to add a security to the algorithm.
 
 Options:
-  --ticker TEXT            The ticker of the symbol to added  [required]
-  --market TEXT            The market of the symbol to added  [required]
-  --security-type TEXT     The security type of the symbol to added  [required]
-  --resolution TEXT        The resolution of the symbol to added
+  --ticker TEXT            The ticker of the symbol to add  [required]
+  --market TEXT            The market of the symbol to add  [required]
+  --security-type TEXT     The security type of the symbol to add  [required]
+  --resolution TEXT        The resolution of the symbol to add
   --fill-data-forward      The fill forward behavior, true to fill forward, false otherwise - defaults to true
   --leverage DECIMAL       The leverage for the security, defaults to 2 for equity, 50 for forex, and 1 for everything
                            else
@@ -937,12 +983,12 @@ _See code: [lean/commands/live/liquidate.py](lean/commands/live/liquidate.py)_
 
 ### `lean live stop`
 
-Stop an already running local live trading a project.
+Stop an already running local live trading project.
 
 ```
 Usage: lean live stop [OPTIONS] PROJECT
 
-  Stop an already running local live trading a project.
+  Stop an already running local live trading project.
 
 Options:
   --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
@@ -962,12 +1008,12 @@ Usage: lean live submit-order [OPTIONS] PROJECT
   Represents a command to submit an order to the algorithm.
 
 Options:
-  --ticker TEXT          The ticker of the symbol to submitted  [required]
-  --market TEXT          The market of the symbol to submitted  [required]
-  --security-type TEXT   The security type of the symbol to submitted  [required]
+  --ticker TEXT          The ticker of the symbol to be submitted  [required]
+  --market TEXT          The market of the symbol to be submitted  [required]
+  --security-type TEXT   The security type of the symbol to be submitted  [required]
   --order-type TEXT      The order type to be submitted  [required]
-  --quantity DECIMAL     the number of units to be ordered (directional)  [required]
-  --limit-price DECIMAL  The limit price of the order to submitted
+  --quantity DECIMAL     The number of units to be ordered (directional)  [required]
+  --limit-price DECIMAL  The limit price of the order be submitted
   --stop-price DECIMAL   The stop price of the order to be submitted
   --tag TEXT             The tag to be attached to the order
   --lean-config FILE     The Lean configuration file that should be used (defaults to the nearest lean.json)
@@ -988,8 +1034,8 @@ Usage: lean live update-order [OPTIONS] PROJECT
 
 Options:
   --order-id INTEGER     The order id to be updated  [required]
-  --quantity DECIMAL     the number of units to be ordered (directional)
-  --limit-price DECIMAL  The limit price of the order to updated
+  --quantity DECIMAL     The number of units to be updated (directional)
+  --limit-price DECIMAL  The limit price of the order to be updated
   --stop-price DECIMAL   The stop price of the order to be updated
   --tag TEXT             The tag to be attached to the order
   --lean-config FILE     The Lean configuration file that should be used (defaults to the nearest lean.json)

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ Options:
   --security-type TEXT     The security type of the symbol to added  [required]
   --resolution TEXT        The resolution of the symbol to added
   --fill-data-forward      The fill forward behavior, true to fill forward, false otherwise - defaults to true
-  --leverage FLOAT         The leverage for the security, defaults to 2 for equity, 50 for forex, and 1 for everything
+  --leverage DECIMAL       The leverage for the security, defaults to 2 for equity, 50 for forex, and 1 for everything
                            else
   --extended-market-hours  The extended market hours flag, true to allow pre/post market data, false for only in market
                            data
@@ -962,17 +962,17 @@ Usage: lean live submit-order [OPTIONS] PROJECT
   Represents a command to submit an order to the algorithm.
 
 Options:
-  --ticker TEXT         The ticker of the symbol to submitted  [required]
-  --market TEXT         The market of the symbol to submitted  [required]
-  --security-type TEXT  The security type of the symbol to submitted  [required]
-  --order-type TEXT     The order type to be submitted  [required]
-  --quantity FLOAT      the number of units to be ordered (directional)  [required]
-  --limit-price FLOAT   The limit price of the order to submitted
-  --stop-price FLOAT    The stop price of the order to be submitted
-  --tag TEXT            The tag to be attached to the order
-  --lean-config FILE    The Lean configuration file that should be used (defaults to the nearest lean.json)
-  --verbose             Enable debug logging
-  --help                Show this message and exit.
+  --ticker TEXT          The ticker of the symbol to submitted  [required]
+  --market TEXT          The market of the symbol to submitted  [required]
+  --security-type TEXT   The security type of the symbol to submitted  [required]
+  --order-type TEXT      The order type to be submitted  [required]
+  --quantity DECIMAL     the number of units to be ordered (directional)  [required]
+  --limit-price DECIMAL  The limit price of the order to submitted
+  --stop-price DECIMAL   The stop price of the order to be submitted
+  --tag TEXT             The tag to be attached to the order
+  --lean-config FILE     The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose              Enable debug logging
+  --help                 Show this message and exit.
 ```
 
 _See code: [lean/commands/live/submit_order.py](lean/commands/live/submit_order.py)_
@@ -987,14 +987,14 @@ Usage: lean live update-order [OPTIONS] PROJECT
   Represents a command to update a specific order by id.
 
 Options:
-  --order-id INTEGER   The order id to be updated  [required]
-  --quantity FLOAT     the number of units to be ordered (directional)
-  --limit-price FLOAT  The limit price of the order to updated
-  --stop-price FLOAT   The stop price of the order to be updated
-  --tag TEXT           The tag to be attached to the order
-  --lean-config FILE   The Lean configuration file that should be used (defaults to the nearest lean.json)
-  --verbose            Enable debug logging
-  --help               Show this message and exit.
+  --order-id INTEGER     The order id to be updated  [required]
+  --quantity DECIMAL     the number of units to be ordered (directional)
+  --limit-price DECIMAL  The limit price of the order to updated
+  --stop-price DECIMAL   The stop price of the order to be updated
+  --tag TEXT             The tag to be attached to the order
+  --lean-config FILE     The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose              Enable debug logging
+  --help                 Show this message and exit.
 ```
 
 _See code: [lean/commands/live/update_order.py](lean/commands/live/update_order.py)_

--- a/lean/commands/__init__.py
+++ b/lean/commands/__init__.py
@@ -22,7 +22,7 @@ from lean.commands.create_project import create_project
 from lean.commands.data import data
 from lean.commands.init import init
 from lean.commands.library import library
-from lean.commands.live import live
+from lean.commands.live.live import live
 from lean.commands.login import login
 from lean.commands.logout import logout
 from lean.commands.logs import logs
@@ -45,7 +45,7 @@ lean.add_command(config)
 lean.add_command(cloud)
 lean.add_command(data)
 lean.add_command(library)
-
+lean.add_command(live)
 lean.add_command(login)
 lean.add_command(logout)
 lean.add_command(whoami)
@@ -55,6 +55,5 @@ lean.add_command(backtest)
 lean.add_command(optimize)
 lean.add_command(research)
 lean.add_command(report)
-lean.add_command(live)
 lean.add_command(build)
 lean.add_command(logs)

--- a/lean/commands/cloud/live/__init__.py
+++ b/lean/commands/cloud/live/__init__.py
@@ -11,27 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
-
-from lean.commands.cloud.backtest import backtest
 from lean.commands.cloud.live.live import live
-from lean.commands.cloud.optimize import optimize
-from lean.commands.cloud.pull import pull
-from lean.commands.cloud.push import push
-from lean.commands.cloud.status import status
+from lean.commands.cloud.live.deploy import deploy
+from lean.commands.cloud.live.stop import stop
+from lean.commands.cloud.live.liquidate import liquidate
 
 
-@click.group()
-def cloud() -> None:
-    """Interact with the QuantConnect cloud."""
-    # This method is intentionally empty
-    # It is used as the command group for all `lean cloud <command>` commands
-    pass
-
-
-cloud.add_command(pull)
-cloud.add_command(push)
-cloud.add_command(backtest)
-cloud.add_command(optimize)
-cloud.add_command(live)
-cloud.add_command(status)
+live.add_command(deploy)
+live.add_command(stop)
+live.add_command(liquidate)

--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -25,6 +25,7 @@ from lean.models.brokerages.cloud.cloud_brokerage import CloudBrokerage
 from lean.models.configuration import Configuration, InfoConfiguration, InternalInputUserInput, OrganzationIdConfiguration
 from lean.models.click_options import options_from_json
 from lean.models.brokerages.cloud import all_cloud_brokerages
+from lean.commands.cloud.live.live import live
 
 def _log_notification_methods(methods: List[QCNotificationMethod]) -> None:
     """Logs a list of notification methods."""
@@ -154,7 +155,7 @@ def _get_configs_for_options() -> Dict[Configuration, str]:
             run_options[config._id] = config
     return list(run_options.values())
 
-@click.command(cls=LeanCommand)
+@live.command(cls=LeanCommand, default_command=True, name="deploy")
 @click.argument("project", type=str)
 @click.option("--brokerage",
               type=click.Choice([b.get_name() for b in all_cloud_brokerages], case_sensitive=False),
@@ -179,7 +180,7 @@ def _get_configs_for_options() -> Dict[Configuration, str]:
               is_flag=True,
               default=False,
               help="Automatically open the live results in the browser once the deployment starts")
-def live(project: str,
+def deploy(project: str,
          brokerage: str,
          node: str,
          auto_restart: bool,

--- a/lean/commands/cloud/live/liquidate.py
+++ b/lean/commands/cloud/live/liquidate.py
@@ -1,0 +1,36 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import click
+from lean.click import LeanCommand
+from lean.container import container
+
+
+@click.command(cls=LeanCommand)
+@click.argument("project", type=str)
+def liquidate(project: str) -> None:
+    """
+    Stops live trading and liquidates existing positions for a certain project.
+    """
+    logger = container.logger()
+    api_client = container.api_client()
+
+    cloud_project_manager = container.cloud_project_manager()
+    cloud_project = cloud_project_manager.get_cloud_project(project, False)
+    logger.info(f"cloud.live.liquidate(): sending command.")
+    response = api_client.live.liquidate_and_stop(cloud_project.projectId)
+    if response.success:
+        logger.info(f"cloud.live.liquidate(): command executed successfully.")
+    else:
+        logger.error(f"cloud.live.liquidate(): command failed.")

--- a/lean/commands/cloud/live/liquidate.py
+++ b/lean/commands/cloud/live/liquidate.py
@@ -33,4 +33,4 @@ def liquidate(project: str) -> None:
     if response.success:
         logger.info(f"cloud.live.liquidate(): command executed successfully.")
     else:
-        logger.error(f"cloud.live.liquidate(): command failed.")
+        raise Exception("cloud.live.liquidate(): Failed: to execute the command successfully.")

--- a/lean/commands/cloud/live/live.py
+++ b/lean/commands/cloud/live/live.py
@@ -12,26 +12,11 @@
 # limitations under the License.
 
 import click
+from lean.components.util.click_group_default_command import DefaultCommandGroup
 
-from lean.commands.cloud.backtest import backtest
-from lean.commands.cloud.live.live import live
-from lean.commands.cloud.optimize import optimize
-from lean.commands.cloud.pull import pull
-from lean.commands.cloud.push import push
-from lean.commands.cloud.status import status
-
-
-@click.group()
-def cloud() -> None:
-    """Interact with the QuantConnect cloud."""
+@click.group(cls=DefaultCommandGroup)
+def live() -> None:
+    """Interact with the QuantConnect cloud live deployments."""
     # This method is intentionally empty
     # It is used as the command group for all `lean cloud <command>` commands
     pass
-
-
-cloud.add_command(pull)
-cloud.add_command(push)
-cloud.add_command(backtest)
-cloud.add_command(optimize)
-cloud.add_command(live)
-cloud.add_command(status)

--- a/lean/commands/cloud/live/stop.py
+++ b/lean/commands/cloud/live/stop.py
@@ -1,0 +1,39 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+import click
+from lean.click import LeanCommand
+from lean.container import container
+
+
+@click.command(cls=LeanCommand)
+@click.argument("project", type=str)
+def stop(project: str) -> None:
+    """
+    Stops live trading for a certain project without liquidating existing positions.
+    """
+    logger = container.logger()
+    api_client = container.api_client()
+
+    cloud_project_manager = container.cloud_project_manager()
+    cloud_project = cloud_project_manager.get_cloud_project(project, False)
+    logger.info(f"cloud.live.stop(): sending command.")
+    response = api_client.live.stop(cloud_project.projectId)
+    if response.success:
+        logger.info(f"cloud.live.stop(): command executed successfully.")
+    else:
+        logger.error(f"cloud.live.stop(): command failed.")
+
+

--- a/lean/commands/cloud/live/stop.py
+++ b/lean/commands/cloud/live/stop.py
@@ -34,6 +34,6 @@ def stop(project: str) -> None:
     if response.success:
         logger.info(f"cloud.live.stop(): command executed successfully.")
     else:
-        logger.error(f"cloud.live.stop(): command failed.")
+        raise Exception("cloud.live.stop(): Failed: to execute the command successfully.")
 
 

--- a/lean/commands/live/__init__.py
+++ b/lean/commands/live/__init__.py
@@ -15,7 +15,15 @@ from lean.commands.live.live import live
 from lean.commands.live.deploy import deploy
 from lean.commands.live.stop import stop
 from lean.commands.live.liquidate import liquidate
+from lean.commands.live.submit_order import submit_order
+from lean.commands.live.cancel_order import cancel_order
+from lean.commands.live.add_security import add_security
+from lean.commands.live.update_order import update_order
 
 live.add_command(deploy)
 live.add_command(stop)
 live.add_command(liquidate)
+live.add_command(submit_order)
+live.add_command(cancel_order)
+live.add_command(add_security)
+live.add_command(update_order)

--- a/lean/commands/live/__init__.py
+++ b/lean/commands/live/__init__.py
@@ -1,0 +1,19 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lean.commands.live.deploy import deploy
+from lean.commands.live.stop import stop
+from lean.commands.live.live import live
+
+live.add_command(deploy)
+live.add_command(stop)

--- a/lean/commands/live/__init__.py
+++ b/lean/commands/live/__init__.py
@@ -11,9 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from lean.commands.live.live import live
 from lean.commands.live.deploy import deploy
 from lean.commands.live.stop import stop
-from lean.commands.live.live import live
+from lean.commands.live.liquidate import liquidate
 
 live.add_command(deploy)
 live.add_command(stop)
+live.add_command(liquidate)

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -1,0 +1,92 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import Optional
+import uuid
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
+import time
+
+@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to liquidate")
+@click.option("--market", type=str, required=True, help="The market of the symbol to liquidate")
+@click.option("--security-type", type=str, required=True, help="The security type of the symbol to liquidate")
+@click.option("--resolution", 
+                type=str,
+                default="Minute",
+                help="The resolution of the symbol to liquidate")
+@click.option("--fill-data-forward", 
+                is_flag=True,
+                default=False,
+                help="The ticker of the symbol to liquidate")
+@click.option("--leverage", 
+                type=float, 
+                default=0.0,
+                help="The market of the symbol to liquidate")
+@click.option("--extended-market-hours",
+                is_flag=True,
+                default=True,
+                help="The security type of the symbol to liquidate")
+def add_security(project: Path,
+                 ticker: str,
+                 market: str,
+                 security_type: str,
+                 resolution: Optional[str],
+                 fill_data_forward: Optional[bool],
+                 leverage: Optional[float],
+                 extended_market_hours: Optional[bool]) -> None:
+    """
+    Represents a command to add a security to the algorithm.
+    """
+    logger = container.logger()
+    live_dir = container.project_config_manager().get_latest_live_directory(project)
+    docker_container_name = container.output_config_manager(
+    ).get_container_name(Path(live_dir))
+    command_id = uuid.uuid4().hex
+    data = {
+        "$type": "QuantConnect.Commands.AddSecurityCommand, QuantConnect.Common",
+        "Id": command_id,
+        "Symbol": ticker,
+        "Market": market,
+        "SecurityType": security_type,
+        "Resolution": resolution,
+        "FillDataForward": fill_data_forward,
+        "Leverage": leverage,
+        "ExtendedMarketHours": extended_market_hours
+    }
+    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    try:
+        logger.info("add_security(): sending command.")
+        container.docker_manager().write_to_file(
+            docker_container_name, file_name, data)
+    except Exception as e:
+        logger.error(f"add_security(): Failed to send the command, error: {e}")
+
+    # Check for result
+    logger.info("add_security(): waiting for results...")
+    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result = container.docker_manager().read_from_file(
+        docker_container_name, result_file_path)
+    if "success" in result and result["success"]:
+        logger.info(
+            "add_security(): Success: The command was executed successfully")
+    elif "container-running" in result and not result["container-running"]:
+        logger.info("add_security(): Failed: The container is not running")
+    else:
+        logger.info(
+            f"add_security(): Failed: to execute the command successfully. {result['error']}")

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -76,7 +76,7 @@ def add_security(project: Path,
             docker_container_name, file_name, data)
     except Exception as e:
         logger.error(f"add_security(): Failed to send the command, error: {e}")
-
+        return
     # Check for result
     logger.info("add_security(): waiting for results...")
     result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -22,13 +22,13 @@ from lean.components.util.click_custom_parameters import DECIMAL
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
-@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to added")
-@click.option("--market", type=str, required=True, help="The market of the symbol to added")
-@click.option("--security-type", type=str, required=True, help="The security type of the symbol to added")
+@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to add")
+@click.option("--market", type=str, required=True, help="The market of the symbol to add")
+@click.option("--security-type", type=str, required=True, help="The security type of the symbol to add")
 @click.option("--resolution",
               type=str,
               default="Minute",
-              help="The resolution of the symbol to added")
+              help="The resolution of the symbol to add")
 @click.option("--fill-data-forward",
               is_flag=True,
               default=True,

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -66,10 +66,5 @@ def add_security(project: Path,
         "ExtendedMarketHours": extended_market_hours
     }
 
-    try:
-        docker_container_name = send_command(project, data)
-    except Exception as e:
-        raise Exception(
-            f"add_security(): Failed to send the command, error: {e}")
-
+    docker_container_name = send_command(project, data)
     get_result(command_id, docker_container_name)

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -18,8 +18,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
-import time
+from lean.commands.live.live import get_command_file_name, get_result_file_name
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -69,7 +68,7 @@ def add_security(project: Path,
         "Leverage": leverage,
         "ExtendedMarketHours": extended_market_hours
     }
-    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    file_name = get_command_file_name()
     try:
         logger.info("add_security(): sending command.")
         container.docker_manager().write_to_file(
@@ -79,7 +78,7 @@ def add_security(project: Path,
         return
     # Check for result
     logger.info("add_security(): waiting for results...")
-    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result_file_path = get_result_file_name(command_id)
     result = container.docker_manager().read_from_file(
         docker_container_name, result_file_path)
     if "success" in result and result["success"]:

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -18,7 +18,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.commands.live.live import get_result, send_command
-
+from lean.components.util.click_custom_parameters import DECIMAL
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -34,7 +34,7 @@ from lean.commands.live.live import get_result, send_command
               default=True,
               help="The fill forward behavior, true to fill forward, false otherwise - defaults to true")
 @click.option("--leverage",
-              type=float,
+              type=DECIMAL,
               default=0.0,
               help="The leverage for the security, defaults to 2 for equity, 50 for forex, and 1 for everything else")
 @click.option("--extended-market-hours",
@@ -47,7 +47,7 @@ def add_security(project: Path,
                  security_type: str,
                  resolution: Optional[str],
                  fill_data_forward: Optional[bool],
-                 leverage: Optional[float],
+                 leverage: Optional[DECIMAL],
                  extended_market_hours: Optional[bool]) -> None:
     """
     Represents a command to add a security to the algorithm.

--- a/lean/commands/live/add_security.py
+++ b/lean/commands/live/add_security.py
@@ -22,25 +22,25 @@ from lean.commands.live.live import get_result, send_command
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
-@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to liquidate")
-@click.option("--market", type=str, required=True, help="The market of the symbol to liquidate")
-@click.option("--security-type", type=str, required=True, help="The security type of the symbol to liquidate")
+@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to added")
+@click.option("--market", type=str, required=True, help="The market of the symbol to added")
+@click.option("--security-type", type=str, required=True, help="The security type of the symbol to added")
 @click.option("--resolution",
               type=str,
               default="Minute",
-              help="The resolution of the symbol to liquidate")
+              help="The resolution of the symbol to added")
 @click.option("--fill-data-forward",
               is_flag=True,
-              default=False,
-              help="The ticker of the symbol to liquidate")
+              default=True,
+              help="The fill forward behavior, true to fill forward, false otherwise - defaults to true")
 @click.option("--leverage",
               type=float,
               default=0.0,
-              help="The market of the symbol to liquidate")
+              help="The leverage for the security, defaults to 2 for equity, 50 for forex, and 1 for everything else")
 @click.option("--extended-market-hours",
               is_flag=True,
-              default=True,
-              help="The security type of the symbol to liquidate")
+              default=False,
+              help="The extended market hours flag, true to allow pre/post market data, false for only in market data")
 def add_security(project: Path,
                  ticker: str,
                  market: str,
@@ -72,7 +72,4 @@ def add_security(project: Path,
         raise Exception(
             f"add_security(): Failed to send the command, error: {e}")
 
-    try:
-        get_result(command_id, docker_container_name)
-    except Exception as e:
-        raise Exception(f"add_security(): Error: {e}")
+    get_result(command_id, docker_container_name)

--- a/lean/commands/live/cancel_order.py
+++ b/lean/commands/live/cancel_order.py
@@ -39,11 +39,6 @@ def cancel_order(project: Path,
         "OrderId": order_id
     }
 
-    try:
-        docker_container_name = send_command(project, data)
-    except Exception as e:
-        raise Exception(
-            f"cancel_order(): Failed to send the command, error: {e}")
-
+    docker_container_name = send_command(project, data)
     get_result(command_id, docker_container_name)
 

--- a/lean/commands/live/cancel_order.py
+++ b/lean/commands/live/cancel_order.py
@@ -50,7 +50,7 @@ def cancel_order(project: Path,
             docker_container_name, file_name, data)
     except Exception as e:
         logger.error(f"cancel_order(): Failed to send the command, error: {e}")
-
+        return
     # Check for result
     logger.info("cancel_order(): waiting for results...")
     result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'

--- a/lean/commands/live/cancel_order.py
+++ b/lean/commands/live/cancel_order.py
@@ -17,8 +17,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
-import time
+from lean.commands.live.live import get_command_file_name, get_result_file_name
 
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
@@ -42,7 +41,7 @@ def cancel_order(project: Path,
             "Id": command_id,
             "OrderId": order_id
         }
-    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    file_name = get_command_file_name()
     try:
         logger.info(
             f"cancel_order(): sending command.")
@@ -53,7 +52,7 @@ def cancel_order(project: Path,
         return
     # Check for result
     logger.info("cancel_order(): waiting for results...")
-    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result_file_path = get_result_file_name(command_id)
     result = container.docker_manager().read_from_file(
         docker_container_name, result_file_path)
     if "success" in result and result["success"]:

--- a/lean/commands/live/cancel_order.py
+++ b/lean/commands/live/cancel_order.py
@@ -22,7 +22,7 @@ from lean.commands.live.live import get_result, send_command
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
 @click.option("--order-id",
-              type=str,
+              type=int,
               required=True,
               help="The order id to be cancelled")
 def cancel_order(project: Path,
@@ -45,7 +45,5 @@ def cancel_order(project: Path,
         raise Exception(
             f"cancel_order(): Failed to send the command, error: {e}")
 
-    try:
-        get_result(command_id, docker_container_name)
-    except Exception as e:
-        raise Exception(f"cancel_order(): Error: {e}")
+    get_result(command_id, docker_container_name)
+

--- a/lean/commands/live/cancel_order.py
+++ b/lean/commands/live/cancel_order.py
@@ -1,0 +1,66 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+import uuid
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
+import time
+
+
+@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+@click.option("--order-id",
+              type=str,
+              required=True,
+              help="The order id to be cancelled")
+def cancel_order(project: Path,
+              order_id: str) -> None:
+    """
+    Represents a command to cancel a specific order by id.
+    """
+    logger = container.logger()
+    live_dir = container.project_config_manager().get_latest_live_directory(project)
+    docker_container_name = container.output_config_manager(
+    ).get_container_name(Path(live_dir))
+    command_id = uuid.uuid4().hex
+    data = {
+            "$type": "QuantConnect.Commands.CancelOrderCommand, QuantConnect.Common",
+            "Id": command_id,
+            "OrderId": order_id
+        }
+    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    try:
+        logger.info(
+            f"cancel_order(): sending command.")
+        container.docker_manager().write_to_file(
+            docker_container_name, file_name, data)
+    except Exception as e:
+        logger.error(f"cancel_order(): Failed to send the command, error: {e}")
+
+    # Check for result
+    logger.info("cancel_order(): waiting for results...")
+    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result = container.docker_manager().read_from_file(
+        docker_container_name, result_file_path)
+    if "success" in result and result["success"]:
+        logger.info(
+            "cancel_order(): Success: The command was executed successfully")
+    elif "container-running" in result and not result["container-running"]:
+        logger.info("liquidate(): Failed: The container is not running")
+    else:
+        logger.info(
+            f"cancel_order(): Failed: to execute the command successfully. {result['error']}")

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -27,6 +27,7 @@ from lean.models.logger import Option
 from lean.models.configuration import Configuration, InfoConfiguration, InternalInputUserInput
 from lean.models.click_options import options_from_json
 from lean.models.json_module import JsonModule
+from lean.commands.live.live import live
 from lean.models.data_providers import all_data_providers
 
 _environment_skeleton = {
@@ -235,7 +236,7 @@ def _get_configs_for_options() -> List[Configuration]:
             config_with_module_id[config._id] = module._id
     return list(run_options.values())
 
-@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@live.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True, default_command=True, name="deploy")
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
 @click.option("--environment",
               type=str,
@@ -269,7 +270,7 @@ def _get_configs_for_options() -> List[Configuration]:
               is_flag=True,
               default=False,
               help="Pull the LEAN engine image before starting live trading")
-def live(project: Path,
+def deploy(project: Path,
         environment: Optional[str],
         output: Optional[Path],
         detach: bool,

--- a/lean/commands/live/liquidate.py
+++ b/lean/commands/live/liquidate.py
@@ -13,6 +13,7 @@
 
 
 from pathlib import Path
+from typing import Optional
 import uuid
 import click
 from lean.click import LeanCommand, PathParameter
@@ -23,13 +24,13 @@ import time
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
-@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to liquidate")
-@click.option("--market", type=str, required=True, help="The market of the symbol to liquidate")
-@click.option("--security-type", type=str, required=True, help="The security type of the symbol to liquidate")
+@click.option("--ticker", type=str, help="The ticker of the symbol to liquidate")
+@click.option("--market", type=str, help="The market of the symbol to liquidate")
+@click.option("--security-type", type=str, default=0, help="The security type of the symbol to liquidate")
 def liquidate(project: Path,
-              ticker: str,
-              market: str,
-              security_type: str) -> None:
+              ticker: Optional[str],
+              market: Optional[str],
+              security_type: Optional[str]) -> None:
     """
     Liquidate the given symbol from the latest deployment of the given project.
     """
@@ -53,7 +54,7 @@ def liquidate(project: Path,
             docker_container_name, file_name, data)
     except Exception as e:
         logger.error(f"liquidate(): Failed to send the command, error: {e}")
-
+        return
     # Check for result
     logger.info("liquidate(): waiting for results...")
     result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'

--- a/lean/commands/live/liquidate.py
+++ b/lean/commands/live/liquidate.py
@@ -43,9 +43,5 @@ def liquidate(project: Path,
         "SecurityType": security_type
     }
 
-    try:
-        docker_container_name = send_command(project, data)
-    except Exception as e:
-        raise Exception(f"liquidate(): Failed to send the command, error: {e}")
-
+    docker_container_name = send_command(project, data)
     get_result(command_id, docker_container_name)

--- a/lean/commands/live/liquidate.py
+++ b/lean/commands/live/liquidate.py
@@ -18,8 +18,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
-import time
+from lean.commands.live.live import get_command_file_name, get_result_file_name
 
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
@@ -46,7 +45,7 @@ def liquidate(project: Path,
         "Market": market,
         "SecurityType": security_type
     }
-    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    file_name = get_command_file_name()
     try:
         logger.info(
             f"liquidate(): sending command.")
@@ -57,7 +56,7 @@ def liquidate(project: Path,
         return
     # Check for result
     logger.info("liquidate(): waiting for results...")
-    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result_file_path = get_result_file_name(command_id)
     result = container.docker_manager().read_from_file(
         docker_container_name, result_file_path)
     if "success" in result and result["success"]:

--- a/lean/commands/live/liquidate.py
+++ b/lean/commands/live/liquidate.py
@@ -1,53 +1,72 @@
-# # QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
-# # Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
-# from pathlib import Path
-# import click
-# from lean.click import LeanCommand, PathParameter
-# from lean.container import container
-# from lean.components.util.logger import Logger
-# from lean.constants import COMMANDS_FILE_PATH
+from pathlib import Path
+from typing import Optional
+import uuid
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.constants import COMMANDS_FILE_PATH, COMMAND_RESULT_FILE_BASENAME
+import time
 
-
-# @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
-# @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
-# @click.option("--environment",
-#               type=str,
-#               help="The environment to use")
-# @click.option("--environment",
-#               type=str,
-#               help="The environment to use")
-# @click.option("--environment",
-#               type=str,
-#               help="The environment to use")
-# def liquidate(project: Path,
-#             brokerage: Optional[str],
-#             data_feed: Optional[str],
-#             data_feed: Optional[str]) -> None:
-#     """
-#     Liquidate .
-#     """
+@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+@click.option("--ticker",
+              type=str,
+              help="The environment to use")
+@click.option("--market",
+              type=str,
+              help="The environment to use")
+@click.option("--security-type",
+              type=str,
+              help="The environment to use")
+def liquidate(project: Path,
+            ticker: Optional[str],
+            market: Optional[str],
+            security_type: Optional[str]) -> None:
+    """
+    Liquidate the given symbol from the latest deployment of the given project.
+    """
+    logger = container.logger()
+    live_dir = container.project_config_manager().get_latest_live_directory(project)
+    docker_container_name = container.output_config_manager().get_container_name(Path(live_dir))
+    command_id = uuid.uuid4().hex
+    data = {
+            "$type": "QuantConnect.Commands.LiquidateCommand, QuantConnect.Common",
+            "Id":command_id,
+            "Ticker": ticker,
+            "Market": market,
+            "SecurityType": security_type
+        }
+    file_name = COMMANDS_FILE_PATH / f'command-{int(time.time())}.json'
+    try:
+        logger.info(f"liquidate(): executing liquidate command with {ticker} {market} {security_type}")
+        container.docker_manager().write_to_file(docker_container_name, file_name, data)
+    except Exception as e:
+        logger.error(f"liquidate(): Failed to execute the command LiquidateCommand: {e}")
     
-#     docker_container_name = container.output_config_manager().get_container_name(project)
-#     data = {
-#         "command": "stop",
-#     }
-#     Logger.info(f"Sending command to container {docker_container_name}")
-#     try:
-#         container.docker_manager().write_to_file(docker_container_name, COMMANDS_FILE_PATH, data)
-#     except Exception as e:
-#         Logger.error(f"Failed to execute the command: {e}")
+    #Check for result
+    logger.info(f"liquidate(): waiting for results...")
+    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result = container.docker_manager().read_from_file(docker_container_name, result_file_path)
+    if "success" in result and result["success"]:
+        logger.info(f"liquidate(): Success: The command was executed successfully")
+    if "container-running" in result and not result["container-running"]:
+        logger.info(f"liquidate(): Failed: The container is not running")
+    else:
+        logger.info(f"liquidate(): Failed: to execute the command successfully. {result['error']}")
 
 
 

--- a/lean/commands/live/liquidate.py
+++ b/lean/commands/live/liquidate.py
@@ -1,0 +1,53 @@
+# # QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# # Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
+
+# from pathlib import Path
+# import click
+# from lean.click import LeanCommand, PathParameter
+# from lean.container import container
+# from lean.components.util.logger import Logger
+# from lean.constants import COMMANDS_FILE_PATH
+
+
+# @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+# @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+# @click.option("--environment",
+#               type=str,
+#               help="The environment to use")
+# @click.option("--environment",
+#               type=str,
+#               help="The environment to use")
+# @click.option("--environment",
+#               type=str,
+#               help="The environment to use")
+# def liquidate(project: Path,
+#             brokerage: Optional[str],
+#             data_feed: Optional[str],
+#             data_feed: Optional[str]) -> None:
+#     """
+#     Liquidate .
+#     """
+    
+#     docker_container_name = container.output_config_manager().get_container_name(project)
+#     data = {
+#         "command": "stop",
+#     }
+#     Logger.info(f"Sending command to container {docker_container_name}")
+#     try:
+#         container.docker_manager().write_to_file(docker_container_name, COMMANDS_FILE_PATH, data)
+#     except Exception as e:
+#         Logger.error(f"Failed to execute the command: {e}")
+
+
+

--- a/lean/commands/live/liquidate.py
+++ b/lean/commands/live/liquidate.py
@@ -48,7 +48,4 @@ def liquidate(project: Path,
     except Exception as e:
         raise Exception(f"liquidate(): Failed to send the command, error: {e}")
 
-    try:
-        get_result(command_id, docker_container_name)
-    except Exception as e:
-        raise Exception(f"liquidate(): Error: {e}")
+    get_result(command_id, docker_container_name)

--- a/lean/commands/live/live.py
+++ b/lean/commands/live/live.py
@@ -84,5 +84,5 @@ def get_result(command_id: str, docker_container_name: str, container_running_re
             logger.info(
                 f"live.get_result(): {inspect.stack()[1].function} - Success: The command was executed successfully")
     else:
-        raise Exception(f"live.get_result(): {inspect.stack()[1].function} - \
-        Failed: to execute the command successfully. {result['error']}")
+        raise Exception((f"live.get_result(): {inspect.stack()[1].function} - "
+                        + f"Failed: to execute the command successfully. {result['error']}"))

--- a/lean/commands/live/live.py
+++ b/lean/commands/live/live.py
@@ -13,6 +13,9 @@
 
 import click
 from lean.components.util.click_group_default_command import DefaultCommandGroup
+from lean.constants import COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
+import time
+from pathlib import Path
 
 @click.group(cls=DefaultCommandGroup)
 def live() -> None:
@@ -20,3 +23,9 @@ def live() -> None:
     # This method is intentionally empty
     # It is used as the command group for all `lean cloud <command>` commands
     pass
+
+def get_command_file_name():
+    return Path(f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json')
+
+def get_result_file_name(command_id: str):
+    return Path(f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json')

--- a/lean/commands/live/live.py
+++ b/lean/commands/live/live.py
@@ -11,11 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+from typing import Any, Dict
 import click
 from lean.components.util.click_group_default_command import DefaultCommandGroup
 from lean.constants import COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
 import time
 from pathlib import Path
+from lean.container import container
+
 
 @click.group(cls=DefaultCommandGroup)
 def live() -> None:
@@ -24,8 +28,61 @@ def live() -> None:
     # It is used as the command group for all `lean cloud <command>` commands
     pass
 
-def get_command_file_name():
+
+def get_command_file_name() -> str:
     return Path(f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json')
 
-def get_result_file_name(command_id: str):
+
+def get_result_file_name(command_id: str) -> str:
     return Path(f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json')
+
+
+def send_command(project: Path, data: Dict[str, Any]) -> str:
+    """send command to the running container of the given project.
+
+    :param project: the project path
+    :param data: the data to send to the container
+    :return: the name of the running docker container of the given project
+    """
+    logger = container.logger()
+    live_dir = container.project_config_manager().get_latest_live_directory(project)
+    docker_container_name = container.output_config_manager(
+    ).get_container_name(Path(live_dir))
+    file_name = get_command_file_name()
+    logger.info(
+        f"live.send_command(): {inspect.stack()[1].function} - sending command.")
+    container.docker_manager().write_to_file(
+        docker_container_name, file_name, data)
+    return docker_container_name
+
+
+def get_result(command_id: str, docker_container_name: str, container_running_required: bool = True,
+               interval: int = 1, timeout: int = 30) -> None:
+    """Get the result of a command.
+
+    :param command_id: command id
+    :param docker_container_name: docker container name
+    :param container_running_required: should the container be alive after command execution, defaults to True
+    :param interval: interval to sleep before retrying, defaults to 1
+    :param timeout: time to stop trying to check for result file, defaults to 30
+    :raises Exception: When the command is not executed successfully
+    """
+    logger = container.logger()
+    logger.info(
+        f"live.get_result(): {inspect.stack()[1].function} -  waiting for results...")
+    result_file_path = get_result_file_name(command_id)
+    result = container.docker_manager().read_from_file(
+        docker_container_name, result_file_path, interval, timeout)
+    if "success" in result and result["success"]:
+        logger.info(
+            f"live.get_result(): {inspect.stack()[1].function} - Success: The command was executed successfully")
+    elif "container-running" in result and not result["container-running"]:
+        if container_running_required:
+            raise Exception(
+                f"live.get_result(): {inspect.stack()[1].function} - Failed: The container is not running")
+        else:
+            logger.info(
+                f"live.get_result(): {inspect.stack()[1].function} - Success: The command was executed successfully")
+    else:
+        raise Exception(f"live.get_result(): {inspect.stack()[1].function} - \
+        Failed: to execute the command successfully. {result['error']}")

--- a/lean/commands/live/live.py
+++ b/lean/commands/live/live.py
@@ -1,0 +1,22 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from lean.components.util.click_group_default_command import DefaultCommandGroup
+
+@click.group(cls=DefaultCommandGroup)
+def live() -> None:
+    """Interact with the local machine."""
+    # This method is intentionally empty
+    # It is used as the command group for all `lean cloud <command>` commands
+    pass

--- a/lean/commands/live/stop.py
+++ b/lean/commands/live/stop.py
@@ -41,7 +41,7 @@ def stop(project: Path) -> None:
         container.docker_manager().write_to_file(docker_container_name, file_name, data)
     except Exception as e:
         logger.error(f"stop(): Failed to send the command, error: {e}")
-    
+        return
     #Check for result
     logger.info(f"stop(): waiting for results...")
     result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'

--- a/lean/commands/live/stop.py
+++ b/lean/commands/live/stop.py
@@ -17,8 +17,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
-import time
+from lean.commands.live.live import get_command_file_name, get_result_file_name
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -35,7 +34,7 @@ def stop(project: Path) -> None:
             "Id": command_id,
             "Status": "Stopped"
         }
-    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    file_name = get_command_file_name()
     try:
         logger.info(f"stop(): sending command.")
         container.docker_manager().write_to_file(docker_container_name, file_name, data)
@@ -44,7 +43,7 @@ def stop(project: Path) -> None:
         return
     #Check for result
     logger.info(f"stop(): waiting for results...")
-    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result_file_path = get_result_file_name(command_id)
     result = container.docker_manager().read_from_file(docker_container_name, result_file_path)
     if result["success"] or not result["container-running"]:
         logger.info(f"stop(): Success: The command was executed successfully")

--- a/lean/commands/live/stop.py
+++ b/lean/commands/live/stop.py
@@ -38,7 +38,5 @@ def stop(project: Path) -> None:
     except Exception as e:
         raise Exception(f"stop(): Failed to send the command, error: {e}")
 
-    try:
-        get_result(command_id, docker_container_name)
-    except Exception as e:
-        raise Exception(f"stop(): Error: {e}")
+    get_result(command_id, docker_container_name)
+

--- a/lean/commands/live/stop.py
+++ b/lean/commands/live/stop.py
@@ -1,0 +1,43 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.components.util.logger import Logger
+from lean.constants import COMMANDS_FILE_PATH
+
+
+@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+def stop(project: Path) -> None:
+    """
+    Stop an already running local live trading a project.
+    """
+    
+    docker_container_name = container.output_config_manager().get_container_name(project)
+    data = {[
+        {
+            "Status": "Stopped"
+        }
+    ]}
+    # Logger.info(f"Sending command to container {docker_container_name}")
+    try:
+        container.docker_manager().write_to_file(docker_container_name, COMMANDS_FILE_PATH, data)
+    except Exception as e:
+        Logger.error(f"Failed to execute the command: {e}")
+
+
+

--- a/lean/commands/live/stop.py
+++ b/lean/commands/live/stop.py
@@ -17,7 +17,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_RESULT_FILE_BASENAME
+from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
 import time
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
@@ -35,12 +35,12 @@ def stop(project: Path) -> None:
             "Id": command_id,
             "Status": "Stopped"
         }
-    file_name = COMMANDS_FILE_PATH / f'command-{int(time.time())}.json'
+    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
     try:
-        logger.info(f"stop(): executing stop command")
+        logger.info(f"stop(): sending command.")
         container.docker_manager().write_to_file(docker_container_name, file_name, data)
     except Exception as e:
-        logger.error(f"stop(): Failed to execute the command: {e}")
+        logger.error(f"stop(): Failed to send the command, error: {e}")
     
     #Check for result
     logger.info(f"stop(): waiting for results...")

--- a/lean/commands/live/stop.py
+++ b/lean/commands/live/stop.py
@@ -23,7 +23,7 @@ from lean.commands.live.live import get_result, send_command
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
 def stop(project: Path) -> None:
     """
-    Stop an already running local live trading a project.
+    Stop an already running local live trading project.
     """
     command_id = uuid.uuid4().hex
 
@@ -33,10 +33,6 @@ def stop(project: Path) -> None:
         "Status": "Stopped"
     }
 
-    try:
-        docker_container_name = send_command(project, data)
-    except Exception as e:
-        raise Exception(f"stop(): Failed to send the command, error: {e}")
-
+    docker_container_name = send_command(project, data)
     get_result(command_id, docker_container_name)
 

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -69,7 +69,7 @@ def submit_order(project: Path,
             docker_container_name, file_name, data)
     except Exception as e:
         logger.error(f"submit_order(): Failed to send the command, error: {e}")
-
+        return
     # Check for result
     logger.info("submit_order(): waiting for results...")
     result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -1,0 +1,85 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import Optional
+import uuid
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
+import time
+
+
+@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to submitted")
+@click.option("--market", type=str, required=True, help="The market of the symbol to submitted")
+@click.option("--security-type", required=True, type=str, help="The security type of the symbol to submitted")
+@click.option("--order-type", type=str, required=True, help="The order type to be submitted")
+@click.option("--quantity", type=float, required=True, help="the number of units to be ordered (directional)")
+@click.option("--limit-price", type=float, default=0.0, help="The limit price of the order to submitted")
+@click.option("--stop-price", type=float, default=0.0, help="The stop price of the order to be submitted")
+@click.option("--tag", type=str, help="The tag to be attached to the order")
+def submit_order(project: Path,
+              ticker: str,
+              market: str,
+              security_type: str,
+              order_type: str,
+              quantity: float,
+              limit_price: Optional[float],
+              stop_price: Optional[float],
+              tag: Optional[str]) -> None:
+    """
+    Represents a command to submit an order to the algorithm.
+    """
+    logger = container.logger()
+    live_dir = container.project_config_manager().get_latest_live_directory(project)
+    docker_container_name = container.output_config_manager(
+    ).get_container_name(Path(live_dir))
+    command_id = uuid.uuid4().hex
+    data = {
+        "$type": "QuantConnect.Commands.OrderCommand, QuantConnect.Common",
+        "Id": command_id,
+        "Ticker": ticker,
+        "Market": market,
+        "SecurityType": security_type,
+        "OrderType": order_type,
+        "Quantity": quantity,
+        "LimitPrice": limit_price,
+        "StopPrice": stop_price,
+        "Tag": tag
+    }
+    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    try:
+        logger.info(
+            f"submit_order(): sending command.")
+        container.docker_manager().write_to_file(
+            docker_container_name, file_name, data)
+    except Exception as e:
+        logger.error(f"submit_order(): Failed to send the command, error: {e}")
+
+    # Check for result
+    logger.info("submit_order(): waiting for results...")
+    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result = container.docker_manager().read_from_file(
+        docker_container_name, result_file_path)
+    if "success" in result and result["success"]:
+        logger.info(
+            "submit_order(): Success: The command was executed successfully")
+    elif "container-running" in result and not result["container-running"]:
+        logger.info("submit_order(): Failed: The container is not running")
+    else:
+        logger.info(
+            f"submit_order(): Failed: to execute the command successfully. {result['error']}")

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -18,8 +18,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
-import time
+from lean.commands.live.live import get_command_file_name, get_result_file_name
 
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
@@ -61,7 +60,7 @@ def submit_order(project: Path,
         "StopPrice": stop_price,
         "Tag": tag
     }
-    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    file_name = get_command_file_name()
     try:
         logger.info(
             f"submit_order(): sending command.")
@@ -72,7 +71,7 @@ def submit_order(project: Path,
         return
     # Check for result
     logger.info("submit_order(): waiting for results...")
-    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result_file_path = get_result_file_name(command_id)
     result = container.docker_manager().read_from_file(
         docker_container_name, result_file_path)
     if "success" in result and result["success"]:

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -64,7 +64,4 @@ def submit_order(project: Path,
         raise Exception(
             f"submit_order(): Failed to send the command, error: {e}")
 
-    try:
-        get_result(command_id, docker_container_name)
-    except Exception as e:
-        raise Exception(f"submit_order(): Error: {e}")
+    get_result(command_id, docker_container_name)

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -18,7 +18,7 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.commands.live.live import get_result, send_command
-
+from lean.components.util.click_custom_parameters import DECIMAL
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -26,18 +26,18 @@ from lean.commands.live.live import get_result, send_command
 @click.option("--market", type=str, required=True, help="The market of the symbol to submitted")
 @click.option("--security-type", required=True, type=str, help="The security type of the symbol to submitted")
 @click.option("--order-type", type=str, required=True, help="The order type to be submitted")
-@click.option("--quantity", type=float, required=True, help="the number of units to be ordered (directional)")
-@click.option("--limit-price", type=float, default=0.0, help="The limit price of the order to submitted")
-@click.option("--stop-price", type=float, default=0.0, help="The stop price of the order to be submitted")
+@click.option("--quantity", type=DECIMAL, required=True, help="the number of units to be ordered (directional)")
+@click.option("--limit-price", type=DECIMAL, default=0.0, help="The limit price of the order to submitted")
+@click.option("--stop-price", type=DECIMAL, default=0.0, help="The stop price of the order to be submitted")
 @click.option("--tag", type=str, help="The tag to be attached to the order")
 def submit_order(project: Path,
                  ticker: str,
                  market: str,
                  security_type: str,
                  order_type: str,
-                 quantity: float,
-                 limit_price: Optional[float],
-                 stop_price: Optional[float],
+                 quantity: DECIMAL,
+                 limit_price: Optional[DECIMAL],
+                 stop_price: Optional[DECIMAL],
                  tag: Optional[str]) -> None:
     """
     Represents a command to submit an order to the algorithm.

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -22,13 +22,13 @@ from lean.components.util.click_custom_parameters import DECIMAL
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
-@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to submitted")
-@click.option("--market", type=str, required=True, help="The market of the symbol to submitted")
-@click.option("--security-type", required=True, type=str, help="The security type of the symbol to submitted")
-@click.option("--order-type", type=str, required=True, help="The order type to be submitted")
+@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to submit")
+@click.option("--market", type=str, required=True, help="The market of the symbol to submit")
+@click.option("--security-type", required=True, type=str, help="The security type of the symbol to submit")
+@click.option("--order-type", type=str, required=True, help="The order type to be submit")
 @click.option("--quantity", type=DECIMAL, required=True, help="the number of units to be ordered (directional)")
-@click.option("--limit-price", type=DECIMAL, default=0.0, help="The limit price of the order to submitted")
-@click.option("--stop-price", type=DECIMAL, default=0.0, help="The stop price of the order to be submitted")
+@click.option("--limit-price", type=DECIMAL, default=0.0, help="The limit price of the order to submit")
+@click.option("--stop-price", type=DECIMAL, default=0.0, help="The stop price of the order to be submit")
 @click.option("--tag", type=str, help="The tag to be attached to the order")
 def submit_order(project: Path,
                  ticker: str,

--- a/lean/commands/live/submit_order.py
+++ b/lean/commands/live/submit_order.py
@@ -22,13 +22,13 @@ from lean.components.util.click_custom_parameters import DECIMAL
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
-@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to submit")
-@click.option("--market", type=str, required=True, help="The market of the symbol to submit")
-@click.option("--security-type", required=True, type=str, help="The security type of the symbol to submit")
-@click.option("--order-type", type=str, required=True, help="The order type to be submit")
-@click.option("--quantity", type=DECIMAL, required=True, help="the number of units to be ordered (directional)")
-@click.option("--limit-price", type=DECIMAL, default=0.0, help="The limit price of the order to submit")
-@click.option("--stop-price", type=DECIMAL, default=0.0, help="The stop price of the order to be submit")
+@click.option("--ticker", type=str, required=True, help="The ticker of the symbol to be submitted")
+@click.option("--market", type=str, required=True, help="The market of the symbol to be submitted")
+@click.option("--security-type", required=True, type=str, help="The security type of the symbol to be submitted")
+@click.option("--order-type", type=str, required=True, help="The order type to be submitted")
+@click.option("--quantity", type=DECIMAL, required=True, help="The number of units to be ordered (directional)")
+@click.option("--limit-price", type=DECIMAL, default=0.0, help="The limit price of the order be submitted")
+@click.option("--stop-price", type=DECIMAL, default=0.0, help="The stop price of the order to be submitted")
 @click.option("--tag", type=str, help="The tag to be attached to the order")
 def submit_order(project: Path,
                  ticker: str,
@@ -58,10 +58,5 @@ def submit_order(project: Path,
         "Tag": tag
     }
 
-    try:
-        docker_container_name = send_command(project, data)
-    except Exception as e:
-        raise Exception(
-            f"submit_order(): Failed to send the command, error: {e}")
-
+    docker_container_name = send_command(project, data)
     get_result(command_id, docker_container_name)

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -1,0 +1,78 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+import uuid
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
+import time
+from typing import Optional
+
+@click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
+@click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
+@click.option("--order-id",
+              type=str,
+              required=True,
+              help="The order id to be cancelled")
+@click.option("--quantity", type=float, help="the number of units to be ordered (directional)")
+@click.option("--limit-price", type=float, help="The limit price of the order to updated")
+@click.option("--stop-price", type=float, help="The stop price of the order to be updated")
+@click.option("--tag", type=str, help="The tag to be attached to the order")
+def update_order(project: Path,
+              order_id: str,
+              quantity: Optional[float],
+              limit_price: Optional[float],
+              stop_price: Optional[float],
+              tag: Optional[str]) -> None:
+    """
+    Represents a command to cancel a specific order by id.
+    """
+    logger = container.logger()
+    live_dir = container.project_config_manager().get_latest_live_directory(project)
+    docker_container_name = container.output_config_manager(
+    ).get_container_name(Path(live_dir))
+    command_id = uuid.uuid4().hex
+    data = {
+            "$type": "QuantConnect.Commands.UpdateOrderCommand, QuantConnect.Common",
+            "Id": command_id,
+            "OrderId": order_id,
+            "Quantity": quantity,
+            "LimitPrice": limit_price,
+            "StopPrice": stop_price,
+            "Tag": tag
+        }
+    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    try:
+        logger.info(
+            f"update_order(): sending command.")
+        container.docker_manager().write_to_file(
+            docker_container_name, file_name, data)
+    except Exception as e:
+        logger.error(f"update_order(): Failed to send the command, error: {e}")
+
+    # Check for result
+    logger.info("update_order(): waiting for results...")
+    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result = container.docker_manager().read_from_file(
+        docker_container_name, result_file_path)
+    if "success" in result and result["success"]:
+        logger.info(
+            "update_order(): Success: The command was executed successfully")
+    elif "container-running" in result and not result["container-running"]:
+        logger.info("liquidate(): Failed: The container is not running")
+    else:
+        logger.info(
+            f"update_order(): Failed: to execute the command successfully. {result['error']}")

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -23,9 +23,9 @@ from lean.commands.live.live import get_result, send_command
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
 @click.option("--order-id",
-              type=str,
+              type=int,
               required=True,
-              help="The order id to be cancelled")
+              help="The order id to be updated")
 @click.option("--quantity", type=float, help="the number of units to be ordered (directional)")
 @click.option("--limit-price", type=float, help="The limit price of the order to updated")
 @click.option("--stop-price", type=float, help="The stop price of the order to be updated")
@@ -37,7 +37,7 @@ def update_order(project: Path,
                  stop_price: Optional[float],
                  tag: Optional[str]) -> None:
     """
-    Represents a command to cancel a specific order by id.
+    Represents a command to update a specific order by id.
     """
 
     command_id = uuid.uuid4().hex
@@ -58,7 +58,4 @@ def update_order(project: Path,
         raise Exception(
             f"update_order(): Failed to send the command, error: {e}")
 
-    try:
-        get_result(command_id, docker_container_name)
-    except Exception as e:
-        raise Exception(f"update_order(): Error: {e}")
+    get_result(command_id, docker_container_name)

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -17,9 +17,8 @@ import uuid
 import click
 from lean.click import LeanCommand, PathParameter
 from lean.container import container
-from lean.constants import COMMANDS_FILE_PATH, COMMAND_FILE_BASENAME, COMMAND_RESULT_FILE_BASENAME
-import time
 from typing import Optional
+from lean.commands.live.live import get_command_file_name, get_result_file_name
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -54,7 +53,7 @@ def update_order(project: Path,
             "StopPrice": stop_price,
             "Tag": tag
         }
-    file_name = COMMANDS_FILE_PATH / f'{COMMAND_FILE_BASENAME}-{int(time.time())}.json'
+    file_name = get_command_file_name()
     try:
         logger.info(
             f"update_order(): sending command.")
@@ -65,7 +64,7 @@ def update_order(project: Path,
         return
     # Check for result
     logger.info("update_order(): waiting for results...")
-    result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'
+    result_file_path = get_result_file_name(command_id)
     result = container.docker_manager().read_from_file(
         docker_container_name, result_file_path)
     if "success" in result and result["success"]:

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -62,7 +62,7 @@ def update_order(project: Path,
             docker_container_name, file_name, data)
     except Exception as e:
         logger.error(f"update_order(): Failed to send the command, error: {e}")
-
+        return
     # Check for result
     logger.info("update_order(): waiting for results...")
     result_file_path = COMMANDS_FILE_PATH / f'{COMMAND_RESULT_FILE_BASENAME}-{command_id}.json'

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -26,8 +26,8 @@ from lean.components.util.click_custom_parameters import DECIMAL
               type=int,
               required=True,
               help="The order id to be updated")
-@click.option("--quantity", type=DECIMAL, help="the number of units to be ordered (directional)")
-@click.option("--limit-price", type=DECIMAL, help="The limit price of the order to updated")
+@click.option("--quantity", type=DECIMAL, help="The number of units to be updated (directional)")
+@click.option("--limit-price", type=DECIMAL, help="The limit price of the order to be updated")
 @click.option("--stop-price", type=DECIMAL, help="The stop price of the order to be updated")
 @click.option("--tag", type=str, help="The tag to be attached to the order")
 def update_order(project: Path,
@@ -52,10 +52,5 @@ def update_order(project: Path,
         "Tag": tag
     }
 
-    try:
-        docker_container_name = send_command(project, data)
-    except Exception as e:
-        raise Exception(
-            f"update_order(): Failed to send the command, error: {e}")
-
+    docker_container_name = send_command(project, data)
     get_result(command_id, docker_container_name)

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -16,9 +16,9 @@ from pathlib import Path
 import uuid
 import click
 from lean.click import LeanCommand, PathParameter
-from lean.container import container
 from typing import Optional
-from lean.commands.live.live import get_command_file_name, get_result_file_name
+from lean.commands.live.live import get_result, send_command
+
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -31,47 +31,34 @@ from lean.commands.live.live import get_command_file_name, get_result_file_name
 @click.option("--stop-price", type=float, help="The stop price of the order to be updated")
 @click.option("--tag", type=str, help="The tag to be attached to the order")
 def update_order(project: Path,
-              order_id: str,
-              quantity: Optional[float],
-              limit_price: Optional[float],
-              stop_price: Optional[float],
-              tag: Optional[str]) -> None:
+                 order_id: str,
+                 quantity: Optional[float],
+                 limit_price: Optional[float],
+                 stop_price: Optional[float],
+                 tag: Optional[str]) -> None:
     """
     Represents a command to cancel a specific order by id.
     """
-    logger = container.logger()
-    live_dir = container.project_config_manager().get_latest_live_directory(project)
-    docker_container_name = container.output_config_manager(
-    ).get_container_name(Path(live_dir))
+
     command_id = uuid.uuid4().hex
+
     data = {
-            "$type": "QuantConnect.Commands.UpdateOrderCommand, QuantConnect.Common",
-            "Id": command_id,
-            "OrderId": order_id,
-            "Quantity": quantity,
-            "LimitPrice": limit_price,
-            "StopPrice": stop_price,
-            "Tag": tag
-        }
-    file_name = get_command_file_name()
+        "$type": "QuantConnect.Commands.UpdateOrderCommand, QuantConnect.Common",
+        "Id": command_id,
+        "OrderId": order_id,
+        "Quantity": quantity,
+        "LimitPrice": limit_price,
+        "StopPrice": stop_price,
+        "Tag": tag
+    }
+
     try:
-        logger.info(
-            f"update_order(): sending command.")
-        container.docker_manager().write_to_file(
-            docker_container_name, file_name, data)
+        docker_container_name = send_command(project, data)
     except Exception as e:
-        logger.error(f"update_order(): Failed to send the command, error: {e}")
-        return
-    # Check for result
-    logger.info("update_order(): waiting for results...")
-    result_file_path = get_result_file_name(command_id)
-    result = container.docker_manager().read_from_file(
-        docker_container_name, result_file_path)
-    if "success" in result and result["success"]:
-        logger.info(
-            "update_order(): Success: The command was executed successfully")
-    elif "container-running" in result and not result["container-running"]:
-        logger.info("liquidate(): Failed: The container is not running")
-    else:
-        logger.info(
-            f"update_order(): Failed: to execute the command successfully. {result['error']}")
+        raise Exception(
+            f"update_order(): Failed to send the command, error: {e}")
+
+    try:
+        get_result(command_id, docker_container_name)
+    except Exception as e:
+        raise Exception(f"update_order(): Error: {e}")

--- a/lean/commands/live/update_order.py
+++ b/lean/commands/live/update_order.py
@@ -18,7 +18,7 @@ import click
 from lean.click import LeanCommand, PathParameter
 from typing import Optional
 from lean.commands.live.live import get_result, send_command
-
+from lean.components.util.click_custom_parameters import DECIMAL
 
 @click.command(cls=LeanCommand, requires_lean_config=True, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=True, dir_okay=True))
@@ -26,15 +26,15 @@ from lean.commands.live.live import get_result, send_command
               type=int,
               required=True,
               help="The order id to be updated")
-@click.option("--quantity", type=float, help="the number of units to be ordered (directional)")
-@click.option("--limit-price", type=float, help="The limit price of the order to updated")
-@click.option("--stop-price", type=float, help="The stop price of the order to be updated")
+@click.option("--quantity", type=DECIMAL, help="the number of units to be ordered (directional)")
+@click.option("--limit-price", type=DECIMAL, help="The limit price of the order to updated")
+@click.option("--stop-price", type=DECIMAL, help="The stop price of the order to be updated")
 @click.option("--tag", type=str, help="The tag to be attached to the order")
 def update_order(project: Path,
                  order_id: str,
-                 quantity: Optional[float],
-                 limit_price: Optional[float],
-                 stop_price: Optional[float],
+                 quantity: Optional[DECIMAL],
+                 limit_price: Optional[DECIMAL],
+                 stop_price: Optional[DECIMAL],
                  tag: Optional[str]) -> None:
     """
     Represents a command to update a specific order by id.

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -16,7 +16,7 @@ from math import floor
 from typing import List, Optional
 
 from lean.components.api.api_client import *
-from lean.models.api import QCFullLiveAlgorithm, QCLiveAlgorithmStatus, QCMinimalLiveAlgorithm, QCNotificationMethod
+from lean.models.api import QCFullLiveAlgorithm, QCLiveAlgorithmStatus, QCMinimalLiveAlgorithm, QCNotificationMethod, QCRestResponse
 
 
 class LiveClient:
@@ -103,20 +103,22 @@ class LiveClient:
         data = self._api.post("live/create", parameters)
         return QCMinimalLiveAlgorithm(**data)
 
-    def stop(self, project_id: int) -> None:
+    def stop(self, project_id: int) -> QCRestResponse:
         """Stops live trading for a certain project without liquidated existing positions.
 
         :param project_id: the id of the project to stop live trading for
         """
-        self._api.post("live/update/stop", {
+        data = self._api.post("live/update/stop", {
             "projectId": project_id
         })
+        return QCRestResponse(**data)
 
-    def liquidate_and_stop(self, project_id: int) -> None:
+    def liquidate_and_stop(self, project_id: int) -> QCRestResponse:
         """Stops live trading and liquidates existing positions for a certain project.
 
         :param project_id: the id of the project to stop live trading and liquidate existing positions for
         """
-        self._api.post("live/update/liquidate", {
+        data = self._api.post("live/update/liquidate", {
             "projectId": project_id
         })
+        return QCRestResponse(**data)

--- a/lean/components/config/output_config_manager.py
+++ b/lean/components/config/output_config_manager.py
@@ -45,7 +45,7 @@ class OutputConfigManager:
         """
         return self._get_id(backtest_directory, 1)
 
-    def get_backtest_name(self, backtest_directory: Path) -> int:
+    def get_backtest_name(self, backtest_directory: Path) -> str:
         """Returns the name of a backtest.
 
         :param backtest_directory: the path to the backtest to retrieve the id of
@@ -58,7 +58,7 @@ class OutputConfigManager:
 
         raise ValueError("Backtest name is not set")
 
-    def get_container_name(self, backtest_directory: Path) -> int:
+    def get_container_name(self, backtest_directory: Path) -> str:
         """Returns the name of a the docker container lean is running in.
 
         :param backtest_directory: the path to the backtest to retrieve the id of

--- a/lean/components/config/project_config_manager.py
+++ b/lean/components/config/project_config_manager.py
@@ -65,14 +65,15 @@ class ProjectConfigManager:
         """
         live_root_dir = project_directory / "live"
         if not live_root_dir.is_dir():
-            return None
+            raise ValueError(f"live directory {live_root_dir} is not a directory")
 
-        live_dirs = []
-        for live_dir in sorted(list(live_root_dir.iterdir())):
-            if (live_dir / "log.txt").is_file():
-                live_dirs.append(live_dir)
+        for live_dir in sorted(list(live_root_dir.iterdir()), reverse=True):
+            if not (live_dir / "log.txt").is_file():
+                continue
+            return live_dir
+        
+        raise ValueError("live directory with log.txt not found")
 
-        return live_dirs[-1]
         
     def get_csharp_libraries(self, project_directory: Path) -> List[CSharpLibrary]:
         """Returns the custom C# libraries in a project.

--- a/lean/components/config/project_config_manager.py
+++ b/lean/components/config/project_config_manager.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import random
 from pathlib import Path
 from typing import List
@@ -56,6 +57,18 @@ class ProjectConfigManager:
         project_config.set("local-id", project_id)
 
         return project_id
+
+    def get_latest_live_directory(self, project_directory: Path) -> int:
+        """Returns the path of the latest live directory.
+
+        :param project_directory: the path to the project to retrieve the local id of
+        :return: the path of the latest live directory
+        """
+        live_dir = os.path.join(project_directory, "live")
+        result = sorted((os.path.join(live_dir, dir) for dir in os.listdir(live_dir)),key=lambda x: os.stat(x).st_ctime, reverse=True)
+        if result:
+            return result[0]
+        return None
 
     def get_csharp_libraries(self, project_directory: Path) -> List[CSharpLibrary]:
         """Returns the custom C# libraries in a project.

--- a/lean/components/config/project_config_manager.py
+++ b/lean/components/config/project_config_manager.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import random
 from pathlib import Path
 from typing import List
@@ -58,18 +57,23 @@ class ProjectConfigManager:
 
         return project_id
 
-    def get_latest_live_directory(self, project_directory: Path) -> int:
+    def get_latest_live_directory(self, project_directory: Path) -> Path:
         """Returns the path of the latest live directory.
 
         :param project_directory: the path to the project to retrieve the local id of
         :return: the path of the latest live directory
         """
-        live_dir = os.path.join(project_directory, "live")
-        result = sorted((os.path.join(live_dir, dir) for dir in os.listdir(live_dir)),key=lambda x: os.stat(x).st_ctime, reverse=True)
-        if result:
-            return result[0]
-        return None
+        live_root_dir = project_directory / "live"
+        if not live_root_dir.is_dir():
+            return None
 
+        live_dirs = []
+        for live_dir in sorted(list(live_root_dir.iterdir())):
+            if (live_dir / "log.txt").is_file():
+                live_dirs.append(live_dir)
+
+        return live_dirs[-1]
+        
     def get_csharp_libraries(self, project_directory: Path) -> List[CSharpLibrary]:
         """Returns the custom C# libraries in a project.
 

--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -429,8 +429,9 @@ class DockerManager:
         """Write data to the file in docker.
 
         Args:
+            docker_container_name: The name of the container to write to
             docker_file: The Dockerfile to write to.
-            options: The options to write to the Dockerfile.
+            data: The data to write to the Dockerfile.
         """
         docker_container = self.get_container_by_name(docker_container_name)
         if docker_container is None:
@@ -448,12 +449,14 @@ class DockerManager:
         except Exception as e:
             raise ValueError(f"Failed to write to {docker_file.name}: {e}")
     
-    def read_from_file(self, docker_container_name: str, docker_file: Path, interval=1, timeout=30) -> None:
+    def read_from_file(self, docker_container_name: str, docker_file: Path, interval=1, timeout=30) -> Dict[str,Any]:
         """Read data from file in docker.
 
         Args:
+            docker_container_name: The name of the container to write to
             docker_file: The Dockerfile to write to.
-            options: The options to write to the Dockerfile.
+            interval: The interval to sleep before checking again.
+            timeout: The timeout to wait for the file.
         """
         command = f'docker exec {docker_container_name} bash -c "cat {docker_file.as_posix()}"'
         start = time.time()

--- a/lean/components/util/click_custom_parameters.py
+++ b/lean/components/util/click_custom_parameters.py
@@ -1,0 +1,26 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from decimal import Decimal, DecimalException
+
+class DecimalParamType(click.ParamType):
+    name = "decimal"
+
+    def convert(self, value, param, ctx):
+        try:
+            return Decimal(value)
+        except DecimalException:
+            self.fail(f"{value!r} is not a valid decimal", param, ctx)
+
+DECIMAL = DecimalParamType()

--- a/lean/components/util/click_group_default_command.py
+++ b/lean/components/util/click_group_default_command.py
@@ -1,0 +1,32 @@
+import click
+
+class DefaultCommandGroup(click.Group):
+    """allow a default command for a group"""
+
+    def command(self, *args, **kwargs):
+        default_command = kwargs.pop('default_command', False)
+        if default_command and not args:
+            kwargs['name'] = kwargs.get('name', '<>')
+        decorator = super(
+            DefaultCommandGroup, self).command(*args, **kwargs)
+
+        if default_command:
+            def new_decorator(f):
+                cmd = decorator(f)
+                self.default_command = cmd.name
+                return cmd
+
+            return new_decorator
+
+        return decorator
+
+    def resolve_command(self, ctx, args):
+        try:
+            # test if the command parses
+            return super(
+                DefaultCommandGroup, self).resolve_command(ctx, args)
+        except click.UsageError:
+            # command did not parse, assume it is the default command
+            args.insert(0, self.default_command)
+            return super(
+                DefaultCommandGroup, self).resolve_command(ctx, args)

--- a/lean/components/util/click_group_default_command.py
+++ b/lean/components/util/click_group_default_command.py
@@ -1,3 +1,16 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import click
 
 class DefaultCommandGroup(click.Group):

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -30,7 +30,10 @@ CACHE_PATH = str(Path("~/.lean/cache").expanduser())
 MODULES_DIRECTORY = str(Path("~/.lean/modules").expanduser())
 
 # The file in which we send live commands to running docker container
-COMMANDS_FILE_PATH = Path("/Lean/Launcher/bin/Debug/commands.json")
+COMMANDS_FILE_PATH = Path("/Lean/Launcher/bin/Debug")
+
+# The file in which we send live commands to running docker container
+COMMAND_RESULT_FILE_BASENAME = "result-command"
 
 # The default name of the file containing the Lean engine configuration
 DEFAULT_LEAN_CONFIG_FILE_NAME = "lean.json"

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -28,9 +28,6 @@ CACHE_PATH = str(Path("~/.lean/cache").expanduser())
 # The directory in which modules are stored
 MODULES_DIRECTORY = str(Path("~/.lean/modules").expanduser())
 
-# The base path of the running docker container to which we send the command file
-COMMANDS_FILE_PATH = Path("/Lean/Launcher/bin/Debug")
-
 # The file in which we send live commands to running docker container
 COMMAND_FILE_BASENAME = "command"
 

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import os
-from datetime import datetime, timezone
 from pathlib import Path
 
 # Due to the way the filesystem is mocked in unit tests, values should not be Path instances.
@@ -29,10 +28,13 @@ CACHE_PATH = str(Path("~/.lean/cache").expanduser())
 # The directory in which modules are stored
 MODULES_DIRECTORY = str(Path("~/.lean/modules").expanduser())
 
-# The file in which we send live commands to running docker container
+# The base path of the running docker container to which we send the command file
 COMMANDS_FILE_PATH = Path("/Lean/Launcher/bin/Debug")
 
 # The file in which we send live commands to running docker container
+COMMAND_FILE_BASENAME = "command"
+
+# The file from which we read results of the command sent to the docker container
 COMMAND_RESULT_FILE_BASENAME = "result-command"
 
 # The default name of the file containing the Lean engine configuration

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -29,6 +29,9 @@ CACHE_PATH = str(Path("~/.lean/cache").expanduser())
 # The directory in which modules are stored
 MODULES_DIRECTORY = str(Path("~/.lean/modules").expanduser())
 
+# The file in which we send live commands to running docker container
+COMMANDS_FILE_PATH = Path("/Lean/Launcher/bin/Debug/commands.json")
+
 # The default name of the file containing the Lean engine configuration
 DEFAULT_LEAN_CONFIG_FILE_NAME = "lean.json"
 

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -278,6 +278,10 @@ class QCLiveAlgorithmStatus(str, Enum):
     History = "History"
 
 
+class QCRestResponse(WrappedBaseModel):
+    success: bool
+    error: Optional[List[str]]
+
 class QCMinimalLiveAlgorithm(WrappedBaseModel):
     projectId: int
     deployId: str

--- a/lean/models/click_options.py
+++ b/lean/models/click_options.py
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, List
 import click
 from lean.click import PathParameter
 from lean.models.configuration import Configuration

--- a/lean/models/click_options.py
+++ b/lean/models/click_options.py
@@ -54,7 +54,7 @@ def get_attribute_type(configuration: Configuration):
 
 def get_the_correct_type_default_value(default_lean_config_key: str, default_input_value: str, expected_type: Any,
                                        choices: List[str] = None):
-    from lean.commands.live import _get_default_value
+    from lean.commands.live.deploy import _get_default_value
     lean_value = _get_default_value(default_lean_config_key)
     if lean_value is None and default_input_value is not None:
         lean_value = default_input_value

--- a/scripts/readme.py
+++ b/scripts/readme.py
@@ -27,6 +27,7 @@ from click.testing import CliRunner
 
 from lean.commands import lean
 from lean.models.pydantic import WrappedBaseModel
+from lean.components.util.click_group_default_command import DefaultCommandGroup
 
 
 class NamedCommand(WrappedBaseModel):
@@ -47,6 +48,9 @@ def get_commands(group: Group, parent_names: List[str] = []) -> List[NamedComman
     all_commands = []
 
     for obj in group.commands.values():
+        if isinstance(obj, DefaultCommandGroup):
+            name_parts = parent_names + [group.name, obj.name]
+            all_commands.append(NamedCommand(name=" ".join(name_parts), command=obj))
         if isinstance(obj, Group):
             all_commands.extend(get_commands(obj, parent_names + [group.name]))
         else:

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -1,0 +1,47 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from unittest import mock
+from click.testing import CliRunner
+from dependency_injector import providers
+import lean.models.brokerages.local
+from lean.commands import lean
+from lean.container import container
+from tests.test_helpers import create_fake_lean_cli_directory
+
+def test_cloud_live_stop() -> None:
+    create_fake_lean_cli_directory()
+
+    api_client = mock.Mock()
+    container.api_client.override(providers.Object(api_client))
+
+    cloud_project_manager = mock.Mock()
+    container.cloud_project_manager.override(providers.Object(cloud_project_manager))
+
+    result = CliRunner().invoke(lean, ["cloud", "live", "stop", "Python Project"])
+
+    assert result.exit_code == 0
+
+def test_cloud_live_liquidate() -> None:
+    create_fake_lean_cli_directory()
+
+    api_client = mock.Mock()
+    container.api_client.override(providers.Object(api_client))
+
+    cloud_project_manager = mock.Mock()
+    container.cloud_project_manager.override(providers.Object(cloud_project_manager))
+
+    result = CliRunner().invoke(lean, ["cloud", "live", "liquidate", "Python Project"])
+
+    assert result.exit_code == 0

--- a/tests/commands/live/test_local_live_commands.py
+++ b/tests/commands/live/test_local_live_commands.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 
-
 from unittest import mock
 from click.testing import CliRunner
 from dependency_injector import providers
@@ -20,6 +19,125 @@ import lean.models.brokerages.local
 from lean.commands import lean
 from lean.container import container
 from tests.test_helpers import create_fake_lean_cli_directory
+
+symbol_options = ["--ticker", "aapl", "--market", "usa", "--security-type", "equity"]
+
+def test_local_live_add_security() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "add-security", "Python Project",
+                                        *symbol_options])
+
+    assert result.exit_code == 0
+
+
+def test_local_live_add_security_fails_without_symbol_arguments() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "add-security", "Python Project"])
+
+    assert result.exit_code != 0
+
+
+def test_local_live_cancel_order() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "cancel-order", "Python Project",
+                                            "--order-id", "1"])
+
+    assert result.exit_code == 0
+
+
+def test_local_live_cancel_order_fails_without_order_id() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "cancel-order", "Python Project"])
+
+    assert result.exit_code != 0
+
+
+def test_local_live_liquidate_all_symbols() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "liquidate", "Python Project"])
+
+    assert result.exit_code == 0
+
+
+def test_local_live_liquidate_one_symbol() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "liquidate", "Python Project",
+                                        *symbol_options])
+
+    assert result.exit_code == 0
+
 
 def test_local_live_stop() -> None:
     create_fake_lean_cli_directory()
@@ -39,7 +157,8 @@ def test_local_live_stop() -> None:
 
     assert result.exit_code == 0
 
-def test_local_live_liquidate_all_symbols() -> None:
+
+def test_local_live_submit_order() -> None:
     create_fake_lean_cli_directory()
 
     project_config_manager = mock.MagicMock()
@@ -53,6 +172,66 @@ def test_local_live_liquidate_all_symbols() -> None:
     docker_manager.read_from_file.return_value = {"success": True}
     container.docker_manager.override(providers.Object(docker_manager))
 
-    result = CliRunner().invoke(lean, ["live", "liquidate", "Python Project"])
+    result = CliRunner().invoke(lean, ["live", "submit-order", "Python Project",
+                                        "--order-type", "market", "--quantity", 10,
+                                        *symbol_options])
 
     assert result.exit_code == 0
+
+
+def test_local_live_submit_order_fails_without_order_type_and_quantity() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "submit-order", "Python Project",
+                                        *symbol_options])
+
+    assert result.exit_code != 0
+
+
+def test_local_live_update_order() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "update-order", "Python Project",
+                                            "--order-id", "1"])
+
+    assert result.exit_code == 0
+
+def test_local_live_update_order_fails_without_order_id() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "update-order", "Python Project"])
+
+    assert result.exit_code != 0

--- a/tests/commands/live/test_local_live_commands.py
+++ b/tests/commands/live/test_local_live_commands.py
@@ -1,0 +1,58 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+from unittest import mock
+from click.testing import CliRunner
+from dependency_injector import providers
+import lean.models.brokerages.local
+from lean.commands import lean
+from lean.container import container
+from tests.test_helpers import create_fake_lean_cli_directory
+
+def test_local_live_stop() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "stop", "Python Project"])
+
+    assert result.exit_code == 0
+
+def test_local_live_liquidate_all_symbols() -> None:
+    create_fake_lean_cli_directory()
+
+    project_config_manager = mock.MagicMock()
+    project_config_manager.get_latest_live_directory.return_value = "mock_live_dir"
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    output_config_manager = mock.Mock()
+    container.output_config_manager.override(providers.Object(output_config_manager))
+
+    docker_manager = mock.MagicMock()
+    docker_manager.read_from_file.return_value = {"success": True}
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    result = CliRunner().invoke(lean, ["live", "liquidate", "Python Project"])
+
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds the following:
- support for commands during live local/cloud deployment
- changes `lean live` command to a group of commands `lean live [OPTIONS] COMMAND [ARGS]...`
- changes `lean live` to  `lean live deploy` with backward compatibility
- changes `lean cloud live` command to a group of commands `lean cloud live [OPTIONS] COMMAND [ARGS]...`
- changes `lean cloud live` to  `lean cloud live deploy` with backward compatibility
- adds tests for the new commands

Closes https://github.com/QuantConnect/lean-cli/issues/103, https://github.com/QuantConnect/lean-cli/issues/47