### PR TITLE
Bug fix issue #124 add data provider arg for local live deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,8 @@ Options:
                                   The brokerage to use
   --data-feed [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|FTX|IQFeed|Polygon Data Feed|Custom data only]
                                   The data feed to use
+  --data-provider [Terminal Link|QuantConnect|Local]
+                                  Update the Lean configuration file to retrieve data from the given provider
   --ib-organization TEXT          The name or id of the organization with the Interactive Brokers module subscription
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -815,6 +817,7 @@ Options:
   --iqfeed-productName TEXT       The product name of your IQFeed developer account
   --iqfeed-version TEXT           The product version of your IQFeed developer account
   --polygon-api-key TEXT          Your Polygon data feed API Key
+  --quantconnect-organization TEXT
   --release                       Compile C# projects in release configuration instead of debug
   --image TEXT                    The LEAN engine image to use (defaults to quantconnect/lean:latest)
   --update                        Pull the LEAN engine image before starting live trading

--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Options:
   --iqfeed-version TEXT           The product version of your IQFeed developer account
   --polygon-api-key TEXT          Your Polygon data feed API Key
   --quantconnect-organization TEXT
+                                  The name or id of the organization with the QuantConnect datafeed module subscription
   --release                       Compile C# projects in release configuration instead of debug
   --image TEXT                    The LEAN engine image to use (defaults to quantconnect/lean:latest)
   --update                        Pull the LEAN engine image before starting live trading

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -312,17 +312,17 @@ brokerage_required_options = {
     "Zerodha": {
         "zerodha-api-key": "123",
         "zerodha-access-token": "456",
-        "zerodha-product-type": "MIS",
-        "zerodha-trading-segment": "EQUITY",
-        "zerodha-history-subscription": "no",
+        "zerodha-product-type": "mis",
+        "zerodha-trading-segment": "equity",
+        "zerodha-history-subscription": "false",
         "zerodha-organization": "abc",
     },
     "Samco": {
         "samco-client-id": "123",
         "samco-client-password": "456",
         "samco-year-of-birth": "2000",
-        "samco-product-type": "MIS",
-        "samco-trading-segment": "EQUITY",
+        "samco-product-type": "mis",
+        "samco-trading-segment": "equity",
         "samco-organization": "abc",
     },
     "Atreyu": {

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -383,6 +383,50 @@ data_feed_required_options = {
 }
 
 
+data_providers_required_options = {
+    "QuantConnect": {},
+    "local": {},
+    "Terminal Link": brokerage_required_options["Terminal Link"]
+}
+
+
+@pytest.mark.parametrize("data_provider", data_providers_required_options.keys())
+def test_live_calls_lean_runner_with_data_provider(data_provider: str) -> None:
+    create_fake_lean_cli_directory()
+    create_fake_environment("live-paper", True)
+
+    docker_manager = mock.Mock()
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    lean_runner = mock.Mock()
+    container.lean_runner.override(providers.Object(lean_runner))
+
+    api_client = mock.MagicMock()
+    api_client.organizations.get_all.return_value = [
+        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
+    ]
+    container.api_client.override(providers.Object(api_client))
+
+    options = []
+    for key, value in data_providers_required_options[data_provider].items():
+        options.extend([f"--{key}", value])
+
+    result = CliRunner().invoke(lean, ["live", "CSharp Project", "--environment", "live-paper", 
+                                "--data-provider", data_provider,
+                                *options])
+
+    assert result.exit_code == 0
+
+    lean_runner.run_lean.assert_called_once_with(mock.ANY,
+                                                 "live-paper",
+                                                 Path("CSharp Project/Main.cs").resolve(),
+                                                 mock.ANY,
+                                                 ENGINE_IMAGE,
+                                                 None,
+                                                 False,
+                                                 False)
+
+
 @pytest.mark.parametrize("brokerage", brokerage_required_options.keys() - ["Paper Trading"])
 def test_live_non_interactive_aborts_when_missing_brokerage_options(brokerage: str) -> None:
     create_fake_lean_cli_directory()


### PR DESCRIPTION
This PR address the followings:
- adds a data-provider option for `lean live` command to give user flexibility to choose from available data providers
- add tests for updates

Previously, `lean live` was implicitly using data provider info present in the existing global lean config. Now the user can explicitly mention the data provider when running  `lean live`

Closes https://github.com/QuantConnect/lean-cli/issues/124