### PR TITLE
Telegram notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Options:
   --notify-webhooks TEXT          A comma-separated list of 'url:HEADER_1=VALUE_1:HEADER_2=VALUE_2:etc' pairs
                                   configuring webhook-notifications
   --notify-sms TEXT               A comma-separated list of phone numbers configuring SMS-notifications
+  --notify-telegram TEXT          A comma-separated list of 'user/group Id:token(optional)' pairs configuring telegram-
+                                  notifications
   --push                          Push local modifications to the cloud before starting live trading
   --open                          Automatically open the live results in the browser once the deployment starts
   --verbose                       Enable debug logging

--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -274,7 +274,7 @@ def deploy(project: str,
         if notify_telegram is not None:
             for config in notify_telegram.split(","):
                 id_token_pair = config.split(":", 1)    # telegram token is like "01234567:Abc132xxx..."
-                if len(config.split(":", 1)) == 2:
+                if len(id_token_pair) == 2:
                     chat_id, token = id_token_pair
                     token = None if not token else token
                     notify_methods.append(QCTelegramNotificationMethod(id=chat_id, token=token))

--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -81,7 +81,7 @@ def _prompt_notification_method() -> QCNotificationMethod:
 
         return QCWebhookNotificationMethod(address=address, headers=headers)
     elif selected_method == "telegram":
-        id = click.prompt("User Id/Group Id")
+        chat_id = click.prompt("User Id/Group Id")
 
         custom_bot = click.confirm("Is a custom bot being used?", default=False)
         if custom_bot:
@@ -89,7 +89,7 @@ def _prompt_notification_method() -> QCNotificationMethod:
         else:
             token = None
 
-        return QCTelegramNotificationMethod(id=id, token=token)
+        return QCTelegramNotificationMethod(id=chat_id, token=token)
     else:
         phone_number = click.prompt("Phone number")
         return QCSMSNotificationMethod(phoneNumber=phone_number)
@@ -273,9 +273,13 @@ def deploy(project: str,
 
         if notify_telegram is not None:
             for config in notify_telegram.split(","):
-                id, token = config.split(":", 1)    # telegram token is like "01234567:Abc132xxx..."
-                token = None if not token else token
-                notify_methods.append(QCTelegramNotificationMethod(id=id, token=token))
+                id_token_pair = config.split(":", 1)    # telegram token is like "01234567:Abc132xxx..."
+                if len(config.split(":", 1)) == 2:
+                    chat_id, token = id_token_pair
+                    token = None if not token else token
+                    notify_methods.append(QCTelegramNotificationMethod(id=chat_id, token=token))
+                else:
+                    notify_methods.append(QCTelegramNotificationMethod(id=id_token_pair[0]))
     else:
         brokerage_instance = _configure_brokerage(logger)
         live_node = _configure_live_node(logger, api_client, cloud_project)

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -97,7 +97,7 @@ class LiveClient:
 
             parameters["notification"] = {
                 "events": events,
-                "targets": [method.dict() for method in notify_methods]
+                "targets": [{x: y for x, y in method.dict().items() if y} for method in notify_methods]
             }
 
         data = self._api.post("live/create", parameters)

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -320,7 +320,12 @@ class QCSMSNotificationMethod(WrappedBaseModel):
     phoneNumber: str
 
 
-QCNotificationMethod = Union[QCEmailNotificationMethod, QCWebhookNotificationMethod, QCSMSNotificationMethod]
+class QCTelegramNotificationMethod(WrappedBaseModel):
+    id: str
+    token: Optional[str] = None
+
+
+QCNotificationMethod = Union[QCEmailNotificationMethod, QCWebhookNotificationMethod, QCSMSNotificationMethod, QCTelegramNotificationMethod]
 
 
 class QCCard(WrappedBaseModel):

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -15,10 +15,12 @@
 from unittest import mock
 from click.testing import CliRunner
 from dependency_injector import providers
+import pytest
 import lean.models.brokerages.local
 from lean.commands import lean
 from lean.container import container
-from tests.test_helpers import create_fake_lean_cli_directory
+from lean.models.api import QCEmailNotificationMethod, QCWebhookNotificationMethod, QCSMSNotificationMethod, QCTelegramNotificationMethod
+from tests.test_helpers import create_fake_lean_cli_directory, create_qc_nodes
 
 def test_cloud_live_stop() -> None:
     create_fake_lean_cli_directory()
@@ -45,3 +47,93 @@ def test_cloud_live_liquidate() -> None:
     result = CliRunner().invoke(lean, ["cloud", "live", "liquidate", "Python Project"])
 
     assert result.exit_code == 0
+
+def test_cloud_live_deploy() -> None:
+    create_fake_lean_cli_directory()
+
+    api_client = mock.Mock()
+    api_client.nodes.get_all.return_value = create_qc_nodes()
+    container.api_client.override(providers.Object(api_client))
+
+    cloud_project_manager = mock.Mock()
+    container.cloud_project_manager.override(providers.Object(cloud_project_manager))
+
+    cloud_runner = mock.Mock()
+    container.cloud_runner.override(providers.Object(cloud_runner))
+        
+    result = CliRunner().invoke(lean, ["cloud", "live", "Python Project", "--brokerage", "Paper Trading", "--node", "live", 
+                                       "--auto-restart", "yes", "--notify-order-events", "no", "--notify-insights", "no"])
+    
+    assert result.exit_code == 0
+    
+    api_client.live.start.assert_called_once_with(mock.ANY,
+                                                  mock.ANY,
+                                                  "3",
+                                                  mock.ANY,
+                                                  mock.ANY,
+                                                  True,
+                                                  mock.ANY,
+                                                  False,
+                                                  False,
+                                                  [])
+
+@pytest.mark.parametrize("notice_method,config", [("emails", "customAddress:customSubject"),
+                                             ("webhooks", "customAddress:header1=value1"),
+                                             ("webhooks", "customAddress:header1=value1:header2=value2"),
+                                             ("sms", "customNumber"),
+                                             ("telegram", "customId:"),
+                                             ("telegram", "customId:custom:token")])
+def test_cloud_live_deploy_with_notifications(notice_method: str, config: str) -> None:
+    create_fake_lean_cli_directory()
+
+    api_client = mock.Mock()
+    api_client.nodes.get_all.return_value = create_qc_nodes()
+    container.api_client.override(providers.Object(api_client))
+
+    cloud_project_manager = mock.Mock()
+    container.cloud_project_manager.override(providers.Object(cloud_project_manager))
+
+    cloud_runner = mock.Mock()
+    container.cloud_runner.override(providers.Object(cloud_runner))
+        
+    result = CliRunner().invoke(lean, ["cloud", "live", "Python Project", "--brokerage", "Paper Trading", "--node", "live", 
+                                       "--auto-restart", "yes", "--notify-order-events", "yes", "--notify-insights", "yes",
+                                       f"--notify-{notice_method}", config])
+    
+    assert result.exit_code == 0
+    
+    if notice_method == "emails":
+        address, subject = config.split(":")
+        notification = QCEmailNotificationMethod(address=address, subject=subject)
+        
+    elif notice_method == "webhooks":
+        address, headers = config.split(":", 1)
+        headers_dict = {}
+        
+        for header in headers.split(":"):
+            key, value = header.split("=")
+            headers_dict[key] = value
+                
+        notification = QCWebhookNotificationMethod(address=address, headers=headers_dict)
+        
+    elif notice_method == "sms":
+        notification = QCSMSNotificationMethod(phoneNumber=config)
+        
+    else:
+        id, token = config.split(":", 1)
+        
+        if not token:
+            notification = QCTelegramNotificationMethod(id=id)
+        else:
+            notification = QCTelegramNotificationMethod(id=id, token=token)
+    
+    api_client.live.start.assert_called_once_with(mock.ANY,
+                                                  mock.ANY,
+                                                  "3",
+                                                  mock.ANY,
+                                                  mock.ANY,
+                                                  True,
+                                                  mock.ANY,
+                                                  True,
+                                                  True,
+                                                  [notification])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from lean.commands.create_project import (DEFAULT_CSHARP_MAIN, DEFAULT_CSHARP_NOTEBOOK, DEFAULT_PYTHON_MAIN,
                                           DEFAULT_PYTHON_NOTEBOOK)
 from lean.models.api import QCLanguage, QCLiveResults, QCProject, QCFullOrganization, \
-    QCOrganizationData, QCOrganizationCredit
+    QCOrganizationData, QCOrganizationCredit, QCNode, QCNodeList, QCNodePrice
 
 
 def create_fake_lean_cli_directory() -> None:
@@ -94,3 +94,50 @@ def create_api_organization() -> QCFullOrganization:
                               products=[],
                               data=QCOrganizationData(signedTime=None, current=False),
                               members=[])
+
+
+def create_qc_nodes() -> QCNodeList:
+    backtest = [QCNode(
+        id="1",
+        name="backtest",
+        sku="backtest_test",
+        busy=False,
+        projectName="Python Project",
+        description="test node",
+        usedBy="Python Project",
+        price=QCNodePrice(monthly=1, yearly=2),
+        speed=0.1,
+        cpu=1,
+        ram=0.2,
+        assets=1
+    )]
+    research = [QCNode(
+        id="2",
+        name="research",
+        sku="research_test",
+        busy=False,
+        projectName="Python Project",
+        description="test node",
+        usedBy="Python Project",
+        price=QCNodePrice(monthly=1, yearly=2),
+        speed=0.1,
+        cpu=1,
+        ram=0.2,
+        assets=2
+    )]
+    live = [QCNode(
+        id="3",
+        name="live",
+        sku="live_test",
+        busy=False,
+        projectName="Python Project",
+        description="test node",
+        usedBy="Python Project",
+        price=QCNodePrice(monthly=1, yearly=2),
+        speed=0.1,
+        cpu=1,
+        ram=0.2,
+        assets=3
+    )]
+    
+    return QCNodeList(backtest=backtest, research=research, live=live)


### PR DESCRIPTION
- Add `--notify-telegram` as a `lean cloud live "<PROJECT>"` command option
- Add telegram notification method in the interactive selection menu for `lean cloud live "<PROJECT>"`
- Add unit tests to cover `lean cloud live deploy` with/without notifications

closes #137 