### PR TITLE
Rename project create and delete commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ A locally-focused workflow (local development, local execution) with the CLI may
 - [`lean logout`](#lean-logout)
 - [`lean logs`](#lean-logs)
 - [`lean optimize`](#lean-optimize)
+- [`lean project-create`](#lean-project-create)
+- [`lean project-delete`](#lean-project-delete)
 - [`lean report`](#lean-report)
 - [`lean research`](#lean-research)
 - [`lean whoami`](#lean-whoami)
@@ -532,7 +534,7 @@ _See code: [lean/commands/config/unset.py](lean/commands/config/unset.py)_
 
 ### `lean create-project`
 
-Create a new project containing starter code.
+Alias for 'project-create'
 
 ```
 Usage: lean create-project [OPTIONS] NAME
@@ -638,7 +640,7 @@ _See code: [lean/commands/data/generate.py](lean/commands/data/generate.py)_
 
 ### `lean delete-project`
 
-Delete a project locally and in the cloud if it exists.
+Alias for 'project-delete'
 
 ```
 Usage: lean delete-project [OPTIONS] PROJECT
@@ -1189,6 +1191,45 @@ Options:
 ```
 
 _See code: [lean/commands/optimize.py](lean/commands/optimize.py)_
+
+### `lean project-create`
+
+Create a new project containing starter code.
+
+```
+Usage: lean project-create [OPTIONS] NAME
+
+  Create a new project containing starter code.
+
+  If NAME is a path containing subdirectories those will be created automatically.
+
+  The default language can be set using `lean config set default-language python/csharp`.
+
+Options:
+  -l, --language [python|csharp]  The language of the project to create
+  --verbose                       Enable debug logging
+  --help                          Show this message and exit.
+```
+
+_See code: [lean/commands/project_create.py](lean/commands/project_create.py)_
+
+### `lean project-delete`
+
+Delete a project locally and in the cloud if it exists.
+
+```
+Usage: lean project-delete [OPTIONS] PROJECT
+
+  Delete a project locally and in the cloud if it exists.
+
+  The project is selected by name or cloud id.
+
+Options:
+  --verbose  Enable debug logging
+  --help     Show this message and exit.
+```
+
+_See code: [lean/commands/project_delete.py](lean/commands/project_delete.py)_
 
 ### `lean report`
 

--- a/lean/commands/__init__.py
+++ b/lean/commands/__init__.py
@@ -11,9 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
-
-from lean import __version__
+from lean.commands.lean import lean
 from lean.commands.backtest import backtest
 from lean.commands.build import build
 from lean.commands.cloud import cloud
@@ -31,16 +29,6 @@ from lean.commands.optimize import optimize
 from lean.commands.report import report
 from lean.commands.research import research
 from lean.commands.whoami import whoami
-
-
-@click.group()
-@click.version_option(__version__)
-def lean() -> None:
-    """The Lean CLI by QuantConnect."""
-    # This method is intentionally empty
-    # It is used as the command group for all `lean <command>` commands
-    pass
-
 
 lean.add_command(config)
 lean.add_command(cloud)

--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -13,7 +13,9 @@
 
 from pathlib import Path
 import click
+
 from lean.click import LeanCommand
+from lean.commands import lean
 from lean.container import container
 from lean.models.api import QCLanguage
 from lean.models.errors import MoreInfoError
@@ -260,7 +262,7 @@ DEFAULT_CSHARP_NOTEBOOK = """
 """.strip() + "\n"
 
 
-@click.command(cls=LeanCommand)
+@lean.command(cls=LeanCommand, name="project-create", aliases=["create-project"])
 @click.argument("name", type=str)
 @click.option("--language", "-l",
               type=click.Choice(container.cli_config_manager().default_language.allowed_values, case_sensitive=False),

--- a/lean/commands/delete_project.py
+++ b/lean/commands/delete_project.py
@@ -16,10 +16,11 @@ from pathlib import Path
 import click
 
 from lean.click import LeanCommand
+from lean.commands import lean
 from lean.container import container
 
 
-@click.command(cls=LeanCommand)
+@lean.command(cls=LeanCommand, name="project-delete", aliases=["delete-project"])
 @click.argument("project", type=str)
 def delete_project(project: str) -> None:
     """Delete a project locally and in the cloud if it exists.

--- a/lean/commands/lean.py
+++ b/lean/commands/lean.py
@@ -14,7 +14,7 @@
 import click
 
 from lean import __version__
-from lean.components.click_aliased_command_group import AliasedCommandGroup
+from lean.components.util.click_aliased_command_group import AliasedCommandGroup
 
 
 @click.group(cls=AliasedCommandGroup)

--- a/lean/commands/lean.py
+++ b/lean/commands/lean.py
@@ -1,0 +1,26 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+from lean import __version__
+from lean.components.click_aliased_command_group import AliasedCommandGroup
+
+
+@click.group(cls=AliasedCommandGroup)
+@click.version_option(__version__)
+def lean() -> None:
+    """The Lean CLI by QuantConnect."""
+    # This method is intentionally empty
+    # It is used as the command group for all `lean <command>` commands
+    pass

--- a/lean/components/click_aliased_command_group.py
+++ b/lean/components/click_aliased_command_group.py
@@ -1,0 +1,49 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+import lean.components.util.logger
+
+
+class AliasedCommandGroup(click.Group):
+    """A click.Group wrapper that implements command aliasing."""
+
+    def command(self, *args, **kwargs):
+        lean.components.util.logger.Logger().info(f"{args}")
+        lean.components.util.logger.Logger().info(f"{kwargs}")
+        aliases = kwargs.pop('aliases', [])
+
+        if not args:
+            cmd_name = kwargs.pop("name", "")
+        else:
+            cmd_name = args[0]
+            args = args[1:]
+
+        alias_help = f"Alias for '{cmd_name}'"
+
+        def _decorator(f):
+            # Add the main command
+            cmd = super(AliasedCommandGroup, self).command(name=cmd_name, *args, **kwargs)(f)
+
+            # Add a command to the group for each alias with the same callback but using the alias as name
+            for alias in aliases:
+                alias_cmd = super(AliasedCommandGroup, self).command(name=alias,
+                                                                     short_help=alias_help,
+                                                                     *args,
+                                                                     **kwargs)(f)
+                alias_cmd.params = cmd.params
+
+            return cmd
+
+        return _decorator

--- a/lean/components/util/click_aliased_command_group.py
+++ b/lean/components/util/click_aliased_command_group.py
@@ -13,15 +13,11 @@
 
 import click
 
-import lean.components.util.logger
-
 
 class AliasedCommandGroup(click.Group):
     """A click.Group wrapper that implements command aliasing."""
 
     def command(self, *args, **kwargs):
-        lean.components.util.logger.Logger().info(f"{args}")
-        lean.components.util.logger.Logger().info(f"{kwargs}")
         aliases = kwargs.pop('aliases', [])
 
         if not args:

--- a/tests/test_click_aliased_command_group.py
+++ b/tests/test_click_aliased_command_group.py
@@ -1,0 +1,82 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from click.testing import CliRunner
+
+from lean.components.util.click_aliased_command_group import AliasedCommandGroup
+
+
+def test_aliased_command_group_takes_named_name_parameter() -> None:
+    @click.command(cls=AliasedCommandGroup)
+    def group() -> None:
+        pass
+
+    @group.command(aliases=["some-other-command"], name="some-command")
+    def command() -> None:
+        pass
+
+    result = CliRunner().invoke(command)
+
+    assert result.exit_code == 0
+
+
+def test_aliased_command_group_takes_positional_name_parameter() -> None:
+    @click.command(cls=AliasedCommandGroup)
+    def group() -> None:
+        pass
+
+    @group.command("some-command", aliases=["some-other-command"])
+    def command() -> None:
+        pass
+
+    result = CliRunner().invoke(command)
+
+    assert result.exit_code == 0
+
+
+def test_aliased_command_group_creates_command_for_each_alias() -> None:
+    @click.command(cls=AliasedCommandGroup)
+    def group() -> None:
+        pass
+
+    command_name = "some-command"
+    aliases = [f"alias-{i}" for i in range(5)]
+    main_command_doc = "some command doc string"
+
+    @group.command(command_name, aliases=aliases, help=main_command_doc)
+    def command() -> None:
+        pass
+
+    command_names = [command_name] + aliases
+    assert len(group.commands) == len(command_names)
+    assert all(name in command_names for name in group.commands.keys())
+
+    result = CliRunner().invoke(group, ["--help"])
+
+    assert result.exit_code == 0
+
+    commands_help = result.output.split("Commands:\n")[-1].split("\n")
+    commands_help = [command_help.strip() for command_help in commands_help]
+    commands_help = [command_help for command_help in commands_help if command_help]
+
+    assert len(commands_help) == len(command_names)
+
+    aliases_help = [command_help
+                    for command_help in commands_help if any(name in command_help for name in aliases)]
+    main_command_help = [command_help
+                         for command_help in commands_help if command_help.strip().startswith(command_name)][0]
+
+    assert len(aliases_help) == len(aliases_help)
+    assert all(f"Alias for '{command_name}'" in alias_help for alias_help in aliases_help)
+    assert main_command_doc in main_command_help


### PR DESCRIPTION
- Rename `create-project` and `remove-project` commands to `project-create` and` project-delete`.
- Kept the old names for backwards compatibility: `project-create` and `create-project` are do the same. Same for remove.
- Created the `AliasedGroupCommand` wrapper to `click.Group` to implement command aliasing.

Closes #169 

