### PR TITLE
Add organization ID option to `cloud push` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,9 +429,11 @@ Usage: lean cloud push [OPTIONS]
   This command will delete cloud files which don't have a local counterpart.
 
 Options:
-  --project DIRECTORY  Path to the local project to push (all local projects if not specified)
-  --verbose            Enable debug logging
-  --help               Show this message and exit.
+  --project DIRECTORY     Path to the local project to push (all local projects if not specified)
+  --organization-id TEXT  ID of the organization where the project will be created in. This is ignored if the project
+                          has already been created in the cloud
+  --verbose               Enable debug logging
+  --help                  Show this message and exit.
 ```
 
 _See code: [lean/commands/cloud/push.py](lean/commands/cloud/push.py)_

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -25,7 +25,11 @@ from lean.container import container
 @click.option("--project",
               type=PathParameter(exists=True, file_okay=False, dir_okay=True),
               help="Path to the local project to push (all local projects if not specified)")
-def push(project: Optional[Path]) -> None:
+@click.option("--organization-id",
+              type=str,
+              help="ID of the organization where the project will be created in. This is ignored if the project has "
+                   "already been created in the cloud")
+def push(project: Optional[Path], organization_id: Optional[str]) -> None:
     """Push local projects to QuantConnect.
 
     This command overrides the content of cloud files with the content of their respective local counterparts.
@@ -43,4 +47,4 @@ def push(project: Optional[Path]) -> None:
         projects_to_push = [p.parent for p in Path.cwd().rglob(PROJECT_CONFIG_FILE_NAME)]
 
     push_manager = container.push_manager()
-    push_manager.push_projects(projects_to_push)
+    push_manager.push_projects(projects_to_push, organization_id)

--- a/lean/components/api/project_client.py
+++ b/lean/components/api/project_client.py
@@ -47,17 +47,21 @@ class ProjectClient:
         data = self._api.get("projects/read")
         return [self._process_project(QCProject(**project)) for project in data["projects"]]
 
-    def create(self, name: str, language: QCLanguage) -> QCCreatedProject:
+    def create(self, name: str, language: QCLanguage, organization_id: Optional[str]) -> QCCreatedProject:
         """Creates a new project.
 
         :param name: the name of the project to create
         :param language: the language of the project to create
+        :param organization_id: the id of the organization to create the project in
         :return: the created project
         """
-        data = self._api.post("projects/create", {
+        parameters = {
             "name": name,
             "language": language.value
-        })
+        }
+        if organization_id is not None:
+            parameters["organizationId"] = organization_id
+        data = self._api.post("projects/create", parameters)
 
         return self._process_project(QCCreatedProject(**data["projects"][0]))
 


### PR DESCRIPTION
Add `organization-id` option to the `cloud push` command in order to allow creating projects in specific organizations instead of doing it only in the one marked as "preferred".

The option is ignored on project update.