### PR TITLE
Add custom json encoder for Decimal object

### DIFF
--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -38,7 +38,7 @@ from lean.constants import SITE_PACKAGES_VOLUME_LIMIT, \
     DOCKER_NETWORK
 from lean.models.docker import DockerImage
 from lean.models.errors import MoreInfoError
-
+from lean.components.util.custom_json_encoder import DecimalEncoder
 
 class DockerManager:
     """The DockerManager contains methods to manage and run Docker images."""
@@ -439,7 +439,7 @@ class DockerManager:
         if docker_container.status != "running":
             raise ValueError(f"Container {docker_container_name} is not running")
             
-        data = json.dumps(data)
+        data = json.dumps(data, cls=DecimalEncoder)
         data = data.replace('"','\\"')
         command = f'docker exec {docker_container_name} bash -c "echo \'{data}\' > {docker_file.as_posix()}"'
         try:

--- a/lean/components/util/custom_json_encoder.py
+++ b/lean/components/util/custom_json_encoder.py
@@ -1,0 +1,22 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from decimal import Decimal
+import json
+
+class DecimalEncoder(json.JSONEncoder):
+  def default(self, obj):
+    if isinstance(obj, Decimal):
+      return str(obj)
+    return json.JSONEncoder.default(self, obj)

--- a/tests/test_custom_json_encoder.py
+++ b/tests/test_custom_json_encoder.py
@@ -1,0 +1,29 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+from decimal import Decimal
+from lean.components.util.custom_json_encoder import DecimalEncoder
+
+def test_custom_json_encoder() -> None:
+
+    data = {
+        "symbol": "AAPL",
+        "market": "usa",
+        "security_type": "equity",
+        "quantity": Decimal("100.1235")
+    }
+
+    assert json.dumps(data, cls=DecimalEncoder) == '{"symbol": "AAPL", "market": "usa", "security_type": "equity", "quantity": "100.1235"}'
+


### PR DESCRIPTION
This PR adds a custom JSON encoder for Decimal objects to help correctly deserialize data with Decimal objects. They are currently being added to support writing data for lean live commands to JSON files.
