### PR TITLE
Add default value to `PushManager.push_projects()` `organization_id` parameter

### DIFF
--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -43,7 +43,7 @@ class PushManager:
         self._project_config_manager = project_config_manager
         self._last_file = None
 
-    def push_projects(self, projects_to_push: List[Path], organization_id: Optional[str]) -> None:
+    def push_projects(self, projects_to_push: List[Path], organization_id: Optional[str] = None) -> None:
         """Pushes the given projects from the local drive to the cloud.
 
         :param projects_to_push: a list of directories containing the local projects that need to be pushed

--- a/tests/components/cloud/test_cloud_project_manager.py
+++ b/tests/components/cloud/test_cloud_project_manager.py
@@ -1,0 +1,44 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from unittest import mock
+
+from dependency_injector import providers
+
+from lean.container import container
+from lean.models.api import QCBacktest, QCMinimalFile
+from tests.test_helpers import create_api_project, create_fake_lean_cli_directory
+
+
+def test_get_cloud_project_pushing_new_project():
+    create_fake_lean_cli_directory()
+
+    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, 11)]
+    cloud_project = create_api_project(20, "Python Project")
+
+    api_client = mock.Mock()
+    api_client.projects.get_all.return_value = cloud_projects
+    api_client.projects.get.return_value = cloud_project
+    api_client.projects.create.return_value = cloud_project
+    api_client.files.get_all.return_value = []
+    api_client.files.create.return_value = QCMinimalFile(name="file.py", content="", modified=datetime.now())
+    container.api_client.override(providers.Object(api_client))
+
+    cloud_project_manager = container.cloud_project_manager()
+    created_cloud_project = cloud_project_manager.get_cloud_project("Python Project", push=True)
+
+    assert created_cloud_project == cloud_project
+
+    api_client.projects.get_all.assert_called_once()
+    api_client.projects.get.assert_called_with(cloud_project.projectId)


### PR DESCRIPTION
Add default value to `PushManager.push_projects()` `organization_id` parameter so that wherever `push_projects()` is called, they don't mind the `organization_id` parameter if not required, so this way we avoid "missing required positional argument" errors.