### PR TITLE
Feature add organization-id in project config.json

### DIFF
--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -84,6 +84,7 @@ class PullManager:
         project_config.set("algorithm-language", project.language.name)
         project_config.set("parameters", {parameter.key: parameter.value for parameter in project.parameters})
         project_config.set("description", project.description)
+        project_config.set("organization-id", project.organizationId)
 
     def _pull_files(self, project: QCProject, local_project_path: Path) -> None:
         """Pull the files of a single project.

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -99,6 +99,9 @@ class PushManager:
             # We need to retrieve the created project again to get all project details
             cloud_project = self._api_client.projects.get(new_project.projectId)
 
+            # set organization-id in project config
+            project_config.set("organization-id", cloud_project.organizationId)
+
         # Push local files to cloud
         self._push_files(project, cloud_project)
 

--- a/tests/commands/cloud/test_push.py
+++ b/tests/commands/cloud/test_push.py
@@ -56,7 +56,6 @@ def test_cloud_push_pushes_single_project_when_project_option_given() -> None:
 
     push_manager.push_projects.assert_called_once_with([Path.cwd() / "Python Project"], None)
 
-
 def test_cloud_push_aborts_when_given_directory_is_not_lean_project() -> None:
     create_fake_lean_cli_directory()
 
@@ -138,3 +137,37 @@ def test_cloud_push_creates_project_with_optional_organization_id(organization_i
 
     mock_get_all_projects.assert_called_once()
     mock_create_project.assert_called_once_with(path, QCLanguage.Python, organization_id)
+
+def test_cloud_push_updates_lean_config() -> None:
+
+    create_fake_lean_cli_directory()
+
+    def my_side_effect(*args, **kwargs):
+        return "Python"
+
+    api_client = mock.Mock()
+    api_client = api_client.projects.create = mock.MagicMock(return_value=create_api_project(1, "Python Project"))
+    fake_cloud_files = [QCFullFile(name="removed_file.py", content="", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+    api_client.files.delete = mock.Mock()
+
+    api_client.projects.get_all = mock.MagicMock(return_value=[])
+    api_client.projects.get = mock.MagicMock(return_value=create_api_project(1, "Python Project"))
+
+    project_config = mock.Mock()
+    project_config.get = mock.MagicMock(side_effect=my_side_effect)
+
+    project_config_manager = mock.Mock()
+    project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
+
+    project_manager = mock.Mock()
+    project_manager.get_source_files = mock.MagicMock(return_value=[])
+
+    push_manager = PushManager(mock.Mock(), api_client, project_manager, project_config_manager)
+    container.push_manager.override(providers.Object(push_manager))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Python Project"])
+
+    assert result.exit_code == 0
+
+    project_config.set.assert_called_with("organization-id", "123")


### PR DESCRIPTION
This PR adds support to set `organization-id` value in config.json of the project when pulling and pushing projects to the cloud.

This was tested by running lean cloud push & lean cloud pull and validating the results. Relevant tests have also been added.