### PR TITLE
Fix bug on getting image in use for logging

### DIFF
--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -344,7 +344,7 @@ def backtest(project: Path,
     project_config = project_config_manager.get_project_config(algorithm_file.parent)
     engine_image = cli_config_manager.get_engine_image(image or project_config.get("engine-image", None))
 
-    if engine_image != DEFAULT_ENGINE_IMAGE:
+    if str(engine_image) != DEFAULT_ENGINE_IMAGE:
         logger.warn(f'A custom engine image: "{engine_image}" is being used!')
 
     container.update_manager().pull_docker_image_if_necessary(engine_image, update)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -457,7 +457,7 @@ def deploy(project: Path,
             "AveragePrice": holding["averagePrice"]
         } for holding in live_holdings]
     
-    if engine_image != DEFAULT_ENGINE_IMAGE:
+    if str(engine_image) != DEFAULT_ENGINE_IMAGE:
         logger.warn(f'A custom engine image: "{engine_image}" is being used!')
     
     lean_runner = container.lean_runner()

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -185,7 +185,7 @@ def optimize(project: Path,
 
     logger = container.logger()
     
-    if engine_image != DEFAULT_ENGINE_IMAGE:
+    if str(engine_image) != DEFAULT_ENGINE_IMAGE:
         logger.warn(f'A custom engine image: "{engine_image}" is being used!')
         
     lean_config_manager = container.lean_config_manager()

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -152,7 +152,7 @@ def research(project: Path,
 
     logger = container.logger()
     
-    if research_image != DEFAULT_RESEARCH_IMAGE:
+    if str(research_image) != DEFAULT_RESEARCH_IMAGE:
         logger.warn(f'A custom research image: "{research_image}" is being used!')
 
     container.update_manager().pull_docker_image_if_necessary(research_image, update)


### PR DESCRIPTION
Minor fix on the custom image usage warning (#185). The current comparison is not based on `str` object. 