### PR TITLE
Add delete project command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A locally-focused workflow (local development, local execution) with the CLI may
 - [`lean create-project`](#lean-create-project)
 - [`lean data download`](#lean-data-download)
 - [`lean data generate`](#lean-data-generate)
+- [`lean delete-project`](#lean-delete-project)
 - [`lean init`](#lean-init)
 - [`lean library add`](#lean-library-add)
 - [`lean library remove`](#lean-library-remove)
@@ -631,6 +632,24 @@ Options:
 ```
 
 _See code: [lean/commands/data/generate.py](lean/commands/data/generate.py)_
+
+### `lean delete-project`
+
+Delete a project locally and in the cloud if it exists.
+
+```
+Usage: lean delete-project [OPTIONS] PROJECT
+
+  Delete a project locally and in the cloud if it exists.
+
+  The project is selected by name or cloud id.
+
+Options:
+  --verbose  Enable debug logging
+  --help     Show this message and exit.
+```
+
+_See code: [lean/commands/delete_project.py](lean/commands/delete_project.py)_
 
 ### `lean init`
 

--- a/lean/commands/__init__.py
+++ b/lean/commands/__init__.py
@@ -19,6 +19,7 @@ from lean.commands.build import build
 from lean.commands.cloud import cloud
 from lean.commands.config import config
 from lean.commands.create_project import create_project
+from lean.commands.delete_project import delete_project
 from lean.commands.data import data
 from lean.commands.init import init
 from lean.commands.library import library
@@ -51,6 +52,7 @@ lean.add_command(logout)
 lean.add_command(whoami)
 lean.add_command(init)
 lean.add_command(create_project)
+lean.add_command(delete_project)
 lean.add_command(backtest)
 lean.add_command(optimize)
 lean.add_command(research)

--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -30,10 +30,17 @@ def pull(project: Optional[str], pull_bootcamp: bool) -> None:
     This command will not delete local files for which there is no counterpart in the cloud.
     """
     # Parse which projects need to be pulled
+    project_id = None
+    if project is not None:
+        try:
+            project_id = int(project)
+        except ValueError:
+            pass
+
     api_client = container.api_client()
     all_projects = api_client.projects.get_all()
     project_manager = container.project_manager()
-    projects_to_pull = project_manager.get_projects_by_name_or_id(all_projects, project)
+    projects_to_pull = project_manager.get_projects_by_name_or_id(all_projects, project_id or project)
 
     if project is None and not pull_bootcamp:
         projects_to_pull = [p for p in projects_to_pull if not p.name.startswith("Boot Camp/")]

--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -29,18 +29,14 @@ def pull(project: Optional[str], pull_bootcamp: bool) -> None:
 
     This command will not delete local files for which there is no counterpart in the cloud.
     """
+    # Parse which projects need to be pulled
     api_client = container.api_client()
     all_projects = api_client.projects.get_all()
+    project_manager = container.project_manager()
+    projects_to_pull = project_manager.get_projects_by_name_or_id(all_projects, project)
 
-    # Parse which projects need to be pulled
-    if project is not None:
-        projects_to_pull = [p for p in all_projects if str(p.projectId) == project or p.name == project]
-        if len(projects_to_pull) == 0:
-            raise RuntimeError("No project with the given name or id exists in the cloud")
-    else:
-        projects_to_pull = all_projects
-        if not pull_bootcamp:
-            projects_to_pull = [p for p in projects_to_pull if not p.name.startswith("Boot Camp/")]
+    if project is None and not pull_bootcamp:
+        projects_to_pull = [p for p in projects_to_pull if not p.name.startswith("Boot Camp/")]
 
     pull_manager = container.pull_manager()
     pull_manager.pull_projects(projects_to_pull)

--- a/lean/commands/delete_project.py
+++ b/lean/commands/delete_project.py
@@ -1,0 +1,37 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import click
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+
+
+@click.command(cls=LeanCommand)
+@click.argument("path", type=PathParameter(exists=True, file_okay=False, dir_okay=True))
+def delete_project(path: Path) -> None:
+    """Delete a project both locally and in the cloud.
+    """
+    # Remove project from cloud
+    project_config = container.project_config_manager().get_project_config(path)
+    cloud_id = project_config.get("cloud-id")
+    if cloud_id is not None:
+        api_client = container.api_client()
+        api_client.projects.delete(cloud_id)
+
+    # Remove project locally
+    project_manager = container.project_manager()
+    project_manager.delete_project(path)
+
+    logger = container.logger()
+    logger.info(f"Successfully deleted project '{path}'")

--- a/lean/commands/delete_project.py
+++ b/lean/commands/delete_project.py
@@ -22,9 +22,9 @@ from lean.container import container
 @click.command(cls=LeanCommand)
 @click.argument("project", type=str)
 def delete_project(project: str) -> None:
-    """Delete a project both locally and in remotely, if there is a counterpart in the cloud.
+    """Delete a project locally and in the cloud if it exists.
 
-    The project is selected by name or id.
+    The project is selected by name or cloud id.
     """
     # Remove project from cloud
     api_client = container.api_client()

--- a/lean/commands/delete_project.py
+++ b/lean/commands/delete_project.py
@@ -20,7 +20,7 @@ from lean.container import container
 @click.command(cls=LeanCommand)
 @click.argument("path", type=PathParameter(exists=True, file_okay=False, dir_okay=True))
 def delete_project(path: Path) -> None:
-    """Delete a project both locally and in the cloud.
+    """Delete a project both locally and in remotely, if there is a counterpart in the cloud.
     """
     # Remove project from cloud
     project_config = container.project_config_manager().get_project_config(path)

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -18,7 +18,7 @@ import site
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import pkg_resources
 
@@ -160,9 +160,29 @@ class ProjectManager:
     def delete_project(self, project_dir: Path) -> None:
         """Deletes a project directory.
 
+        :cloud_projects: all projects fetched from the cloud
         :param project_dir: the directory of the project to delete
         """
         shutil.rmtree(project_dir)
+
+    def get_projects_by_name_or_id(self, cloud_projects: List[QCProject], project: Optional[str]) -> List[QCProject]:
+        """Returns a list of all the projects in the cloud that match the given name or id.
+
+        :param cloud_projects: all projects fetched from the cloud
+        :param project: the name or id of the project
+        """
+        projects = []
+
+        if project is not None:
+            project_path = Path(project).as_posix()
+            projects = [p for p in cloud_projects
+                        if str(p.projectId) == project or Path(p.name).as_posix() == project_path]
+            if len(projects) == 0:
+                raise RuntimeError("No project with the given name or id exists in the cloud")
+        else:
+            projects = cloud_projects
+
+        return projects
 
     def _generate_python_library_projects_config(self) -> None:
         """Generates the required configuration to enable autocomplete on Python library projects."""

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -157,6 +157,13 @@ class ProjectManager:
             self._generate_csproj(project_dir)
             self.generate_rider_config()
 
+    def delete_project(self, project_dir: Path) -> None:
+        """Deletes a project directory.
+
+        :param project_dir: the directory of the project to delete
+        """
+        shutil.rmtree(project_dir)
+
     def _generate_python_library_projects_config(self) -> None:
         """Generates the required configuration to enable autocomplete on Python library projects."""
         try:

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -164,9 +164,6 @@ class ProjectManager:
 
         :param project_dir: the directory of the project to delete
         """
-        if not self._directory_is_project(project_dir):
-            raise RuntimeError(f"Project directory {project_dir} is not a valid Lean project directory")
-
         try:
             shutil.rmtree(project_dir)
         except FileNotFoundError:
@@ -194,30 +191,6 @@ class ProjectManager:
             projects = cloud_projects
 
         return projects
-
-    def _directory_is_project(self, project_dir: Path) -> bool:
-        """Checks if a directory is a project.
-
-        :param project_dir: the directory of the project to check
-        """
-        if not project_dir.exists():
-            return False
-
-        config_file = project_dir / "config.json"
-        if not config_file.exists():
-            return False
-
-        project_language = None
-        with open(config_file) as file:
-            project_language = json.load(file)["algorithm-language"]
-
-        if project_language is None:
-            return False
-
-        if project_language == "Python":
-            return (project_dir / "main.py").exists() and (project_dir / "research.ipynb").exists()
-
-        return (project_dir / "Main.cs").exists() and (project_dir / "research.ipynb").exists()
 
     def _generate_python_library_projects_config(self) -> None:
         """Generates the required configuration to enable autocomplete on Python library projects."""

--- a/tests/commands/test_delete_project.py
+++ b/tests/commands/test_delete_project.py
@@ -11,17 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from pathlib import Path
 from unittest import mock
-from re import sub
 
+import pytest
 from click.testing import CliRunner
 
 from lean.commands import lean
 from lean.components.api.project_client import ProjectClient
-from lean.components.config.storage import Storage
-from tests.test_helpers import create_fake_lean_cli_directory
+from tests.test_helpers import create_fake_lean_cli_directory, create_api_project
 
 
 def assert_project_exists(path: str) -> None:
@@ -37,35 +35,37 @@ def assert_project_does_not_exist(path: str) -> None:
     assert not project_dir.exists()
 
 
-def test_delete_project_deletes_project_directory() -> None:
+def test_delete_project_locally_that_does_not_have_cloud_counterpart() -> None:
     create_fake_lean_cli_directory()
 
     path = "Python Project"
     assert_project_exists(path)
 
-    with mock.patch.object(ProjectClient, 'delete', return_value=None) as mock_delete:
-        result = CliRunner().invoke(lean, ["delete-project", path])
-        assert result.exit_code == 0
-
-    mock_delete.assert_not_called()
-    assert_project_does_not_exist(path)
-
-
-def test_delete_project_deletes_in_cloud_if_cloud_id_is_set() -> None:
-    create_fake_lean_cli_directory()
-
-    project_id = 1
-    path = "Python Project"
-    assert_project_exists(path)
-
-    with mock.patch.object(Storage, 'get', return_value=project_id) as mock_get,\
+    with mock.patch.object(ProjectClient, 'get_all', return_value=[]) as mock_get_all,\
          mock.patch.object(ProjectClient, 'delete', return_value=None) as mock_delete:
         result = CliRunner().invoke(lean, ["delete-project", path])
         assert result.exit_code == 0
 
-    mock_get.assert_called_once_with("cloud-id")
-    mock_delete.assert_called_once_with(project_id)
+    mock_get_all.assert_called_once()
+    mock_delete.assert_not_called()
     assert_project_does_not_exist(path)
+
+
+@pytest.mark.parametrize("name_or_id", ["Python Project", "1"])
+def test_delete_project_deletes_in_cloud(name_or_id: str) -> None:
+    create_fake_lean_cli_directory()
+
+    cloud_project = create_api_project(1, "Python Project")
+    assert_project_exists(cloud_project.name)
+
+    with mock.patch.object(ProjectClient, 'get_all', return_value=[cloud_project]) as mock_get_all,\
+         mock.patch.object(ProjectClient, 'delete', return_value=None) as mock_delete:
+        result = CliRunner().invoke(lean, ["delete-project", name_or_id])
+        assert result.exit_code == 0
+
+    mock_get_all.assert_called_once()
+    mock_delete.assert_called_once_with(cloud_project.projectId)
+    assert_project_does_not_exist(cloud_project.name)
 
 
 def test_delete_project_aborts_when_path_does_not_exist() -> None:
@@ -73,6 +73,12 @@ def test_delete_project_aborts_when_path_does_not_exist() -> None:
 
     path = "Non Existing Project"
     assert_project_does_not_exist(path)
-    result = CliRunner().invoke(lean, ["delete-project", path])
 
-    assert result.exit_code != 0
+    with mock.patch.object(ProjectClient, 'get_all', return_value=[]) as mock_get_all,\
+         mock.patch.object(ProjectClient, 'delete', return_value=None) as mock_delete:
+        result = CliRunner().invoke(lean, ["delete-project", path])
+        assert result.exit_code != 0
+
+    mock_get_all.assert_called_once()
+    mock_delete.assert_not_called()
+    assert_project_does_not_exist(path)

--- a/tests/commands/test_delete_project.py
+++ b/tests/commands/test_delete_project.py
@@ -98,21 +98,6 @@ def test_delete_project_aborts_when_path_does_not_exist() -> None:
     mock_delete.assert_not_called()
 
 
-def test_delete_project_aborts_when_path_is_no_a_valid_project() -> None:
-    create_fake_lean_cli_directory()
-
-    path = "Non Existing Project"
-    assert_project_does_not_exist(path)
-
-    with mock.patch.object(ProjectClient, 'get_all', return_value=create_cloud_projects()) as mock_get_all,\
-         mock.patch.object(ProjectClient, 'delete', return_value=None) as mock_delete:
-        result = CliRunner().invoke(lean, ["delete-project", path])
-        assert result.exit_code != 0
-
-    mock_get_all.assert_called_once()
-    mock_delete.assert_not_called()
-
-
 def test_delete_project_by_id_aborts_when_not_found_in_cloud() -> None:
     create_fake_lean_cli_directory()
 

--- a/tests/commands/test_delete_project.py
+++ b/tests/commands/test_delete_project.py
@@ -1,0 +1,60 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from re import sub
+
+from click.testing import CliRunner
+
+from lean.commands import lean
+from tests.test_helpers import create_fake_lean_cli_directory
+
+
+def assert_project_exists(path: str) -> None:
+    project_dir = (Path.cwd() / path)
+
+    assert project_dir.exists()
+    assert (project_dir / "main.py").exists()
+    assert (project_dir / "research.ipynb").exists()
+
+    class_name = ''.join(sub(r"([_\-])+", " ", path).title().replace(" ", ""))
+
+    with open(project_dir / "main.py") as file:
+        if path.startswith("Library/"):
+            assert f"class {class_name}" in file.read()
+        else:
+            assert f"class {class_name}(QCAlgorithm)" in file.read()
+
+    with open(project_dir / "research.ipynb") as file:
+        assert json.load(file)["metadata"]["kernelspec"]["language"] == "python"
+
+    with open(project_dir / "config.json") as file:
+        assert json.load(file)["algorithm-language"] == "Python"
+
+
+def assert_project_does_not_exist(path: str) -> None:
+    project_dir = (Path.cwd() / path)
+    assert not project_dir.exists()
+
+
+def test_delete_project_deletes_project_directory() -> None:
+    create_fake_lean_cli_directory()
+
+    path = "Python Project"
+    assert_project_exists(path)
+    result = CliRunner().invoke(lean, ["delete-project", path])
+
+    assert result.exit_code == 0
+
+    assert_project_does_not_exist(path)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -32,13 +32,13 @@ def create_fake_lean_cli_directory() -> None:
     "data-folder": "data"
 }
         """,
-        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$NAME$", "PythonProject"),
+        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonProject"),
         (Path.cwd() / "Python Project" / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
         (Path.cwd() / "Python Project" / "config.json"): json.dumps({
             "algorithm-language": "Python",
             "parameters": {}
         }),
-        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$NAME$", "CSharpProject"),
+        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$CLASS_NAME$", "CSharpProject"),
         (Path.cwd() / "CSharp Project" / "research.ipynb"): DEFAULT_CSHARP_NOTEBOOK,
         (Path.cwd() / "CSharp Project" / "config.json"): json.dumps({
             "algorithm-language": "CSharp",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -32,13 +32,13 @@ def create_fake_lean_cli_directory() -> None:
     "data-folder": "data"
 }
         """,
-        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonProject"),
+        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$NAME$", "PythonProject"),
         (Path.cwd() / "Python Project" / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
         (Path.cwd() / "Python Project" / "config.json"): json.dumps({
             "algorithm-language": "Python",
             "parameters": {}
         }),
-        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$CLASS_NAME$", "CSharpProject"),
+        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$NAME$", "CSharpProject"),
         (Path.cwd() / "CSharp Project" / "research.ipynb"): DEFAULT_CSHARP_NOTEBOOK,
         (Path.cwd() / "CSharp Project" / "config.json"): json.dumps({
             "algorithm-language": "CSharp",


### PR DESCRIPTION
Add a new command `delete-project` to delete entire projects both locally and from the cloud, if the project has already been pushed.