### PR TITLE
Library projects for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,11 +681,13 @@ Usage: lean library add [OPTIONS] PROJECT NAME
 
   PROJECT must be the path to the project.
 
-  NAME must be the name of a NuGet package (for C# projects) or of a PyPI package (for Python projects).
+  NAME must be either the name of a NuGet package (for C# projects), a PyPI package (for Python projects), or a path to
+  a Lean CLI library.
 
-  If --version is not given, the package is pinned to the latest compatible version. For C# projects, this is the latest
-  available version. For Python projects, this is the latest version compatible with Python 3.8 (which is what the
-  Docker images use).
+  If --version is not given, and the library is a NuGet or PyPI package the package, it is pinned to the latest
+  compatible version. For C# projects, this is the latest available version. For Python projects, this is the latest
+  version compatible with Python 3.8 (which is what the Docker images use). For Lean CLI library projects, this is
+  ignored.
 
   Custom C# libraries are added to your project's .csproj file, which is then restored if dotnet is on your PATH and the
   --no-local flag has not been given.
@@ -696,10 +698,12 @@ Usage: lean library add [OPTIONS] PROJECT NAME
   C# example usage:
   $ lean library add "My CSharp Project" Microsoft.ML
   $ lean library add "My CSharp Project" Microsoft.ML --version 1.5.5
+  $ lean library add "My CSharp Project" "Library/My CSharp Library"
 
   Python example usage:
   $ lean library add "My Python Project" tensorflow
   $ lean library add "My Python Project" tensorflow --version 2.5.0
+  $ lean library add "My Python Project" "Library/My Python Library"
 
 Options:
   --version TEXT  The version of the library to add (defaults to latest compatible version)
@@ -721,7 +725,8 @@ Usage: lean library remove [OPTIONS] PROJECT NAME
 
   PROJECT must be the path to the project directory.
 
-  NAME must be the name of the NuGet package (for C# projects) or of the PyPI package (for Python projects) to remove.
+  NAME must be either the name of the NuGet package (for C# projects), the PyPI package (for Python projects), or the
+  path to the Lean CLI library to remove.
 
   Custom C# libraries are removed from the project's .csproj file, which is then restored if dotnet is on your PATH and
   the --no-local flag has not been given.

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -359,16 +359,6 @@ def backtest(project: Path,
     if python_venv is not None and python_venv != "":
         lean_config["python-venv"] = f'{"/" if python_venv[0] != "/" else ""}{python_venv}'
 
-    # Add libraries paths to python project
-    project_language = project_config.get("algorithm-language", None)
-    if project_language == "Python":
-        library_references = project_config.get("libraries", [])
-        python_paths = lean_config.get("python-additional-paths", [])
-        python_paths.extend([(Path("/") / library["path"]).as_posix() for library in library_references])
-        if len(python_paths) > 0:
-            python_paths.append("/Library")
-        lean_config["python-additional-paths"] = python_paths
-
     lean_runner = container.lean_runner()
     lean_runner.run_lean(lean_config,
                          "backtesting",

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -365,6 +365,8 @@ def backtest(project: Path,
         library_references = project_config.get("libraries", [])
         python_paths = lean_config.get("python-additional-paths", [])
         python_paths.extend([(Path("/") / library["path"]).as_posix() for library in library_references])
+        if len(python_paths) > 0:
+            python_paths.append("/Library")
         lean_config["python-additional-paths"] = python_paths
 
     lean_runner = container.lean_runner()

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -355,10 +355,18 @@ def backtest(project: Path,
     # Set backtest name
     if backtest_name is not None and backtest_name != "":
         lean_config["backtest-name"] = backtest_name
-        
+
     if python_venv is not None and python_venv != "":
         lean_config["python-venv"] = f'{"/" if python_venv[0] != "/" else ""}{python_venv}'
-    
+
+    # Add libraries paths to python project
+    project_language = project_config.get("algorithm-language", None)
+    if project_language == "Python":
+        library_references = project_config.get("libraries", [])
+        python_paths = lean_config.get("python-additional-paths", [])
+        python_paths.extend([(Path("/") / library["path"]).as_posix() for library in library_references])
+        lean_config["python-additional-paths"] = python_paths
+
     lean_runner = container.lean_runner()
     lean_runner.run_lean(lean_config,
                          "backtesting",

--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -11,12 +11,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from pathlib import Path
+from typing import Optional, List
 
 import click
 
 from lean.click import LeanCommand
 from lean.container import container
+from lean.models.api import QCProject
+from lean.models.utils import LeanLibraryReference
+
+
+def _add_local_library_references_to_project(project: QCProject, cloud_libraries: List[QCProject]) -> None:
+    logger = container.logger()
+    library_manager = container.library_manager()
+
+    if len(cloud_libraries) > 0:
+        logger.info(f"Adding/updating local library references to project {project.name}")
+
+    cwd = Path.cwd()
+    project_dir = cwd / project.name
+    for i, library in enumerate(cloud_libraries, start=1):
+        logger.info(f"[{i}/{len(cloud_libraries)}] "
+                    f"Adding/updating local library {library.name} reference to project {project.name}")
+        # TODO: no_local flag??
+        library_manager.add_lean_library_to_project(project_dir, cwd / library.name, False)
+
+
+def _remove_local_library_references_from_project(project: QCProject, cloud_libraries: List[QCProject]) -> None:
+    logger = container.logger()
+    library_manager = container.library_manager()
+
+    project_dir = Path.cwd() / project.name
+    project_config = container.project_config_manager().get_project_config(project_dir)
+    local_libraries = project_config.get("libraries", [])
+    cloud_library_paths = [Path(library.name) for library in cloud_libraries]
+    libraries_to_remove = [LeanLibraryReference(**library_reference)
+                           for library_reference in local_libraries
+                           if Path(library_reference["path"]) not in cloud_library_paths]
+
+    if len(libraries_to_remove) > 0:
+        logger.info(f"Removing local library references from project {project.name}")
+
+    for i, library_reference in enumerate(libraries_to_remove, start=1):
+        logger.info(f"[{i}/{len(libraries_to_remove)}] "
+                    f"Removing local library {library_reference.name} reference from project {project.name}")
+        # TODO: no_local flag??
+        library_manager.remove_lean_library_from_project(project_dir, Path.cwd() / library_reference.path, False)
+
+
+def _update_local_library_references(projects: List[QCProject]) -> None:
+    for project in projects:
+        cloud_libraries = [library
+                           for library_id in project.libraries
+                           for library in projects if library.projectId == library_id]
+
+        # Add cloud library references to local config
+        _add_local_library_references_to_project(project, cloud_libraries)
+
+        # Remove library references locally if they were removed in the cloud
+        _remove_local_library_references_from_project(project, cloud_libraries)
 
 
 @click.command(cls=LeanCommand)
@@ -47,3 +101,5 @@ def pull(project: Optional[str], pull_bootcamp: bool) -> None:
 
     pull_manager = container.pull_manager()
     pull_manager.pull_projects(projects_to_pull)
+
+    _update_local_library_references(projects_to_pull)

--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -34,7 +34,6 @@ def _add_local_library_references_to_project(project: QCProject, cloud_libraries
     for i, library in enumerate(cloud_libraries, start=1):
         logger.info(f"[{i}/{len(cloud_libraries)}] "
                     f"Adding/updating local library {library.name} reference to project {project.name}")
-        # TODO: no_local flag??
         library_manager.add_lean_library_to_project(project_dir, cwd / library.name, False)
 
 
@@ -56,7 +55,6 @@ def _remove_local_library_references_from_project(project: QCProject, cloud_libr
     for i, library_reference in enumerate(libraries_to_remove, start=1):
         logger.info(f"[{i}/{len(libraries_to_remove)}] "
                     f"Removing local library {library_reference.name} reference from project {project.name}")
-        # TODO: no_local flag??
         library_manager.remove_lean_library_from_project(project_dir, Path.cwd() / library_reference.path, False)
 
 

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -12,13 +12,92 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 import click
 
 from lean.click import LeanCommand, PathParameter
 from lean.constants import PROJECT_CONFIG_FILE_NAME
 from lean.container import container
+from lean.models.api import QCProject
+from lean.models.utils import LeanLibraryReference
+
+
+def _get_cloud_project(project: Path, cloud_projects: List[QCProject]) -> QCProject:
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+    project_relative_path = project.relative_to(lean_cli_root_dir)
+    cloud_project = [cloud_project for cloud_project in cloud_projects
+                     if Path(cloud_project.name) == project_relative_path][0]
+
+    return cloud_project
+
+
+def _get_local_libraries_cloud_ids(project_dir: Path) -> List[int]:
+    project_config_manager = container.project_config_manager()
+    project_config = project_config_manager.get_project_config(project_dir)
+
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+
+    libraries_in_config = project_config.get("libraries", [])
+    library_paths = [lean_cli_root_dir / LeanLibraryReference(**library).path for library in libraries_in_config]
+
+    local_libraries_cloud_ids = [int(project_config_manager.get_project_config(path).get("cloud-id", None))
+                                 for path in library_paths]
+
+    return local_libraries_cloud_ids
+
+
+def _get_library_name(library_cloud_id: int, cloud_projects: List[QCProject]) -> str:
+    return [project.name for project in cloud_projects if project.projectId == library_cloud_id][0]
+
+
+def _add_new_libraries(project: QCProject,
+                       local_libraries_cloud_ids: List[int],
+                       cloud_projects: List[QCProject]) -> None:
+    logger = container.logger()
+    api_client = container.api_client()
+    libraries_to_add = [library_id for library_id in local_libraries_cloud_ids if library_id not in project.libraries]
+
+    if len(libraries_to_add) > 0:
+        logger.info(f"Adding libraries to project {project.name} in the cloud")
+
+    for i, library_cloud_id in enumerate(libraries_to_add, start=1):
+        library_name = _get_library_name(library_cloud_id, cloud_projects)
+        logger.info(f"[{i}/{len(libraries_to_add)}] "
+                    f"Adding library {library_name} to project {project.name} in the cloud")
+        api_client.projects.add_library(project.projectId, library_cloud_id)
+
+
+def _remove_outdated_libraries(project: QCProject,
+                               local_libraries_cloud_ids: List[int],
+                               cloud_projects: List[QCProject]) -> None:
+    logger = container.logger()
+    api_client = container.api_client()
+    libraries_to_remove = [library_id for library_id in project.libraries
+                           if library_id not in local_libraries_cloud_ids]
+
+    if len(libraries_to_remove) > 0:
+        logger.info(f"Removing libraries from project {project.name} in the cloud")
+
+    for i, library_cloud_id in enumerate(libraries_to_remove, start=1):
+        library_name = _get_library_name(library_cloud_id, cloud_projects)
+        logger.info(f"[{i}/{len(libraries_to_remove)}] "
+                    f"Removing library {library_name} from project {project.name} in the cloud")
+        api_client.projects.delete_library(project.projectId, library_cloud_id)
+
+
+def _update_cloud_library_references(projects: List[Path]) -> None:
+    api_client = container.api_client()
+    cloud_projects = api_client.projects.get_all()
+
+    for project in projects:
+        cloud_project = _get_cloud_project(project, cloud_projects)
+        local_libraries_cloud_ids = _get_local_libraries_cloud_ids(project)
+
+        _add_new_libraries(cloud_project, local_libraries_cloud_ids, cloud_projects)
+        _remove_outdated_libraries(cloud_project, local_libraries_cloud_ids, cloud_projects)
 
 
 @click.command(cls=LeanCommand)
@@ -39,12 +118,18 @@ def push(project: Optional[Path], organization_id: Optional[str]) -> None:
     # Parse which projects need to be pushed
     if project is not None:
         project_config_manager = container.project_config_manager()
-        if not project_config_manager.get_project_config(project).file.exists():
+        project_config = project_config_manager.get_project_config(project)
+        if not project_config.file.exists():
             raise RuntimeError(f"'{project}' is not a Lean project")
 
         projects_to_push = [project]
+        libraries_in_config = project_config.get("libraries", [])
+        libraries = [LeanLibraryReference(**library).path.expanduser().resolve() for library in libraries_in_config]
+        projects_to_push.extend(libraries)
     else:
         projects_to_push = [p.parent for p in Path.cwd().rglob(PROJECT_CONFIG_FILE_NAME)]
 
     push_manager = container.push_manager()
     push_manager.push_projects(projects_to_push, organization_id)
+
+    _update_cloud_library_references(projects_to_push)

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -102,7 +102,7 @@ def _update_cloud_library_references(projects: List[Path]) -> None:
 
 def _get_libraries_to_push(project_dir: Path, seen_projects: List[Path] = None) -> List[Path]:
     if seen_projects is None:
-        seen_projects = []
+        seen_projects = [project_dir]
 
     project_config_manager = container.project_config_manager()
     project_config = project_config_manager.get_project_config(project_dir)
@@ -115,13 +115,12 @@ def _get_libraries_to_push(project_dir: Path, seen_projects: List[Path] = None) 
         if library_path in seen_projects:
             continue
 
-        referenced_libraries.extend(_get_libraries_to_push(library_path))
         seen_projects.append(library_path)
+        referenced_libraries.extend(_get_libraries_to_push(library_path, seen_projects))
 
     libraries.extend(referenced_libraries)
-    seen_projects = None
 
-    return list(set(libraries))
+    return list(dict.fromkeys(libraries))
 
 
 @click.command(cls=LeanCommand)

--- a/lean/commands/library/add.py
+++ b/lean/commands/library/add.py
@@ -161,8 +161,8 @@ def _add_csharp_nuget_package(project_dir: Path, name: str, version: Optional[st
         logger.info("Retrieving latest available version from NuGet")
         name, version = _get_nuget_package(name)
 
-    library_manager = container.library_manager()
-    csproj_file = library_manager.get_csproj_file_path(project_dir)
+    project_manager = container.project_manager()
+    csproj_file = project_manager.get_csproj_file_path(project_dir)
     path_manager = container.path_manager()
     logger.info(f"Adding {name} {version} to '{path_manager.get_relative_path(csproj_file)}'")
 
@@ -187,11 +187,12 @@ def _add_csharp_lean_library(project_dir: Path, library_dir: Path, no_local: boo
         return
 
     library_manager = container.library_manager()
-    library_csproj_file = library_manager.get_csharp_lean_library_path_for_csproj_file(project_dir, library_dir)
-    project_csproj_file = library_manager.get_csproj_file_path(project_dir)
+    library_csproj_file_path = library_manager.get_csharp_lean_library_path_for_csproj_file(project_dir, library_dir)
+    project_manager = container.project_manager()
+    project_csproj_file = project_manager.get_csproj_file_path(project_dir)
 
     original_csproj_content = project_csproj_file.read_text(encoding="utf-8")
-    _add_csharp_project_to_csproj(project_csproj_file, library_csproj_file)
+    _add_csharp_project_to_csproj(project_csproj_file, library_csproj_file_path)
     _try_restore_csharp_project(project_csproj_file, original_csproj_content, no_local)
 
 

--- a/lean/commands/library/remove.py
+++ b/lean/commands/library/remove.py
@@ -23,7 +23,7 @@ from lean.container import container
 from lean.models.errors import MoreInfoError
 
 
-def _remove_csharp(project_dir: Path, name: str, no_local: bool) -> None:
+def _remove_csharp_nuget_package(project_dir: Path, name: str, no_local: bool) -> None:
     """Removes a custom C# library from a C# project.
 
     Removes the library from the project's .csproj file,
@@ -57,7 +57,7 @@ def _remove_csharp(project_dir: Path, name: str, no_local: bool) -> None:
             raise RuntimeError("Something went wrong while restoring packages, see the logs above for more information")
 
 
-def _remove_python(project_dir: Path, name: str) -> None:
+def _remove_python_pypi_package(project_dir: Path, name: str) -> None:
     """Removes a custom Python library from a Python project.
 
     Removes the library from the project's requirements.txt file.
@@ -90,6 +90,48 @@ def _remove_python(project_dir: Path, name: str) -> None:
     requirements_file.write_text(new_content, encoding="utf-8")
 
 
+def _remove_lean_library_reference_from_project(project_dir: Path, library_dir: Path) -> None:
+    """Removed a Lean CLI library reference from a project.
+
+    Removes the library path from the project's config.json
+
+    :param project_dir: the path to the project directory
+    :param library_dir: the path to the C# library directory
+    """
+    project_config = container.project_config_manager().get_project_config(project_dir)
+    libraries = project_config.get("libraries", [])
+
+    lean_config_manager = container.lean_config_manager()
+    path_manager = container.path_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+    library_relative_path = path_manager.get_relative_path(library_dir, lean_cli_root_dir).as_posix()
+
+    libraries.remove(library_relative_path)
+    project_config.set("libraries", libraries)
+
+
+def _remove_csharp_lean_library(project_dir: Path, library_dir: Path, no_local: bool) -> None:
+    """Removes a Lean CLI C# library from a C# project.
+
+    Removes the library from the project's .csproj file,
+    and restores the project if dotnet is on the user's PATH and no_local is False.
+
+    :param project_dir: Path to the project directory
+    :param library_dir: Path to the library directory
+    :param no_local: Whether restoring the packages locally must be skipped
+    """
+    _remove_lean_library_reference_from_project(project_dir, library_dir)
+
+
+def _remove_python_lean_library(project_dir: Path, library_dir: Path) -> None:
+    """Removes a Lean CLI Python library from a Python project.
+
+    :param project_dir: Path to the project directory
+    :param library_dir: Path to the library directory
+    """
+    _remove_lean_library_reference_from_project(project_dir, library_dir)
+
+
 @click.command(cls=LeanCommand, requires_docker=True)
 @click.argument("project", type=PathParameter(exists=True, file_okay=False, dir_okay=True))
 @click.argument("name", type=str)
@@ -99,7 +141,8 @@ def remove(project: Path, name: str, no_local: bool) -> None:
 
     PROJECT must be the path to the project directory.
 
-    NAME must be the name of the NuGet package (for C# projects) or of the PyPI package (for Python projects) to remove.
+    NAME must be either the name of the NuGet package (for C# projects), the PyPI package (for Python projects),
+    or the path to the Lean CLI library to remove.
 
     Custom C# libraries are removed from the project's .csproj file,
     which is then restored if dotnet is on your PATH and the --no-local flag has not been given.
@@ -121,7 +164,18 @@ def remove(project: Path, name: str, no_local: bool) -> None:
         raise MoreInfoError(f"{project} is not a Lean CLI project",
                             "https://www.lean.io/docs/v2/lean-cli/projects/project-management#02-Create-Projects")
 
-    if project_language == "CSharp":
-        _remove_csharp(project, name, no_local)
+    logger = container.logger()
+    library_manager = container.library_manager()
+    library_dir = Path(name).expanduser().resolve()
+    if library_manager.is_lean_library(library_dir):
+        logger.info(f"Removing Lean CLI library {library_dir} from project {project}")
+        if project_language == "CSharp":
+            _remove_csharp_lean_library(project, library_dir, no_local)
+        else:
+            _remove_python_lean_library(project, library_dir)
     else:
-        _remove_python(project, name)
+        logger.info(f"Removing package {name} from project {project}")
+        if project_language == "CSharp":
+            _remove_csharp_nuget_package(project, name, no_local)
+        else:
+            _remove_python_pypi_package(project, name)

--- a/lean/commands/library/remove.py
+++ b/lean/commands/library/remove.py
@@ -38,9 +38,10 @@ def _remove_csharp_package(project_dir: Path, name: Union[str, Path], no_local: 
     """
     logger = container.logger()
     path_manager = container.path_manager()
+    project_manager = container.project_manager()
     library_manager = container.library_manager()
 
-    csproj_file = library_manager.get_csproj_file_path(project_dir)
+    csproj_file = project_manager.get_csproj_file_path(project_dir)
     logger.info(f"Removing {name} from '{path_manager.get_relative_path(csproj_file)}'")
 
     xml_manager = container.xml_manager()

--- a/lean/commands/library/remove.py
+++ b/lean/commands/library/remove.py
@@ -129,7 +129,7 @@ def remove(project: Path, name: str, no_local: bool) -> None:
         if project_language == "CSharp":
             library_manager.remove_lean_library_from_csharp_project(project, library_dir, no_local)
         else:
-            _remove_lean_library_from_python_project(project, library_dir)
+            library_manager.remove_lean_library_from_python_project(project, library_dir)
     else:
         if project_language == "CSharp":
             _remove_package_from_csharp_project(project, name, no_local)

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -139,19 +139,11 @@ class PushManager:
 
         # Delete locally removed files in cloud
         files_to_remove = [cloud_file for cloud_file in cloud_files
-                           if not any(local_file_name == cloud_file.name for local_file_name in local_file_names)]
+                           if (not cloud_file.isLibrary and
+                               not any(local_file_name == cloud_file.name for local_file_name in local_file_names))]
         for file in files_to_remove:
             self._last_file = Path(file.name)
-
-            try:
-                self._api_client.files.delete(cloud_project.projectId, file.name)
-            except RequestFailedError as e:
-                # Some files fetched from cloud are not downloaded to local environments (like copies of library files),
-                # so the delete call will fail with "File not found" error
-                if "File not found" in str(e):
-                    continue
-                raise e
-
+            self._api_client.files.delete(cloud_project.projectId, file.name)
             self._logger.info(f"Successfully removed cloud file '{cloud_project.name}/{file.name}'")
 
         self._last_file = None

--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -261,7 +261,16 @@ class LeanConfigManager:
 
         project_config = self._project_config_manager.get_project_config(algorithm_file.parent)
         config["parameters"] = project_config.get("parameters", {})
-        config["python-additional-paths"] = project_config.get("python-additional-paths", [])
+
+        # Add libraries paths to python project
+        project_language = project_config.get("algorithm-language", None)
+        if project_language == "Python":
+            library_references = project_config.get("libraries", [])
+            python_paths = config.get("python-additional-paths", [])
+            python_paths.extend([(Path("/") / library["path"]).as_posix() for library in library_references])
+            if len(python_paths) > 0:
+                python_paths.append("/Library")
+            config["python-additional-paths"] = python_paths
 
         # No real limit for the object store by default
         if "storage-limit-mb" not in config:

--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -261,6 +261,7 @@ class LeanConfigManager:
 
         project_config = self._project_config_manager.get_project_config(algorithm_file.parent)
         config["parameters"] = project_config.get("parameters", {})
+        config["python-additional-paths"] = project_config.get("python-additional-paths", [])
 
         # No real limit for the object store by default
         if "storage-limit-mb" not in config:

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -455,6 +455,15 @@ class LeanRunner:
             "mode": "ro"
         }
 
+        # Check if the user has library projects
+        library_dir = self._lean_config_manager.get_cli_root_directory() / "Library"
+        if library_dir.is_dir():
+            # Mount the library projects
+            run_options["volumes"][str(library_dir)] = {
+                "bind": "/Library",
+                "mode": "ro"
+            }
+
         # Ensure all .csproj files refer to the version of LEAN in the Docker container
         csproj_temp_dir = self._temp_manager.create_temporary_directory()
         for path in compile_root.rglob("*.csproj"):

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -367,11 +367,7 @@ class LeanRunner:
                 "bind": "/Library",
                 "mode": "rw"
             }
-
-            # Ensure library projects are used when resolving Python imports
-            run_options["commands"].append("mkdir -p $(python -m site --user-site)")
-            run_options["commands"].append("echo /Library > $(python -m site --user-site)/lean-cli.pth")
-
+            
         # Combine the requirements from all library projects and the current project
         requirements_files = list(library_dir.rglob("requirements.txt")) + [project_dir / "requirements.txt"]
         requirements_files = [file for file in requirements_files if file.is_file()]

--- a/lean/components/util/library_manager.py
+++ b/lean/components/util/library_manager.py
@@ -1,0 +1,64 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from lean.components.config.lean_config_manager import LeanConfigManager
+from lean.components.config.project_config_manager import ProjectConfigManager
+from lean.components.util.path_manager import PathManager
+from lean.components.util.platform_manager import PlatformManager
+from lean.components.util.xml_manager import XMLManager
+
+
+class LibraryManager:
+    """The LibraryManager class provides utilities for handling a libraries."""
+
+    def __init__(self,
+                 project_config_manager: ProjectConfigManager,
+                 lean_config_manager: LeanConfigManager,
+                 path_manager: PathManager) -> None:
+        """Creates a new LibraryManager instance.
+
+        :param project_config_manager: the ProjectConfigManager to use when creating new projects
+        :param lean_config_manager: the LeanConfigManager to get the CLI root directory from
+        :param path_manager: the path manager to use to handle library paths
+        """
+        self._project_config_manager = project_config_manager
+        self._lean_config_manager = lean_config_manager
+        self._path_manager = path_manager
+
+    def is_lean_library(self, path: Path) -> bool:
+        """Checks whether the library name is a Lean library path
+
+        :param path: path to check whether it is a Lean library
+        :return: true if the path is a Lean library path
+        """
+        if not self._path_manager.is_path_valid(path):
+            return False
+
+        relative_path = self._path_manager.get_relative_path(path, self._lean_config_manager.get_cli_root_directory())
+        path_parts = relative_path.parts
+
+        return len(path_parts) > 0 and path_parts[0] == "Library" and relative_path.is_dir()
+
+    def is_valid_lean_library_for_project(self, path: Path, project_language: str) -> bool:
+        """Checks whether the library name is a Lean library path
+
+        :param path: path to check whether it is a valid Lean library
+        :param project_language: language of the project the library is for
+        :return: true if the library is a Lean library path
+        """
+        library_config = self._project_config_manager.get_project_config(path)
+        library_language = library_config.get("algorithm-language", None)
+
+        return library_language is not None and library_language == project_language

--- a/lean/components/util/library_manager.py
+++ b/lean/components/util/library_manager.py
@@ -16,8 +16,6 @@ from pathlib import Path
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.path_manager import PathManager
-from lean.components.util.platform_manager import PlatformManager
-from lean.components.util.xml_manager import XMLManager
 
 
 class LibraryManager:
@@ -51,7 +49,7 @@ class LibraryManager:
 
         return len(path_parts) > 0 and path_parts[0] == "Library" and relative_path.is_dir()
 
-    def is_valid_lean_library_for_project(self, path: Path, project_language: str) -> bool:
+    def is_valid_lean_library_for_project(self, path: Path, project_language: str) -> str:
         """Checks whether the library name is a Lean library path
 
         :param path: path to check whether it is a valid Lean library
@@ -62,3 +60,21 @@ class LibraryManager:
         library_language = library_config.get("algorithm-language", None)
 
         return library_language is not None and library_language == project_language
+
+    def get_csharp_lean_library_path_for_csproj_file(self, project_dir: Path, library_dir: Path) -> str:
+        cli_root_dir = self._lean_config_manager.get_cli_root_directory()
+        project_dir_relative_to_cli = self._path_manager.get_relative_path(project_dir, cli_root_dir)
+        library_dir_relative_to_cli = self._path_manager.get_relative_path(library_dir, cli_root_dir)
+        library_csproj_file = self.get_csproj_file_path(library_dir_relative_to_cli)
+        library_csproj_file = "../" * len(project_dir_relative_to_cli.parts) / library_csproj_file
+
+        return library_csproj_file.as_posix()
+
+    @staticmethod
+    def get_csproj_file_path(project_dir: Path) -> Path:
+        """Gets the path to the csproj file in the project directory.
+
+        :param project_dir: Path to the project directory
+        :return: Path to the csproj file in the project directory
+        """
+        return next(p for p in project_dir.iterdir() if p.name.endswith(".csproj"))

--- a/lean/components/util/library_manager.py
+++ b/lean/components/util/library_manager.py
@@ -12,12 +12,18 @@
 # limitations under the License.
 
 import json
+import shutil
+import subprocess
 from pathlib import Path
+
+from lxml import etree
 
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
+from lean.components.util.logger import Logger
 from lean.components.util.path_manager import PathManager
 from lean.components.util.project_manager import ProjectManager
+from lean.components.util.xml_manager import XMLManager
 from lean.models.utils import LeanLibraryReference
 
 
@@ -25,21 +31,27 @@ class LibraryManager:
     """The LibraryManager class provides utilities for handling a libraries."""
 
     def __init__(self,
+                 logger: Logger,
                  project_manager: ProjectManager,
                  project_config_manager: ProjectConfigManager,
                  lean_config_manager: LeanConfigManager,
-                 path_manager: PathManager) -> None:
+                 path_manager: PathManager,
+                 xml_manager: XMLManager) -> None:
         """Creates a new LibraryManager instance.
 
+        :param logger: the logger to use to log messages with
         :param project_manager: the ProjectManager to use when requesting project csproj file
         :param project_config_manager: the ProjectConfigManager to use to get project's config
         :param lean_config_manager: the LeanConfigManager to get the CLI root directory from
         :param path_manager: the path manager to use to handle library paths
+        :param xml_manager: the XMLManager to use when working with XML
         """
+        self._logger = logger
         self._project_manager = project_manager
         self._project_config_manager = project_config_manager
         self._lean_config_manager = lean_config_manager
         self._path_manager = path_manager
+        self._xml_manager = xml_manager
 
     def is_lean_library(self, path: Path) -> bool:
         """Checks whether the library name is a Lean library path
@@ -128,3 +140,166 @@ class LibraryManager:
         libraries = project_config.get("libraries", [])
         libraries = [library for library in libraries if LeanLibraryReference(**library).path != library_relative_path]
         project_config.set("libraries", libraries)
+
+    def add_lean_library_to_csharp_project(self, project_dir: Path, library_dir: Path, no_local: bool) -> None:
+        """Adds a Lean CLI C# library to the project's csproj file.
+
+        It will add a reference to the library and restore the project if dotnet is the user's PATH.
+
+        It will raise a RuntimeError if the library is a C# library and does not have a .csproj file.
+
+        :param project_dir: Path to the project directory
+        :param library_dir: Path to the library directory
+        :param no_local: Whether restoring the packages locally must be skipped
+        """
+        already_added = self.add_lean_library_reference_to_project(project_dir, library_dir)
+        # If the library was already referenced by the project,
+        # do not proceed further with adding it to the .csproj file
+        if already_added:
+            self._logger.info(f"Library {library_dir.name} has already been added to the project {project_dir.name}")
+            return
+
+        library_config = self._project_config_manager.get_project_config(library_dir)
+        library_language = library_config.get("algorithm-language", None)
+
+        # Python library references are not added to .csproj file
+        if library_language == 'Python':
+            return
+
+        library_csproj_file_path = self.get_csharp_lean_library_path_for_csproj_file(project_dir, library_dir)
+
+        if library_csproj_file_path is None:
+            raise RuntimeError(f"C# library {library_dir.name} does not contain a .csproj file")
+
+        project_csproj_file = self._project_manager.get_csproj_file_path(project_dir)
+
+        original_csproj_content = project_csproj_file.read_text(encoding="utf-8")
+        self._add_csharp_project_to_csproj(project_csproj_file, library_csproj_file_path)
+        self._project_manager.try_restore_csharp_project(project_csproj_file, original_csproj_content, no_local)
+
+    def add_lean_library_to_python_project(self, project_dir: Path, library_dir: Path) -> None:
+        """Adds a Lean CLI Python library to a Python project.
+
+        :param project_dir: the path to the project directory
+        :param library_dir: the path to the library directory
+        """
+        self.add_lean_library_reference_to_project(project_dir, library_dir)
+
+    def add_lean_library_to_project(self, project_dir: Path, library_dir: Path, no_local: bool) -> None:
+        """Adds a Lean CLI library to a project.
+
+        :param project_dir: the path to the project directory
+        :param library_dir: the path to the library directory
+        :param no_local: whether restoring the packages locally must be skipped
+        """
+        project_language = self._get_project_language(project_dir)
+
+        if project_language == "CSharp":
+            self.add_lean_library_to_csharp_project(project_dir, library_dir, no_local)
+        else:
+            self.add_lean_library_to_python_project(project_dir, library_dir)
+
+    def remove_lean_library_from_csharp_project(self, project_dir: Path, library_dir: Path, no_local: bool) -> None:
+        """Removes a Lean CLI library from a C# project.
+
+        Removes the library from the project's .csproj file,
+        and restores the project if dotnet is on the user's PATH and no_local is False.
+
+        :param project_dir: Path to the project directory
+        :param library_dir: Path to the library directory
+        :param no_local: Whether restoring the packages locally must be skipped
+        """
+        self.remove_lean_library_reference_from_project(project_dir, library_dir)
+
+        library_config = self._project_config_manager.get_project_config(library_dir)
+        library_language = library_config.get("algorithm-language", None)
+
+        # Python library references are not added to .csproj file, so no need to remove
+        if library_language == 'Python':
+            return
+
+        self._remove_project_reference_from_csharp_project(project_dir, library_dir, no_local)
+
+    def remove_lean_library_from_python_project(self, project_dir: Path, library_dir: Path) -> None:
+        """Removes a Lean CLI library from a Python project.
+
+        :param project_dir: Path to the project directory
+        :param library_dir: Path to the library directory
+        """
+        self.remove_lean_library_reference_from_project(project_dir, library_dir)
+
+    def remove_lean_library_from_project(self, project_dir: Path, library_dir: Path, no_local: bool) -> None:
+        """Removes a Lean CLI library from a project.
+
+        Removes the library from the project's .csproj file,
+        and restores the project if dotnet is on the user's PATH and no_local is False.
+
+        :param project_dir: Path to the project directory
+        :param library_dir: Path to the library directory
+        :param no_local: Whether restoring the packages locally must be skipped
+        """
+        project_language = self._get_project_language(project_dir)
+
+        if project_language == "CSharp":
+            self.remove_lean_library_from_csharp_project(project_dir, library_dir, no_local)
+        else:
+            self.remove_lean_library_from_python_project(project_dir, library_dir)
+
+    def _get_project_language(self, project_dir: Path) -> str:
+        """Gets a project language.
+
+        :param project_dir: Path to the project directory
+        :return The project language
+        """
+        project_config = self._project_config_manager.get_project_config(project_dir)
+        return project_config.get("algorithm-language", None)
+
+    def _add_csharp_project_to_csproj(self, csproj_file: Path, library_csproj_path: str) -> None:
+        """Adds a Lean CLI library project reference to a .csproj file.
+
+        :param csproj_file: the path to the .csproj file
+        :param library_csproj_path: the path to the library's .csproj file
+        """
+        csproj_tree = self._xml_manager.parse(csproj_file.read_text(encoding="utf-8"))
+
+        existing_project_reference = csproj_tree.find(f".//ProjectReference[@Include='{library_csproj_path}']")
+        if existing_project_reference is None:
+            last_item_group = csproj_tree.find(".//ItemGroup[last()]")
+            if last_item_group is None:
+                last_item_group = etree.SubElement(csproj_tree.find(".//Project"), "ItemGroup")
+
+            last_item_group.append(etree.fromstring(f'<ProjectReference Include="{library_csproj_path}" />'))
+
+        csproj_file.write_text(self._xml_manager.to_string(csproj_tree), encoding="utf-8")
+
+    def _remove_project_reference_from_csharp_project(self, project_dir: Path, name: Path, no_local: bool) -> None:
+        """Removes a Lean CLI C# library from a C# project.
+
+        Removes the library from the project's .csproj file,
+        and restores the project if dotnet is on the user's PATH and no_local is False.
+
+        :param project_dir: the path to the project directory
+        :param name: the path to the Lean CLI library to remove
+        :param no_local: Whether restoring the packages locally must be skipped
+        """
+        csproj_file = self._project_manager.get_csproj_file_path(project_dir)
+        self._logger.info(f"Removing {name} from '{self._path_manager.get_relative_path(csproj_file)}'")
+
+        csproj_tree = self._xml_manager.parse(csproj_file.read_text(encoding="utf-8"))
+
+        library_reference = self.get_csharp_lean_library_path_for_csproj_file(project_dir, name)
+
+        for package_reference in csproj_tree.findall('.//ProjectReference'):
+            if package_reference.get("Include", "") == library_reference:
+                package_reference.getparent().remove(package_reference)
+
+        csproj_file.write_text(self._xml_manager.to_string(csproj_tree), encoding="utf-8")
+
+        if not no_local and shutil.which("dotnet") is not None:
+            self._logger.info(f"Restoring packages in '{self._path_manager.get_relative_path(project_dir)}'")
+
+            process = subprocess.run(["dotnet", "restore", str(csproj_file)], cwd=project_dir)
+
+            if process.returncode != 0:
+                raise RuntimeError(
+                    "Something went wrong while restoring packages, see the logs above for more information")

--- a/lean/components/util/library_manager.py
+++ b/lean/components/util/library_manager.py
@@ -16,21 +16,25 @@ from pathlib import Path
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.path_manager import PathManager
+from lean.components.util.project_manager import ProjectManager
 
 
 class LibraryManager:
     """The LibraryManager class provides utilities for handling a libraries."""
 
     def __init__(self,
+                 project_manager: ProjectManager,
                  project_config_manager: ProjectConfigManager,
                  lean_config_manager: LeanConfigManager,
                  path_manager: PathManager) -> None:
         """Creates a new LibraryManager instance.
 
-        :param project_config_manager: the ProjectConfigManager to use when creating new projects
+        :param project_manager: the ProjectManager to use when requesting project csproj file
+        :param project_config_manager: the ProjectConfigManager to use to get project's config
         :param lean_config_manager: the LeanConfigManager to get the CLI root directory from
         :param path_manager: the path manager to use to handle library paths
         """
+        self._project_manager = project_manager
         self._project_config_manager = project_config_manager
         self._lean_config_manager = lean_config_manager
         self._path_manager = path_manager
@@ -68,7 +72,7 @@ class LibraryManager:
         cli_root_dir = self._lean_config_manager.get_cli_root_directory()
         project_dir_relative_to_cli = self._path_manager.get_relative_path(project_dir, cli_root_dir)
         library_dir_relative_to_cli = self._path_manager.get_relative_path(library_dir, cli_root_dir)
-        library_csproj_file = self.get_csproj_file_path(library_dir_relative_to_cli)
+        library_csproj_file = self._project_manager.get_csproj_file_path(library_dir_relative_to_cli)
         library_csproj_file = "../" * len(project_dir_relative_to_cli.parts) / library_csproj_file
 
         return library_csproj_file
@@ -81,12 +85,3 @@ class LibraryManager:
         """
         lean_cli_root_dir = self._lean_config_manager.get_cli_root_directory()
         return self._path_manager.get_relative_path(library_dir, lean_cli_root_dir)
-
-    @staticmethod
-    def get_csproj_file_path(project_dir: Path) -> Path:
-        """Gets the path to the csproj file in the project directory.
-
-        :param project_dir: Path to the project directory
-        :return: Path to the csproj file in the project directory
-        """
-        return next(p for p in project_dir.iterdir() if p.name.endswith(".csproj"))

--- a/lean/components/util/library_manager.py
+++ b/lean/components/util/library_manager.py
@@ -12,12 +12,10 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List
 
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.path_manager import PathManager
-from lean.models.utils import LeanLibraryReference
 
 
 class LibraryManager:

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -193,9 +193,9 @@ class ProjectManager:
 
         if project is not None:
             project_path = Path(project).as_posix() if not search_by_id else None
-            projects = [project for project in cloud_projects
-                        if (search_by_id and project.projectId == project or
-                            not search_by_id and Path(project.name).as_posix() == project_path)]
+            projects = [cloud_project for cloud_project in cloud_projects
+                        if (search_by_id and cloud_project.projectId == project or
+                            not search_by_id and Path(cloud_project.name).as_posix() == project_path)]
 
             if len(projects) == 0:
                 raise RuntimeError("No project with the given name or id exists in the cloud")

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -419,23 +419,7 @@ class ProjectManager:
 
         :param project_dir: the path of the new project
         """
-        self._generate_file(project_dir / f"{project_dir.name}.csproj", """
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <TargetFramework>net6.0</TargetFramework>
-        <OutputPath>bin/$(Configuration)</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <DefaultItemExcludes>$(DefaultItemExcludes);backtests/*/code/**;live/*/code/**;optimizations/*/code/**</DefaultItemExcludes>
-        <NoWarn>CS0618</NoWarn>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="QuantConnect.Lean" Version="2.5.*"/>
-        <PackageReference Include="QuantConnect.DataSource.Libraries" Version="2.5.*"/>
-    </ItemGroup>
-</Project>
-        """)
+        self._generate_file(project_dir / f"{project_dir.name}.csproj", self.get_csproj_file_default_content())
 
     def generate_rider_config(self) -> None:
         """Generates C# debugging configuration for Rider."""
@@ -551,10 +535,30 @@ class ProjectManager:
         return directories
 
     @staticmethod
+    def get_csproj_file_default_content() -> str:
+        return """
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <TargetFramework>net6.0</TargetFramework>
+        <OutputPath>bin/$(Configuration)</OutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <DefaultItemExcludes>$(DefaultItemExcludes);backtests/*/code/**;live/*/code/**;optimizations/*/code/**</DefaultItemExcludes>
+        <NoWarn>CS0618</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="QuantConnect.Lean" Version="2.5.*"/>
+        <PackageReference Include="QuantConnect.DataSource.Libraries" Version="2.5.*"/>
+    </ItemGroup>
+</Project>
+        """
+
+    @staticmethod
     def get_csproj_file_path(project_dir: Path) -> Path:
         """Gets the path to the csproj file in the project directory.
 
         :param project_dir: Path to the project directory
         :return: Path to the csproj file in the project directory
         """
-        return next(p for p in project_dir.iterdir() if p.name.endswith(".csproj"))
+        return next((p for p in project_dir.iterdir() if p.name.endswith(".csproj")), None)

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -549,3 +549,12 @@ class ProjectManager:
             directories.append(root_dir / editor_name)
 
         return directories
+
+    @staticmethod
+    def get_csproj_file_path(project_dir: Path) -> Path:
+        """Gets the path to the csproj file in the project directory.
+
+        :param project_dir: Path to the project directory
+        :return: Path to the csproj file in the project directory
+        """
+        return next(p for p in project_dir.iterdir() if p.name.endswith(".csproj"))

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -614,7 +614,6 @@ class ProjectManager:
             referenced_libraries.extend(self._get_libraries(cloud_projects, library, seen_libraries))
 
         libraries.extend(referenced_libraries)
-        seen_libraries = None
 
         return list(set(libraries))
 
@@ -637,8 +636,6 @@ class ProjectManager:
         libraries = []
         for project in projects:
             libraries.extend(self._get_libraries(cloud_projects, project, seen_projects))
-
-        seen_projects = None
 
         return list(set(libraries))
 

--- a/lean/container.py
+++ b/lean/container.py
@@ -85,7 +85,11 @@ class Container(DeclarativeContainer):
                                 lean_config_manager,
                                 xml_manager,
                                 platform_manager)
-    library_manager = Singleton(LibraryManager, project_config_manager, lean_config_manager, path_manager)
+    library_manager = Singleton(LibraryManager,
+                                project_manager,
+                                project_config_manager,
+                                lean_config_manager,
+                                path_manager)
 
     cloud_runner = Singleton(CloudRunner, logger, api_client, task_manager)
     pull_manager = Singleton(PullManager, logger, api_client, project_manager, project_config_manager, platform_manager)

--- a/lean/container.py
+++ b/lean/container.py
@@ -30,6 +30,7 @@ from lean.components.config.storage import Storage
 from lean.components.docker.docker_manager import DockerManager
 from lean.components.docker.lean_runner import LeanRunner
 from lean.components.util.http_client import HTTPClient
+from lean.components.util.library_manager import LibraryManager
 from lean.components.util.logger import Logger
 from lean.components.util.market_hours_database import MarketHoursDatabase
 from lean.components.util.name_generator import NameGenerator
@@ -84,6 +85,7 @@ class Container(DeclarativeContainer):
                                 lean_config_manager,
                                 xml_manager,
                                 platform_manager)
+    library_manager = Singleton(LibraryManager, project_config_manager, lean_config_manager, path_manager)
 
     cloud_runner = Singleton(CloudRunner, logger, api_client, task_manager)
     pull_manager = Singleton(PullManager, logger, api_client, project_manager, project_config_manager, platform_manager)

--- a/lean/container.py
+++ b/lean/container.py
@@ -81,15 +81,19 @@ class Container(DeclarativeContainer):
     optimizer_config_manager = Singleton(OptimizerConfigManager, logger)
 
     project_manager = Singleton(ProjectManager,
+                                logger,
                                 project_config_manager,
                                 lean_config_manager,
+                                path_manager,
                                 xml_manager,
                                 platform_manager)
     library_manager = Singleton(LibraryManager,
+                                logger,
                                 project_manager,
                                 project_config_manager,
                                 lean_config_manager,
-                                path_manager)
+                                path_manager,
+                                xml_manager)
 
     cloud_runner = Singleton(CloudRunner, logger, api_client, task_manager)
     pull_manager = Singleton(PullManager, logger, api_client, project_manager, project_config_manager, platform_manager)

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -103,6 +103,14 @@ class QCProject(WrappedBaseModel):
         """
         return f"https://www.quantconnect.com/project/{self.projectId}"
 
+    def __hash__(self):
+        return hash(self.projectId)
+
+    def __eq__(self, other: Any):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.projectId == other.projectId
+
 
 class QCCreatedProject(WrappedBaseModel):
     projectId: int

--- a/lean/models/utils.py
+++ b/lean/models/utils.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 from enum import Enum
+from pathlib import Path
+
 from lean.models.pydantic import WrappedBaseModel
 
 class DebuggingMethod(Enum):
@@ -31,7 +33,14 @@ class DebuggingMethod(Enum):
             DebuggingMethod.PTVSD: "PTVSD"
         }.get(self, "LocalCmdline")
 
+
 class CSharpLibrary(WrappedBaseModel):
     """The information of a PackageReference tag in a .csproj file."""
     name: str
     version: str
+
+
+class LeanLibraryReference(WrappedBaseModel):
+    """The information of a library reference in a project's config.json file"""
+    name: str
+    path: Path

--- a/tests/commands/cloud/test_push.py
+++ b/tests/commands/cloud/test_push.py
@@ -31,6 +31,16 @@ from tests.test_helpers import create_fake_lean_cli_directory, create_api_projec
 def test_cloud_push_pushes_all_projects_when_no_options_given() -> None:
     create_fake_lean_cli_directory()
 
+    cloud_projects = [
+        create_api_project(1, "Python Project"),
+        create_api_project(2, "CSharp Project"),
+        create_api_project(3, "Library/Python Library"),
+        create_api_project(4, "Library/CSharp Library")
+    ]
+    api_client = mock.Mock()
+    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
+    container.api_client.override(providers.Object(api_client))
+
     push_manager = mock.Mock()
     container.push_manager.override(providers.Object(push_manager))
 
@@ -41,11 +51,23 @@ def test_cloud_push_pushes_all_projects_when_no_options_given() -> None:
     push_manager.push_projects.assert_called_once()
     args, kwargs = push_manager.push_projects.call_args
 
-    assert set(args[0]) == {Path.cwd() / "Python Project", Path.cwd() / "CSharp Project"}
+    expected_args = {
+        Path.cwd() / "Python Project",
+        Path.cwd() / "CSharp Project",
+        Path.cwd() / "Library/Python Library",
+        Path.cwd() / "Library/CSharp Library"
+    }
+
+    assert set(args[0]) == expected_args
 
 
 def test_cloud_push_pushes_single_project_when_project_option_given() -> None:
     create_fake_lean_cli_directory()
+
+    cloud_projects = [create_api_project(1, "Python Project")]
+    api_client = mock.Mock()
+    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
+    container.api_client.override(providers.Object(api_client))
 
     push_manager = mock.Mock()
     container.push_manager.override(providers.Object(push_manager))
@@ -55,6 +77,7 @@ def test_cloud_push_pushes_single_project_when_project_option_given() -> None:
     assert result.exit_code == 0
 
     push_manager.push_projects.assert_called_once_with([Path.cwd() / "Python Project"], None)
+
 
 def test_cloud_push_aborts_when_given_directory_is_not_lean_project() -> None:
     create_fake_lean_cli_directory()
@@ -92,11 +115,8 @@ def test_cloud_push_removes_locally_removed_files_in_cloud() -> None:
     client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
     client.files.delete = mock.Mock()
 
-    project = mock.Mock()
-    project.projectId = 1
-    project.description = ""
-    project.parameters = []
-    client.projects.get_all = mock.MagicMock(return_value=[project])
+    cloud_projects = [create_api_project(1, "Python Project")]
+    client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
 
     project_config = mock.Mock()
     project_config.get = mock.MagicMock(side_effect=[1, "", {}])
@@ -109,13 +129,14 @@ def test_cloud_push_removes_locally_removed_files_in_cloud() -> None:
 
     push_manager = PushManager(mock.Mock(), client, project_manager, project_config_manager)
     container.push_manager.override(providers.Object(push_manager))
+    container.api_client.override(providers.Object(client))
 
     result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Python Project"])
 
     assert result.exit_code == 0
 
     project_config.get.assert_called()
-    client.projects.get_all.assert_called_once()
+    client.projects.get_all.assert_has_calls([mock.call(), mock.call()])
     project_manager.get_source_files.assert_called_once()
     project_config_manager.get_project_config.assert_called()
     client.files.get_all.assert_called_once()
@@ -127,16 +148,18 @@ def test_cloud_push_creates_project_with_optional_organization_id(organization_i
     create_fake_lean_cli_directory()
 
     path = "Python Project"
+    cloud_project = create_api_project(1, path)
 
     with mock.patch.object(ProjectClient, 'create', return_value=create_api_project(1, path)) as mock_create_project,\
-         mock.patch.object(ProjectClient, 'get_all', return_value=[]) as mock_get_all_projects:
+         mock.patch.object(ProjectClient, 'get_all', side_effect=[[], [cloud_project]]) as mock_get_all_projects:
         organization_id_option = ["--organization-id", organization_id] if organization_id is not None else []
         result = CliRunner().invoke(lean, ["cloud", "push", "--project", path, *organization_id_option])
 
     assert result.exit_code == 0
 
-    mock_get_all_projects.assert_called_once()
+    mock_get_all_projects.assert_has_calls([mock.call(), mock.call()])
     mock_create_project.assert_called_once_with(path, QCLanguage.Python, organization_id)
+
 
 def test_cloud_push_updates_lean_config() -> None:
 
@@ -145,13 +168,14 @@ def test_cloud_push_updates_lean_config() -> None:
     def my_side_effect(*args, **kwargs):
         return "Python"
 
+    cloud_project = create_api_project(1, "Python Project")
     api_client = mock.Mock()
-    api_client = api_client.projects.create = mock.MagicMock(return_value=create_api_project(1, "Python Project"))
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
     fake_cloud_files = [QCFullFile(name="removed_file.py", content="", modified=datetime.now(), isLibrary=False)]
     api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
     api_client.files.delete = mock.Mock()
 
-    api_client.projects.get_all = mock.MagicMock(return_value=[])
+    api_client.projects.get_all = mock.MagicMock(return_value=[cloud_project])
     api_client.projects.get = mock.MagicMock(return_value=create_api_project(1, "Python Project"))
 
     project_config = mock.Mock()
@@ -165,9 +189,192 @@ def test_cloud_push_updates_lean_config() -> None:
 
     push_manager = PushManager(mock.Mock(), api_client, project_manager, project_config_manager)
     container.push_manager.override(providers.Object(push_manager))
+    container.api_client.override(providers.Object(api_client))
 
     result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Python Project"])
 
     assert result.exit_code == 0
 
     project_config.set.assert_called_with("organization-id", "123")
+
+
+def test_cloud_push_pushes_libraries_referenced_by_the_project() -> None:
+    create_fake_lean_cli_directory()
+
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+
+    project_path = lean_cli_root_dir / "Python Project"
+    library_path = lean_cli_root_dir / "Library/Python Library"
+
+    push_manager = mock.Mock()
+    push_manager.push_projects = mock.Mock()
+    container.push_manager.override(providers.Object(push_manager))
+
+    api_client = mock.Mock()
+    api_client.projects.add_library = mock.Mock()
+    api_client.projects.delete_library = mock.Mock()
+
+    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, 6)]
+    project_id = 1000
+    library_id = 1001
+    cloud_projects.append(create_api_project(project_id, project_path.name))
+    cloud_projects.append(create_api_project(library_id, str(library_path.relative_to(lean_cli_root_dir))))
+    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
+
+    container.api_client.override(providers.Object(api_client))
+
+    project_config = mock.Mock()
+    project_config.file.exists = mock.MagicMock(return_value=True)
+    project_config.get = mock.MagicMock(return_value=[{
+        "name": library_path.name,
+        "path": str(library_path.relative_to(lean_cli_root_dir))
+    }])
+
+    library_config = mock.Mock()
+    library_config.get = mock.MagicMock(return_value=str(library_id))
+
+    library_projects_config = mock.Mock()
+    library_projects_config.get = mock.MagicMock(return_value=[])
+
+    project_config_manager = mock.Mock()
+    project_config_manager.get_project_config = mock.MagicMock(side_effect=[project_config,
+                                                                            project_config,
+                                                                            library_config,
+                                                                            library_projects_config])
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path.name])
+
+    assert result.exit_code == 0
+
+    push_manager.push_projects.assert_called_once_with([project_path, library_path], None)
+
+    project_config_manager.get_project_config.assert_has_calls([mock.call(project_path),
+                                                                mock.call(project_path),
+                                                                mock.call(library_path),
+                                                                mock.call(library_path)])
+    project_config.get.assert_has_calls([mock.call("libraries", []), mock.call("libraries", [])])
+    library_config.get.assert_called_once_with("cloud-id", None)
+    library_projects_config.get.assert_has_calls([mock.call("libraries", [])])
+
+    api_client.projects.get_all.assert_called_once()
+    api_client.projects.add_library.assert_called_once_with(project_id, library_id)
+    api_client.projects.delete_library.assert_not_called()
+
+
+def test_cloud_push_removes_libraries_in_the_cloud() -> None:
+    create_fake_lean_cli_directory()
+
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+
+    project_path = lean_cli_root_dir / "Python Project"
+    library_path = lean_cli_root_dir / "Library/Python Library"
+
+    push_manager = mock.Mock()
+    push_manager.push_projects = mock.Mock()
+    container.push_manager.override(providers.Object(push_manager))
+
+    api_client = mock.Mock()
+    api_client.projects.add_library = mock.Mock()
+    api_client.projects.delete_library = mock.Mock()
+
+    project_id = 1000
+    library_id = 1001
+    test_project = create_api_project(project_id, project_path.name)
+    library = create_api_project(library_id, str(library_path.relative_to(lean_cli_root_dir)))
+    test_project.libraries.append(library.projectId)
+
+    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, 6)]
+    cloud_projects.append(test_project)
+    cloud_projects.append(library)
+
+    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
+
+    container.api_client.override(providers.Object(api_client))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path.name])
+
+    assert result.exit_code == 0
+
+    push_manager.push_projects.assert_called_once_with([project_path], None)
+
+    api_client.projects.get_all.assert_called_once()
+    api_client.projects.add_library.assert_not_called()
+    api_client.projects.delete_library.assert_called_once_with(project_id, library_id)
+
+
+def test_cloud_push_adds_and_removes_libraries_simultaneously() -> None:
+    create_fake_lean_cli_directory()
+
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+
+    project_path = lean_cli_root_dir / "Python Project"
+
+    push_manager = mock.Mock()
+    push_manager.push_projects = mock.Mock()
+    container.push_manager.override(providers.Object(push_manager))
+
+    api_client = mock.Mock()
+    api_client.projects.add_library = mock.Mock()
+    api_client.projects.delete_library = mock.Mock()
+
+    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, 6)]
+    project_id = 1000
+    test_project_library_id = 1001
+    test_project = create_api_project(project_id, project_path.name)
+    test_project_library = create_api_project(test_project_library_id, "Library/Cloud Library")
+    # test_project_library is added in the cloud but not locally, should be removed
+    test_project.libraries.append(test_project_library.projectId)
+    cloud_projects.append(test_project)
+    cloud_projects.append(test_project_library)
+
+    local_library_path = lean_cli_root_dir / "Library/Python Library"
+    local_library_id = 1002
+    cloud_projects.append(create_api_project(local_library_id, str(local_library_path.relative_to(lean_cli_root_dir))))
+
+    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
+
+    container.api_client.override(providers.Object(api_client))
+
+    project_config = mock.Mock()
+    project_config.file.exists = mock.MagicMock(return_value=True)
+
+    # local_library_path is added locally but not in the cloud, should be added
+    project_config.get = mock.MagicMock(return_value=[{
+        "name": local_library_path.name,
+        "path": str(local_library_path.relative_to(lean_cli_root_dir))
+    }])
+
+    library_config = mock.Mock()
+    library_config.get = mock.MagicMock(return_value=str(local_library_id))
+
+    library_projects_config = mock.Mock()
+    library_projects_config.get = mock.MagicMock(return_value=[])
+
+    project_config_manager = mock.Mock()
+    project_config_manager.get_project_config = mock.MagicMock(side_effect=[project_config,
+                                                                            project_config,
+                                                                            library_config,
+                                                                            library_projects_config])
+    container.project_config_manager.override(providers.Object(project_config_manager))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path.name])
+
+    assert result.exit_code == 0
+
+    push_manager.push_projects.assert_called_once_with([project_path, local_library_path], None)
+
+    project_config_manager.get_project_config.assert_has_calls([mock.call(project_path),
+                                                                mock.call(project_path),
+                                                                mock.call(local_library_path),
+                                                                mock.call(local_library_path)])
+    project_config.get.assert_has_calls([mock.call("libraries", []), mock.call("libraries", [])])
+    library_config.get.assert_called_once_with("cloud-id", None)
+    library_projects_config.get.assert_has_calls([mock.call("libraries", [])])
+
+    api_client.projects.get_all.assert_called_once()
+    api_client.projects.add_library.assert_called_once_with(test_project.projectId, local_library_id)
+    api_client.projects.delete_library.assert_called_once_with(test_project.projectId, test_project_library.projectId)

--- a/tests/commands/library/__init__.py
+++ b/tests/commands/library/__init__.py
@@ -1,0 +1,12 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/commands/library/test_add.py
+++ b/tests/commands/library/test_add.py
@@ -1,0 +1,8 @@
+import unittest
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        self.assertEqual(True, False)  # add assertion here
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/commands/library/test_add.py
+++ b/tests/commands/library/test_add.py
@@ -1,8 +1,101 @@
-import unittest
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, False)  # add assertion here
+from pathlib import Path
 
-if __name__ == '__main__':
-    unittest.main()
+import pytest
+from click.testing import CliRunner
+
+from lean.commands import lean
+from lean.container import container
+from lean.models.utils import LeanLibraryReference
+from tests.test_helpers import create_fake_lean_cli_directory, create_fake_lean_cli_directory_with_subdirectories
+
+
+def _assert_library_reference_was_added_to_project_config_file(project_dir: Path, library_dir: Path) -> None:
+    project_config = container.project_config_manager().get_project_config(project_dir)
+    project_libraries = project_config.get("libraries")
+
+    assert len(project_libraries) == 1
+
+    library_reference = LeanLibraryReference(**project_libraries[0])
+
+    assert library_reference.name == library_dir.name
+    assert library_reference.path == library_dir
+
+
+def _assert_library_reference_was_added_to_csharp_project_csproj_file(project_dir: Path, library_dir: Path) -> None:
+    project_csproj_file = container.project_manager().get_csproj_file_path(project_dir)
+    library_reference = container.library_manager().get_csharp_lean_library_path_for_csproj_file(project_dir,
+                                                                                                 library_dir)
+
+    xml_manager = container.xml_manager()
+    csproj_tree = xml_manager.parse(project_csproj_file.read_text(encoding="utf-8"))
+
+    assert any(Path(project_reference.get("Include")) == library_reference
+               for project_reference in csproj_tree.findall('.//ProjectReference'))
+
+
+def test_adds_library_reference_to_python_project_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_dir = Path("Python Project")
+    library_dir = Path("Library/Python Library")
+
+    result = CliRunner().invoke(lean, ["library", "add", str(project_dir), str(library_dir)])
+
+    assert result.exit_code == 0
+
+    _assert_library_reference_was_added_to_project_config_file(project_dir, library_dir)
+
+
+@pytest.mark.parametrize("project_depth", range(5))
+def test_adds_library_reference_to_csharp_project_config_file(project_depth: int) -> None:
+    create_fake_lean_cli_directory_with_subdirectories(project_depth)
+
+    project_dir = Path("/".join(f"Subdir{i}" for i in range(project_depth))) / "CSharp Project"
+    library_dir = Path("Library/CSharp Library")
+
+    result = CliRunner().invoke(lean, ["library", "add", str(project_dir), str(library_dir), "--no-local"])
+
+    assert result.exit_code == 0
+
+    _assert_library_reference_was_added_to_project_config_file(project_dir, library_dir)
+    _assert_library_reference_was_added_to_csharp_project_csproj_file(project_dir, library_dir)
+
+
+@pytest.mark.parametrize("project_dir", [
+    "Non Existing Directory",
+    "CSharp Project/Main.cs",
+    "."
+])
+def test_library_add_fails_when_project_directory_is_not_valid(project_dir: str) -> None:
+    create_fake_lean_cli_directory()
+
+    result = CliRunner().invoke(lean, ["library", "add", project_dir, "Library/CSharp Library", "--no-local"])
+
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize("library_dir", [
+    "CSharp Project",
+    "Non Existing Directory",
+    "CSharp Project/Main.cs"
+])
+def test_library_add_fails_when_library_directory_is_not_valid(library_dir: str) -> None:
+    create_fake_lean_cli_directory()
+
+    result = CliRunner().invoke(lean, ["library", "add", "CSharp Project", library_dir, "--no-local"])
+
+    assert result.exit_code != 0
+

--- a/tests/commands/library/test_remove.py
+++ b/tests/commands/library/test_remove.py
@@ -1,0 +1,151 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path, PurePosixPath
+
+import pytest
+from click.testing import CliRunner
+from lxml import etree
+
+from lean.commands import lean
+from lean.container import container
+from lean.models.api import QCLanguage
+from lean.models.utils import LeanLibraryReference
+from tests.test_helpers import create_fake_lean_cli_directory, create_fake_lean_cli_directory_with_subdirectories
+
+
+def _assert_project_config_file_has_library_reference(project_dir: Path, library_dir: Path) -> None:
+    project_config = container.project_config_manager().get_project_config(project_dir)
+    project_libraries = project_config.get("libraries")
+
+    assert len([library for library in project_libraries if LeanLibraryReference(**library).path == library_dir]) == 1
+
+
+def _add_library_to_project_config(project_dir: Path, library_dir: Path) -> None:
+    library_manager = container.library_manager()
+
+    assert not library_manager.add_lean_library_reference_to_project(project_dir, library_dir)
+    _assert_project_config_file_has_library_reference(project_dir, library_dir)
+
+
+def _assert_library_reference_was_removed_from_project_config_file(project_dir: Path, library_dir: Path) -> None:
+    project_config = container.project_config_manager().get_project_config(project_dir)
+    project_libraries = project_config.get("libraries")
+
+    assert len([library for library in project_libraries if LeanLibraryReference(**library).path == library_dir]) == 0
+
+
+def _assert_csharp_project_csproj_file_has_library_reference(project_dir: Path, library_dir: Path) -> None:
+    project_csproj_file = container.project_manager().get_csproj_file_path(project_dir)
+
+    xml_manager = container.xml_manager()
+    csproj_tree = xml_manager.parse(project_csproj_file.read_text(encoding="utf-8"))
+
+    library_config = container.project_config_manager().get_project_config(library_dir)
+    library_language = library_config.get("algorithm-language")
+
+    if library_language == "Python":
+        assert not any(str(library_dir) in project_reference.get("Include")
+                       for project_reference in csproj_tree.findall('.//ProjectReference'))
+    else:
+        library_reference = container.library_manager().get_csharp_lean_library_path_for_csproj_file(project_dir,
+                                                                                                     library_dir)
+
+        assert any(project_reference.get("Include") == library_reference
+                   for project_reference in csproj_tree.findall('.//ProjectReference'))
+
+
+def _add_library_to_csharp_project_csproj_file(project_dir: Path, library_dir: Path) -> None:
+    library_manager = container.library_manager()
+    library_reference = library_manager.get_csharp_lean_library_path_for_csproj_file(project_dir, library_dir)
+
+    project_manager = container.project_manager()
+    project_csproj_file = project_manager.get_csproj_file_path(project_dir)
+
+    xml_manager = container.xml_manager()
+    csproj_tree = xml_manager.parse(project_csproj_file.read_text(encoding="utf-8"))
+
+    last_item_group = csproj_tree.find(".//ItemGroup[last()]")
+    if last_item_group is None:
+        last_item_group = etree.SubElement(csproj_tree.find(".//Project"), "ItemGroup")
+    last_item_group.append(etree.fromstring(f'<ProjectReference Include="{library_reference}" />'))
+
+    project_csproj_file.write_text(xml_manager.to_string(csproj_tree), encoding="utf-8")
+
+    _assert_csharp_project_csproj_file_has_library_reference(project_dir, library_dir)
+
+
+def _assert_library_reference_was_removed_from_csharp_project_csproj_file(project_dir: Path, library_dir: Path) -> None:
+    project_csproj_file = container.project_manager().get_csproj_file_path(project_dir)
+
+    xml_manager = container.xml_manager()
+    csproj_tree = xml_manager.parse(project_csproj_file.read_text(encoding="utf-8"))
+
+    library_config = container.project_config_manager().get_project_config(library_dir)
+    library_language = library_config.get("algorithm-language")
+
+    if library_language == "Python":
+        assert not any(str(library_dir) in project_reference.get("Include")
+                       for project_reference in csproj_tree.findall('.//ProjectReference'))
+    else:
+        library_reference = container.library_manager().get_csharp_lean_library_path_for_csproj_file(project_dir,
+                                                                                                     library_dir)
+        assert not any(project_reference.get("Include") == library_reference
+                       for project_reference in csproj_tree.findall('.//ProjectReference'))
+
+
+def test_remove_library_reference_from_python_project() -> None:
+    create_fake_lean_cli_directory()
+
+    project_dir = Path("Python Project")
+    library_dir = Path("Library/Python Library")
+    _add_library_to_project_config(project_dir, library_dir)
+
+    result = CliRunner().invoke(lean, ["library", "remove", str(project_dir), str(library_dir)])
+
+    assert result.exit_code == 0
+
+    _assert_library_reference_was_removed_from_project_config_file(project_dir, library_dir)
+
+
+@pytest.mark.parametrize("project_depth, library_language", [
+    *[(i, QCLanguage.CSharp) for i in range(5)],
+    *[(i, QCLanguage.Python) for i in range(5)],
+])
+def test_remove_library_reference_from_csharp_project(project_depth: int, library_language: QCLanguage) -> None:
+    create_fake_lean_cli_directory_with_subdirectories(project_depth)
+
+    project_dir = Path("/".join(f"Subdir{i}" for i in range(project_depth))) / "CSharp Project"
+    library_dir = Path("Library/CSharp Library" if library_language == QCLanguage.CSharp else "Library/Python Library")
+    _add_library_to_project_config(project_dir, library_dir)
+    _add_library_to_csharp_project_csproj_file(project_dir, library_dir)
+
+    result = CliRunner().invoke(lean, ["library", "remove", str(project_dir), str(library_dir), "--no-local"])
+
+    assert result.exit_code == 0
+
+    _assert_library_reference_was_removed_from_project_config_file(project_dir, library_dir)
+    _assert_library_reference_was_removed_from_csharp_project_csproj_file(project_dir, library_dir)
+
+
+@pytest.mark.parametrize("project_dir", [
+    "Non Existing Directory",
+    "CSharp Project/Main.cs",
+    "."
+])
+def test_library_remove_fails_when_project_directory_is_not_valid(project_dir: str) -> None:
+    create_fake_lean_cli_directory()
+
+    result = CliRunner().invoke(lean, ["library", "remove", project_dir, "Library/CSharp Library", "--no-local"])
+
+    assert result.exit_code != 0

--- a/tests/commands/test_backtest.py
+++ b/tests/commands/test_backtest.py
@@ -655,3 +655,33 @@ def test_backtest_ignores_data_purchase_limit_when_not_using_api_data_provider()
     args, _ = lean_runner.run_lean.call_args
 
     assert "data-purchase-limit" not in args[0]
+
+
+def test_backtest_adds_python_libraries_path_to_lean_config() -> None:
+    create_fake_lean_cli_directory()
+
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+    project_path = lean_cli_root_dir / "Python Project"
+    library_path = lean_cli_root_dir / "Library/Python Library"
+
+    library_manager = container.library_manager()
+    library_manager.add_lean_library_to_project(project_path, library_path, False)
+
+    docker_manager = mock.Mock()
+    container.docker_manager.override(providers.Object(docker_manager))
+
+    lean_runner = mock.Mock()
+    container.lean_runner.override(providers.Object(lean_runner))
+
+    result = CliRunner().invoke(lean, ["backtest", str(project_path)])
+
+    assert result.exit_code == 0
+
+    lean_runner.run_lean.assert_called_once()
+    args, _ = lean_runner.run_lean.call_args
+
+    lean_config = args[0]
+    expected_library_path = (Path("/") / library_path.relative_to(lean_cli_root_dir)).as_posix()
+
+    assert expected_library_path in lean_config.get('python-additional-paths')

--- a/tests/commands/test_backtest.py
+++ b/tests/commands/test_backtest.py
@@ -371,29 +371,34 @@ def test_backtest_auto_updates_outdated_python_pycharm_debug_config() -> None:
 def test_backtest_auto_updates_outdated_python_vscode_debug_config() -> None:
     create_fake_lean_cli_directory()
 
+    lean_config_manager = container.lean_config_manager()
+    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
+
     launch_json_path = Path.cwd() / "Python Project" / ".vscode" / "launch.json"
-    _generate_file(launch_json_path, """
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Debug with Lean CLI",
-            "type": "python",
-            "request": "attach",
-            "connect": {
-                "host": "localhost",
-                "port": 5678
-            },
-            "pathMappings": [
-                {
-                    "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "/Lean/Launcher/bin/Debug"
-                }
-            ]
-        }
-    ]
-}
-        """)
+    _generate_file(launch_json_path, json.dumps({
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Debug with Lean CLI",
+                "type": "python",
+                "request": "attach",
+                "connect": {
+                    "host": "localhost",
+                    "port": 5678
+                },
+                "pathMappings": [
+                    {
+                        "localRoot": "${workspaceFolder}",
+                        "remoteRoot": "/Lean/Launcher/bin/Debug"
+                    },
+                    {
+                        "localRoot": str(lean_cli_root_dir / "Library"),
+                        "remoteRoot": "/Library"
+                    }
+                ]
+            }
+        ]
+    }))
 
     docker_manager = mock.Mock()
     container.docker_manager.override(providers.Object(docker_manager))
@@ -419,6 +424,10 @@ def test_backtest_auto_updates_outdated_python_vscode_debug_config() -> None:
             {
                 "localRoot": "${workspaceFolder}",
                 "remoteRoot": "/LeanCLI"
+            },
+            {
+                "localRoot": str(lean_cli_root_dir / "Library"),
+                "remoteRoot": "/Library"
             }
         ]
     }

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -21,6 +21,7 @@ from lean.components.config.output_config_manager import OutputConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.config.storage import Storage
 from lean.components.docker.lean_runner import LeanRunner
+from lean.components.util.path_manager import PathManager
 from lean.components.util.platform_manager import PlatformManager
 from lean.components.util.project_manager import ProjectManager
 from lean.components.util.temp_manager import TempManager
@@ -56,7 +57,14 @@ def create_lean_runner(docker_manager: mock.Mock) -> LeanRunner:
     module_manager.get_installed_packages.return_value = [NuGetPackage(name="QuantConnect.Brokerages", version="1.0.0")]
 
     xml_manager = XMLManager()
-    project_manager = ProjectManager(project_config_manager, lean_config_manager, xml_manager, PlatformManager())
+    platform_manager = PlatformManager()
+    path_manager = PathManager(platform_manager)
+    project_manager = ProjectManager(logger,
+                                     project_config_manager,
+                                     lean_config_manager,
+                                     path_manager,
+                                     xml_manager,
+                                     platform_manager)
 
     return LeanRunner(logger,
                       project_config_manager,

--- a/tests/components/util/test_library_manager.py
+++ b/tests/components/util/test_library_manager.py
@@ -39,9 +39,20 @@ def _create_library_manager() -> LibraryManager:
     path_manager = PathManager(platform_manager)
     xml_manager = mock.Mock()
     project_config_manager = ProjectConfigManager(xml_manager)
-    project_manager = ProjectManager(project_config_manager, lean_config_manager, xml_manager, platform_manager)
+    logger = mock.Mock()
+    project_manager = ProjectManager(logger,
+                                     project_config_manager,
+                                     lean_config_manager,
+                                     path_manager,
+                                     xml_manager,
+                                     platform_manager)
 
-    return LibraryManager(project_manager, project_config_manager, lean_config_manager, path_manager)
+    return LibraryManager(logger,
+                          project_manager,
+                          project_config_manager,
+                          lean_config_manager,
+                          path_manager,
+                          xml_manager)
 
 
 def _project_has_library_reference_in_config(project_dir: Path, library_dir: Path) -> bool:

--- a/tests/components/util/test_library_manager.py
+++ b/tests/components/util/test_library_manager.py
@@ -1,0 +1,84 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from lean.components.config.lean_config_manager import LeanConfigManager
+from lean.components.config.storage import Storage
+from lean.components.util.library_manager import LibraryManager
+from lean.components.util.path_manager import PathManager
+from lean.components.util.platform_manager import PlatformManager
+from tests.test_helpers import create_fake_lean_cli_directory
+
+
+def _create_library_manager() -> LibraryManager:
+    cache_storage = Storage(str(Path("~/.lean/cache").expanduser()))
+    lean_config_manager = LeanConfigManager(mock.Mock(),
+                                            mock.Mock(),
+                                            mock.Mock(),
+                                            mock.Mock(),
+                                            cache_storage)
+    path_manager = PathManager(PlatformManager())
+
+    return LibraryManager(mock.Mock(), lean_config_manager, path_manager)
+
+
+@pytest.mark.parametrize("path, expected_result", [
+    (Path("Library/Python Library"), True),
+    (Path("Library/CSharp Library"), True),
+    (Path("Python Project"), False),
+    (Path("CSharp Project"), False),
+    (Path("Library/Python Library/main.py"), False),
+    (Path("NonExistingDirectory"), False)
+])
+def test_is_lean_library_returns_true_when_path_is_a_library_directory(path: Path, expected_result: bool) -> None:
+    create_fake_lean_cli_directory()
+
+    library_manager = _create_library_manager()
+    result = library_manager.is_lean_library(Path.cwd() / path)
+
+    assert result == expected_result
+
+
+@pytest.mark.parametrize("project_depth", range(1, 11))
+def test_get_csharp_lean_library_path_for_csproj_file(project_depth: int) -> None:
+    create_fake_lean_cli_directory()
+
+    library_dir_relative_to_cli = Path("Library/CSharp Library")
+    library_dir = Path.cwd() / library_dir_relative_to_cli
+    project_dir = Path.cwd() / Path("/".join([f"Subdir{i}" for i in range(project_depth)])) / "CSharp Project"
+
+    library_manager = _create_library_manager()
+    csproj_file_path = library_manager.get_csharp_lean_library_path_for_csproj_file(project_dir, library_dir)
+
+    # 'csproj_file_path' should contain:
+    # ('project_depth' + 1) ../ parts (to go from the project dir to the cli root dir),
+    # plus 'Library/CSharp Library/CSharp Project.csproj' (2 more parts),
+    # plus the csproj file name (1 more part)
+    expected_csproj_file_path = \
+        Path("/".join(".." for i in range(project_depth + 1))) / library_dir_relative_to_cli / "CSharp Library.csproj"
+    assert csproj_file_path == expected_csproj_file_path
+
+
+def test_get_library_path_for_project_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    library_dir = Path.cwd() / "Library" / "CSharp Library"
+
+    library_manager = _create_library_manager()
+    library_reference = library_manager.get_library_path_for_project_config_file(library_dir)
+
+    assert library_reference == library_dir.relative_to(Path.cwd())

--- a/tests/components/util/test_library_manager.py
+++ b/tests/components/util/test_library_manager.py
@@ -21,6 +21,7 @@ from lean.components.config.storage import Storage
 from lean.components.util.library_manager import LibraryManager
 from lean.components.util.path_manager import PathManager
 from lean.components.util.platform_manager import PlatformManager
+from lean.components.util.project_manager import ProjectManager
 from tests.test_helpers import create_fake_lean_cli_directory
 
 
@@ -31,9 +32,12 @@ def _create_library_manager() -> LibraryManager:
                                             mock.Mock(),
                                             mock.Mock(),
                                             cache_storage)
-    path_manager = PathManager(PlatformManager())
+    platform_manager = PlatformManager()
+    path_manager = PathManager(platform_manager)
+    project_config_manager = mock.Mock()
+    project_manager = ProjectManager(project_config_manager, lean_config_manager, mock.Mock(), platform_manager)
 
-    return LibraryManager(mock.Mock(), lean_config_manager, path_manager)
+    return LibraryManager(project_manager, project_config_manager, lean_config_manager, path_manager)
 
 
 @pytest.mark.parametrize("path, expected_result", [
@@ -53,7 +57,7 @@ def test_is_lean_library_returns_true_when_path_is_a_library_directory(path: Pat
     assert result == expected_result
 
 
-@pytest.mark.parametrize("project_depth", range(1, 11))
+@pytest.mark.parametrize("project_depth", range(5))
 def test_get_csharp_lean_library_path_for_csproj_file(project_depth: int) -> None:
     create_fake_lean_cli_directory()
 

--- a/tests/components/util/test_project_manager.py
+++ b/tests/components/util/test_project_manager.py
@@ -23,6 +23,7 @@ from lxml import etree
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.config.storage import Storage
+from lean.components.util.path_manager import PathManager
 from lean.components.util.platform_manager import PlatformManager
 from lean.components.util.project_manager import ProjectManager
 from lean.components.util.xml_manager import XMLManager
@@ -31,18 +32,23 @@ from tests.test_helpers import create_fake_lean_cli_directory
 
 
 def _create_project_manager() -> ProjectManager:
+    logger = mock.Mock()
     xml_manager = XMLManager()
     project_config_manager = ProjectConfigManager(xml_manager)
     cache_storage = Storage(str(Path("~/.lean/cache").expanduser()))
+    platform_manager = PlatformManager()
+    path_manager = PathManager(platform_manager)
 
-    return ProjectManager(project_config_manager,
+    return ProjectManager(logger,
+                          project_config_manager,
                           LeanConfigManager(mock.Mock(),
                                             mock.Mock(),
                                             project_config_manager,
                                             mock.Mock(),
                                             cache_storage),
+                          path_manager,
                           xml_manager,
-                          PlatformManager())
+                          platform_manager)
 
 
 def test_find_algorithm_file_returns_input_when_input_is_file() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from lean.commands.create_project import (DEFAULT_CSHARP_MAIN, DEFAULT_CSHARP_NOTEBOOK, DEFAULT_PYTHON_MAIN,
                                           DEFAULT_PYTHON_NOTEBOOK, LIBRARY_PYTHON_MAIN, LIBRARY_CSHARP_MAIN)
+from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCLanguage, QCLiveResults, QCProject, QCFullOrganization, \
     QCOrganizationData, QCOrganizationCredit, QCNode, QCNodeList, QCNodePrice
 
@@ -40,21 +41,7 @@ def _get_csharp_project_files(path: Path) -> dict:
             "algorithm-language": "CSharp",
             "parameters": {}
         }),
-        (path / "CSharp Project.csproj"): """
-        <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup>
-                <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                <TargetFramework>net6.0</TargetFramework>
-                <OutputPath>bin/$(Configuration)</OutputPath>
-                <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-                <NoWarn>CS0618</NoWarn>
-            </PropertyGroup>
-            <ItemGroup>
-                <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
-            </ItemGroup>
-        </Project>
-            """
+        (path / "CSharp Project.csproj"): ProjectManager.get_csproj_file_default_content()
     }
 
 
@@ -74,21 +61,8 @@ def _get_fake_libraries() -> dict:
             "algorithm-language": "CSharp",
             "parameters": {}
         }),
-        (Path.cwd() / "Library" / "CSharp Library" / "CSharp Library.csproj"): """
-    <Project Sdk="Microsoft.NET.Sdk">
-        <PropertyGroup>
-            <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-            <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-            <TargetFramework>net6.0</TargetFramework>
-            <OutputPath>bin/$(Configuration)</OutputPath>
-            <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-            <NoWarn>CS0618</NoWarn>
-        </PropertyGroup>
-        <ItemGroup>
-            <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
-        </ItemGroup>
-    </Project>
-        """
+        (Path.cwd() / "Library" / "CSharp Library" / "CSharp Library.csproj"):
+            ProjectManager.get_csproj_file_default_content()
     }
 
 
@@ -160,6 +134,7 @@ def create_api_project(id: int, name: str) -> QCProject:
         liveResults=QCLiveResults(eStatus="Unknown"),
         libraries=[]
     )
+
 
 def create_api_organization() -> QCFullOrganization:
     return QCFullOrganization(id="1",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,44 +21,45 @@ from lean.models.api import QCLanguage, QCLiveResults, QCProject, QCFullOrganiza
     QCOrganizationData, QCOrganizationCredit, QCNode, QCNodeList, QCNodePrice
 
 
-def create_fake_lean_cli_directory() -> None:
-    """Creates a directory structure similar to the one created by `lean init` with a Python and a C# project."""
-    (Path.cwd() / "data").mkdir()
-
-    files = {
-        (Path.cwd() / "lean.json"): """
-{
-    // data-folder documentation
-    "data-folder": "data"
-}
-        """,
-        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonProject"),
-        (Path.cwd() / "Python Project" / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
-        (Path.cwd() / "Python Project" / "config.json"): json.dumps({
+def _get_python_project_files(path: Path) -> dict:
+    return {
+        (path / "main.py"): DEFAULT_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonProject"),
+        (path / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
+        (path / "config.json"): json.dumps({
             "algorithm-language": "Python",
             "parameters": {}
         }),
-        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$CLASS_NAME$", "CSharpProject"),
-        (Path.cwd() / "CSharp Project" / "research.ipynb"): DEFAULT_CSHARP_NOTEBOOK,
-        (Path.cwd() / "CSharp Project" / "config.json"): json.dumps({
+    }
+
+
+def _get_csharp_project_files(path: Path) -> dict:
+    return {
+        (path / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$CLASS_NAME$", "CSharpProject"),
+        (path / "research.ipynb"): DEFAULT_CSHARP_NOTEBOOK,
+        (path / "config.json"): json.dumps({
             "algorithm-language": "CSharp",
             "parameters": {}
         }),
-        (Path.cwd() / "CSharp Project" / "CSharp Project.csproj"): """
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <TargetFramework>net6.0</TargetFramework>
-        <OutputPath>bin/$(Configuration)</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <NoWarn>CS0618</NoWarn>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
-    </ItemGroup>
-</Project>
-        """,
+        (path / "CSharp Project.csproj"): """
+        <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+                <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                <TargetFramework>net6.0</TargetFramework>
+                <OutputPath>bin/$(Configuration)</OutputPath>
+                <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                <NoWarn>CS0618</NoWarn>
+            </PropertyGroup>
+            <ItemGroup>
+                <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
+            </ItemGroup>
+        </Project>
+            """
+    }
+
+
+def _get_fake_libraries() -> dict:
+    return {
         (Path.cwd() / "Library" / "Python Library" / "main.py"):
             LIBRARY_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonLibrary"),
         (Path.cwd() / "Library" / "Python Library" / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
@@ -74,26 +75,72 @@ def create_fake_lean_cli_directory() -> None:
             "parameters": {}
         }),
         (Path.cwd() / "Library" / "CSharp Library" / "CSharp Library.csproj"): """
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <TargetFramework>net6.0</TargetFramework>
-        <OutputPath>bin/$(Configuration)</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <NoWarn>CS0618</NoWarn>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
-    </ItemGroup>
-</Project>
+    <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+            <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+            <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+            <TargetFramework>net6.0</TargetFramework>
+            <OutputPath>bin/$(Configuration)</OutputPath>
+            <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+            <NoWarn>CS0618</NoWarn>
+        </PropertyGroup>
+        <ItemGroup>
+            <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
+        </ItemGroup>
+    </Project>
         """
     }
 
+
+def _write_fake_directory(files: dict) -> None:
     for path, content in files.items():
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w+") as file:
             file.write(content)
+
+
+def create_fake_lean_cli_directory() -> None:
+    """Creates a directory structure similar to the one created by `lean init` with a Python and a C# project,
+    and a Python and a C# library"""
+    (Path.cwd() / "data").mkdir()
+
+    files = {
+        (Path.cwd() / "lean.json"): """
+{
+    // data-folder documentation
+    "data-folder": "data"
+}
+        """,
+        **_get_python_project_files(Path.cwd() / "Python Project"),
+        **_get_csharp_project_files(Path.cwd() / "CSharp Project"),
+        **_get_fake_libraries()
+    }
+
+    _write_fake_directory(files)
+
+
+def create_fake_lean_cli_directory_with_subdirectories(depth: int) -> None:
+    """Creates a directory structure similar to the one created by `lean init` with a Python and a C# project,
+    and a Python and a C# library"""
+    (Path.cwd() / "data").mkdir()
+
+    sub_dirs = Path('/'.join([f"Subdir{i}" for i in range(depth)]))
+    python_project_dir = Path.cwd() / sub_dirs / "Python Project"
+    csharp_project_dir = Path.cwd() / sub_dirs / "CSharp Project"
+
+    files = {
+        (Path.cwd() / "lean.json"): """
+{
+    // data-folder documentation
+    "data-folder": "data"
+}
+        """,
+        **_get_python_project_files(python_project_dir),
+        **_get_csharp_project_files(csharp_project_dir),
+        **_get_fake_libraries()
+    }
+
+    _write_fake_directory(files)
 
 
 def create_api_project(id: int, name: str) -> QCProject:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from pathlib import Path
 
 from lean.commands.create_project import (DEFAULT_CSHARP_MAIN, DEFAULT_CSHARP_NOTEBOOK, DEFAULT_PYTHON_MAIN,
-                                          DEFAULT_PYTHON_NOTEBOOK)
+                                          DEFAULT_PYTHON_NOTEBOOK, LIBRARY_PYTHON_MAIN, LIBRARY_CSHARP_MAIN)
 from lean.models.api import QCLanguage, QCLiveResults, QCProject, QCFullOrganization, \
     QCOrganizationData, QCOrganizationCredit, QCNode, QCNodeList, QCNodePrice
 
@@ -32,19 +32,48 @@ def create_fake_lean_cli_directory() -> None:
     "data-folder": "data"
 }
         """,
-        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$NAME$", "PythonProject"),
+        (Path.cwd() / "Python Project" / "main.py"): DEFAULT_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonProject"),
         (Path.cwd() / "Python Project" / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
         (Path.cwd() / "Python Project" / "config.json"): json.dumps({
             "algorithm-language": "Python",
             "parameters": {}
         }),
-        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$NAME$", "CSharpProject"),
+        (Path.cwd() / "CSharp Project" / "Main.cs"): DEFAULT_CSHARP_MAIN.replace("$CLASS_NAME$", "CSharpProject"),
         (Path.cwd() / "CSharp Project" / "research.ipynb"): DEFAULT_CSHARP_NOTEBOOK,
         (Path.cwd() / "CSharp Project" / "config.json"): json.dumps({
             "algorithm-language": "CSharp",
             "parameters": {}
         }),
         (Path.cwd() / "CSharp Project" / "CSharp Project.csproj"): """
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <TargetFramework>net6.0</TargetFramework>
+        <OutputPath>bin/$(Configuration)</OutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <NoWarn>CS0618</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="QuantConnect.Lean" Version="2.5.11940" />
+    </ItemGroup>
+</Project>
+        """,
+        (Path.cwd() / "Library" / "Python Library" / "main.py"):
+            LIBRARY_PYTHON_MAIN.replace("$CLASS_NAME$", "PythonLibrary"),
+        (Path.cwd() / "Library" / "Python Library" / "research.ipynb"): DEFAULT_PYTHON_NOTEBOOK,
+        (Path.cwd() / "Library" / "Python Library" / "config.json"): json.dumps({
+            "algorithm-language": "Python",
+            "parameters": {}
+        }),
+        (Path.cwd() / "Library" / "CSharp Library" / "Main.cs"):
+            LIBRARY_CSHARP_MAIN.replace("$CLASS_NAME$", "CSharpLibrary"),
+        (Path.cwd() / "Library" / "CSharp Library" / "research.ipynb"): DEFAULT_CSHARP_NOTEBOOK,
+        (Path.cwd() / "Library" / "CSharp Library" / "config.json"): json.dumps({
+            "algorithm-language": "CSharp",
+            "parameters": {}
+        }),
+        (Path.cwd() / "Library" / "CSharp Library" / "CSharp Library.csproj"): """
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -139,5 +168,5 @@ def create_qc_nodes() -> QCNodeList:
         ram=0.2,
         assets=3
     )]
-    
+
     return QCNodeList(backtest=backtest, research=research, live=live)


### PR DESCRIPTION
- Adding/removing Lean CLI library projects to/from algorithm projects.
- Library reference synchronization with cloud projects on push/pull:
  - Adding and removing libraries to projects locally when they have been added or removed in the cloud on `pull`.
  - Adding and removing libraries to projects in the cloud when they have been added or removed locally on `push`.
- C#:
  - Adding library reference to project's .csproj file.
  - Mounting /Library volume in container to compile libraries with the project.
- Python:
  - Adding libraries and `/Library` paths to Python path (through Lean config file) so algorithms can use libraries at runtime.
  - Note: no longer using use site file (`lean-cli.pth`) to include `/Library` in Python path on backtest. Using Lean config file `python-additional-paths` instead.
- Common:
  - Adding libraries references in project's `config.json` file to keep track of them locally.