### PR TITLE
more verbose invalid credentials message

### DIFF
--- a/lean/commands/login.py
+++ b/lean/commands/login.py
@@ -46,8 +46,8 @@ def login(user_id: Optional[str], api_token: Optional[str]) -> None:
 
     api_client = container.api_client(user_id=user_id, api_token=api_token)
     if not api_client.is_authenticated():
-        raise MoreInfoError("Credentials are invalid",
-                            "https://www.lean.io/docs/lean-cli/initialization/authenticating-accounts#02-Log-In")
+        raise MoreInfoError("Credentials are invalid. Please ensure your computer clock is correct, or try using another terminal, or enter API token manually instead of copy-pasting.",
+                            "https://www.lean.io/docs/v2/lean-cli")
 
     cli_config_manager = container.cli_config_manager()
     cli_config_manager.user_id.set_value(user_id)


### PR DESCRIPTION
There are some known issues in CLI handling of API tokens (example: https://coder.social/QuantConnect/lean-cli/issues/23) and we do not describe these cases anywhere on the website. A more verbose error message would help users avoid onboarding frustration and reduce extra support requests.