### PR TITLE
Bug fix zerodha-history-subscription bckwards compatibility

### DIFF
--- a/lean/models/__init__.py
+++ b/lean/models/__init__.py
@@ -17,7 +17,7 @@ import requests
 from pathlib import Path
 
 json_modules = {}
-file_name = "modules-1.2.json"
+file_name = "modules-1.3.json"
 dirname = os.path.dirname(__file__)
 file_path = os.path.join(dirname, f'../{file_name}')
 

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -19,7 +19,7 @@ from click.testing import CliRunner
 
 from lean.commands import lean
 from tests.test_helpers import create_fake_lean_cli_directory
-
+import time
 
 def _prepare_directories() -> None:
     create_fake_lean_cli_directory()
@@ -30,6 +30,7 @@ def _prepare_directories() -> None:
             output_directory.mkdir(parents=True)
 
             log_file = output_directory / "log.txt"
+            time.sleep(0.001)
             with log_file.open("w+") as file:
                 file.write(f"{project}/{mode}")
 


### PR DESCRIPTION
This PR adds support for backward compatibility for zerodha-history-subscription config value for old projects still having boolen values when now string value is expected. 