### PR TITLE
Install modules when using environment option

### DIFF
--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -31,7 +31,6 @@ from lean.models.json_module import JsonModule
 from lean.commands.live.live import live
 from lean.models.data_providers import all_data_providers
 
-
 _environment_skeleton = {
     "live-mode": True,
     "setup-handler": "QuantConnect.Lean.Engine.Setup.BrokerageSetupHandler",
@@ -67,6 +66,8 @@ def _install_modules(modules: List[LeanConfigConfigurer], user_kwargs: Dict[str,
     :param modules: the modules to check
     """
     for module in modules:
+        if not module._installs:
+            continue
         organization_id = module.get_organzation_id()
         if organization_id is None or organization_id == "":
             [organization_config] = module.get_config_from_type(OrganzationIdConfiguration)

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -89,6 +89,9 @@ class JsonModule(abc.ABC):
             env_config_values = env_config._env_and_values[target_env]
         return env_config_values
 
+    def get_config_from_type(self, config_type: Configuration) -> str:
+        return [copy.copy(config) for config in self._lean_configs if type(config) is config_type]
+
     def get_organzation_id(self) -> str:
         [organization_id] = [
             config._value for config in self._lean_configs if config.is_type_organization_id]

--- a/lean/models/lean_config_configurer.py
+++ b/lean/models/lean_config_configurer.py
@@ -39,7 +39,6 @@ class LeanConfigConfigurer(JsonModule, abc.ABC):
         :param lean_config: the Lean configuration dict to write to
         :param environment_name: the name of the environment to update
         """
-        self.ensure_module_installed()
         for environment_config in self.get_configurations_env_values_from_name(environment_name):
             environment_config_name = environment_config["name"]
             if self.__class__.__name__ == 'DataFeed':
@@ -86,11 +85,11 @@ class LeanConfigConfigurer(JsonModule, abc.ABC):
         container.logger().debug(f"LeanConfigConfigurer.ensure_module_installed(): _save_properties for module {self._id}: {self.get_required_properties()}")
         self._save_properties(lean_config, self.get_required_properties())
 
-    def ensure_module_installed(self) -> None:
+    def ensure_module_installed(self, organization_id: str) -> None:
         if not self._is_module_installed and self._installs:
             container.logger().debug(f"LeanConfigConfigurer.ensure_module_installed(): installing module for module {self._id}: {self._product_id}")
             container.module_manager().install_module(
-                self._product_id, self.get_organzation_id())
+                self._product_id, organization_id)
             self._is_module_installed = True
 
     def _get_default(cls, lean_config: Dict[str, Any], key: str) -> Optional[Any]:

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -75,6 +75,12 @@ def test_live_calls_lean_runner_with_correct_algorithm_file() -> None:
     lean_runner = mock.Mock()
     container.lean_runner.override(providers.Object(lean_runner))
 
+    api_client = mock.MagicMock()
+    api_client.organizations.get_all.return_value = [
+        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
+    ]
+    container.api_client.override(providers.Object(api_client))
+
     result = CliRunner().invoke(lean, ["live", "Python Project", "--environment", "live-paper"])
 
     traceback.print_exception(*result.exc_info)
@@ -134,6 +140,12 @@ def test_live_calls_lean_runner_with_default_output_directory() -> None:
     lean_runner = mock.Mock()
     container.lean_runner.override(providers.Object(lean_runner))
 
+    api_client = mock.MagicMock()
+    api_client.organizations.get_all.return_value = [
+        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
+    ]
+    container.api_client.override(providers.Object(api_client))
+
     result = CliRunner().invoke(lean, ["live", "Python Project", "--environment", "live-paper"])
 
     assert result.exit_code == 0
@@ -155,6 +167,12 @@ def test_live_calls_lean_runner_with_custom_output_directory() -> None:
     lean_runner = mock.Mock()
     container.lean_runner.override(providers.Object(lean_runner))
 
+    api_client = mock.MagicMock()
+    api_client.organizations.get_all.return_value = [
+        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
+    ]
+    container.api_client.override(providers.Object(api_client))
+    
     result = CliRunner().invoke(lean, ["live",
                                        "Python Project",
                                        "--environment", "live-paper",
@@ -179,6 +197,12 @@ def test_live_calls_lean_runner_with_release_mode() -> None:
     lean_runner = mock.Mock()
     container.lean_runner.override(providers.Object(lean_runner))
 
+    api_client = mock.MagicMock()
+    api_client.organizations.get_all.return_value = [
+        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
+    ]
+    container.api_client.override(providers.Object(api_client))
+
     result = CliRunner().invoke(lean, ["live", "CSharp Project", "--environment", "live-paper", "--release"])
 
     assert result.exit_code == 0
@@ -202,6 +226,12 @@ def test_live_calls_lean_runner_with_detach() -> None:
 
     lean_runner = mock.Mock()
     container.lean_runner.override(providers.Object(lean_runner))
+
+    api_client = mock.MagicMock()
+    api_client.organizations.get_all.return_value = [
+        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
+    ]
+    container.api_client.override(providers.Object(api_client))
 
     result = CliRunner().invoke(lean, ["live", "Python Project", "--environment", "live-paper", "--detach"])
 


### PR DESCRIPTION
Currently, modules are missing to be installed using the environment option for `lean live`/`lean live deploy`.

This PR addresses the issue by abstracting the logic of installing modules in one place.

Closes: #128 