### PR TITLE
Restore C# projects on pull

### DIFF
--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -11,64 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import Optional, List
+from typing import Optional
 
 import click
 
 from lean.click import LeanCommand
 from lean.container import container
-from lean.models.api import QCProject
-from lean.models.utils import LeanLibraryReference
-
-
-def _add_local_library_references_to_project(project: QCProject, cloud_libraries: List[QCProject]) -> None:
-    logger = container.logger()
-    library_manager = container.library_manager()
-
-    if len(cloud_libraries) > 0:
-        logger.info(f"Adding/updating local library references to project {project.name}")
-
-    cwd = Path.cwd()
-    project_dir = cwd / project.name
-    for i, library in enumerate(cloud_libraries, start=1):
-        logger.info(f"[{i}/{len(cloud_libraries)}] "
-                    f"Adding/updating local library {library.name} reference to project {project.name}")
-        library_manager.add_lean_library_to_project(project_dir, cwd / library.name, False)
-
-
-def _remove_local_library_references_from_project(project: QCProject, cloud_libraries: List[QCProject]) -> None:
-    logger = container.logger()
-    library_manager = container.library_manager()
-
-    project_dir = Path.cwd() / project.name
-    project_config = container.project_config_manager().get_project_config(project_dir)
-    local_libraries = project_config.get("libraries", [])
-    cloud_library_paths = [Path(library.name) for library in cloud_libraries]
-    libraries_to_remove = [LeanLibraryReference(**library_reference)
-                           for library_reference in local_libraries
-                           if Path(library_reference["path"]) not in cloud_library_paths]
-
-    if len(libraries_to_remove) > 0:
-        logger.info(f"Removing local library references from project {project.name}")
-
-    for i, library_reference in enumerate(libraries_to_remove, start=1):
-        logger.info(f"[{i}/{len(libraries_to_remove)}] "
-                    f"Removing local library {library_reference.name} reference from project {project.name}")
-        library_manager.remove_lean_library_from_project(project_dir, Path.cwd() / library_reference.path, False)
-
-
-def _update_local_library_references(projects: List[QCProject]) -> None:
-    for project in projects:
-        cloud_libraries = [library
-                           for library_id in project.libraries
-                           for library in projects if library.projectId == library_id]
-
-        # Add cloud library references to local config
-        _add_local_library_references_to_project(project, cloud_libraries)
-
-        # Remove library references locally if they were removed in the cloud
-        _remove_local_library_references_from_project(project, cloud_libraries)
 
 
 @click.command(cls=LeanCommand)
@@ -98,6 +46,4 @@ def pull(project: Optional[str], pull_bootcamp: bool) -> None:
         projects_to_pull = [p for p in projects_to_pull if not p.name.startswith("Boot Camp/")]
 
     pull_manager = container.pull_manager()
-    pull_manager.pull_projects(projects_to_pull)
-
-    _update_local_library_references(projects_to_pull)
+    pull_manager.pull_projects(projects_to_pull, all_projects)

--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -17,10 +17,12 @@ from typing import List
 
 from lean.components.api.api_client import APIClient
 from lean.components.config.project_config_manager import ProjectConfigManager
+from lean.components.util.library_manager import LibraryManager
 from lean.components.util.logger import Logger
 from lean.components.util.platform_manager import PlatformManager
 from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCProject, QCLeanEnvironment
+from lean.models.utils import LeanLibraryReference
 
 
 class PullManager:
@@ -31,6 +33,7 @@ class PullManager:
                  api_client: APIClient,
                  project_manager: ProjectManager,
                  project_config_manager: ProjectConfigManager,
+                 library_manager: LibraryManager,
                  platform_manager: PlatformManager) -> None:
         """Creates a new PullManager instance.
 
@@ -38,34 +41,46 @@ class PullManager:
         :param api_client: the APIClient instance to use when communicating with the cloud
         :param project_manager: the ProjectManager instance to use when creating new projects
         :param project_config_manager: the ProjectConfigManager instance to use
+        :param library_manager: the LibraryManager instance to use when updating library references
         :param platform_manager: the PlatformManager used when checking which operating system is in use
         """
         self._logger = logger
         self._api_client = api_client
         self._project_manager = project_manager
         self._project_config_manager = project_config_manager
+        self._library_manager = library_manager
         self._platform_manager = platform_manager
         self._last_file = None
 
-    def pull_projects(self, projects_to_pull: List[QCProject]) -> None:
+    def pull_projects(self, projects_to_pull: List[QCProject], all_cloud_projects: List[QCProject]) -> None:
         """Pulls the given projects from the cloud to the local drive.
 
+        This will also pull libraries referenced by the project.
+
         :param projects_to_pull: the cloud projects that need to be pulled
+        :param all_cloud_projects: all the projects available in the cloud
         """
+        projects_to_pull.extend(self._project_manager.get_cloud_projects_libraries(all_cloud_projects,
+                                                                                   projects_to_pull))
         projects_to_pull = sorted(projects_to_pull, key=lambda p: p.name)
         environments = self._api_client.lean.environments()
+        projects_not_pulled = []
 
         for index, project in enumerate(projects_to_pull, start=1):
             try:
                 self._logger.info(f"[{index}/{len(projects_to_pull)}] Pulling '{project.name}'")
                 self._pull_project(project, environments)
             except Exception as ex:
+                projects_not_pulled.append(project)
                 self._logger.debug(traceback.format_exc().strip())
                 if self._last_file is not None:
                     self._logger.warn(
                         f"Cannot pull '{project.name}' (id {project.projectId}, failed on {self._last_file}): {ex}")
                 else:
                     self._logger.warn(f"Cannot pull '{project.name}' (id {project.projectId}): {ex}")
+
+        self._update_local_library_references([project for project in projects_to_pull
+                                               if project not in projects_not_pulled])
 
     def _pull_project(self, project: QCProject, environments: List[QCLeanEnvironment]) -> None:
         """Pulls a single project from the cloud to the local drive.
@@ -203,3 +218,48 @@ class PullManager:
             cloud_path = "/".join(new_components)
 
         return cloud_path
+
+    def _add_local_library_references_to_project(self, project: QCProject, cloud_libraries: List[QCProject]) -> None:
+        if len(cloud_libraries) > 0:
+            self._logger.info(f"Adding/updating local library references to project {project.name}")
+
+        cwd = Path.cwd()
+        project_dir = cwd / project.name
+        for i, library in enumerate(cloud_libraries, start=1):
+            self._logger.info(f"[{i}/{len(cloud_libraries)}] "
+                        f"Adding/updating local library {library.name} reference to project {project.name}")
+            self._library_manager.add_lean_library_to_project(project_dir, cwd / library.name, False)
+
+    def _remove_local_library_references_from_project(self,
+                                                      project: QCProject,
+                                                      cloud_libraries: List[QCProject]) -> None:
+
+        project_dir = Path.cwd() / project.name
+        project_config = self._project_config_manager.get_project_config(project_dir)
+        local_libraries = project_config.get("libraries", [])
+        cloud_library_paths = [Path(library.name) for library in cloud_libraries]
+        libraries_to_remove = [LeanLibraryReference(**library_reference)
+                               for library_reference in local_libraries
+                               if Path(library_reference["path"]) not in cloud_library_paths]
+
+        if len(libraries_to_remove) > 0:
+            self._logger.info(f"Removing local library references from project {project.name}")
+
+        for i, library_reference in enumerate(libraries_to_remove, start=1):
+            self._logger.info(f"[{i}/{len(libraries_to_remove)}] "
+                        f"Removing local library {library_reference.name} reference from project {project.name}")
+            self._library_manager.remove_lean_library_from_project(project_dir,
+                                                                   Path.cwd() / library_reference.path,
+                                                                   False)
+
+    def _update_local_library_references(self, projects: List[QCProject]) -> None:
+        for project in projects:
+            cloud_libraries = [library
+                               for library_id in project.libraries
+                               for library in projects if library.projectId == library_id]
+
+            # Add cloud library references to local config
+            self._add_local_library_references_to_project(project, cloud_libraries)
+
+            # Remove library references locally if they were removed in the cloud
+            self._remove_local_library_references_from_project(project, cloud_libraries)

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -183,12 +183,9 @@ class ProjectManager:
                                    project: Optional[Union[str, int]]) -> List[QCProject]:
         """Returns a list of all the projects in the cloud that match the given name or id.
 
-        This will also return all the libraries referenced by the project.
-
         :param cloud_projects: all projects fetched from the cloud
         :param project: the name or id of the project
-        :return: a list of all the projects in the cloud that match the given name or id,
-                 including the libraries they might reference
+        :return: a list of all the projects in the cloud that match the given name or id
         """
         search_by_id = isinstance(project, int)
 
@@ -200,8 +197,6 @@ class ProjectManager:
 
             if len(projects) == 0:
                 raise RuntimeError("No project with the given name or id exists in the cloud")
-
-            projects.extend(self._get_cloud_projects_libraries(cloud_projects, projects))
         else:
             projects = cloud_projects
 
@@ -624,10 +619,10 @@ class ProjectManager:
 
         return directories
 
-    def _get_cloud_project_libraries(self,
-                                     cloud_projects: List[QCProject],
-                                     project: QCProject,
-                                     seen_libraries: List[int] = None) -> List[QCProject]:
+    def get_cloud_project_libraries(self,
+                                    cloud_projects: List[QCProject],
+                                    project: QCProject,
+                                    seen_libraries: List[int] = None) -> List[QCProject]:
         """Gets the libraries referenced by the project and its dependencies from the given cloud projects.
 
         It recursively gets every Lean CLI library referenced by the project
@@ -651,16 +646,16 @@ class ProjectManager:
                 continue
 
             seen_libraries.append(library.projectId)
-            referenced_libraries.extend(self._get_cloud_project_libraries(cloud_projects, library, seen_libraries))
+            referenced_libraries.extend(self.get_cloud_project_libraries(cloud_projects, library, seen_libraries))
 
         libraries.extend(referenced_libraries)
 
         return list(set(libraries))
 
-    def _get_cloud_projects_libraries(self,
-                                      cloud_projects: List[QCProject],
-                                      projects: List[QCProject],
-                                      seen_projects: List[int] = None) -> List[QCProject]:
+    def get_cloud_projects_libraries(self,
+                                     cloud_projects: List[QCProject],
+                                     projects: List[QCProject],
+                                     seen_projects: List[int] = None) -> List[QCProject]:
         """Gets the libraries referenced by the passed projects and its dependencies from the given cloud projects.
 
         It recursively gets every Lean CLI library referenced by the passed projects
@@ -675,7 +670,7 @@ class ProjectManager:
 
         libraries = []
         for project in projects:
-            libraries.extend(self._get_cloud_project_libraries(cloud_projects, project, seen_projects))
+            libraries.extend(self.get_cloud_project_libraries(cloud_projects, project, seen_projects))
 
         return list(set(libraries))
 

--- a/lean/container.py
+++ b/lean/container.py
@@ -96,7 +96,13 @@ class Container(DeclarativeContainer):
                                 xml_manager)
 
     cloud_runner = Singleton(CloudRunner, logger, api_client, task_manager)
-    pull_manager = Singleton(PullManager, logger, api_client, project_manager, project_config_manager, platform_manager)
+    pull_manager = Singleton(PullManager,
+                             logger,
+                             api_client,
+                             project_manager,
+                             project_config_manager,
+                             library_manager,
+                             platform_manager)
     push_manager = Singleton(PushManager, logger, api_client, project_manager, project_config_manager)
     data_downloader = Singleton(DataDownloader, logger, api_client, lean_config_manager)
     cloud_project_manager = Singleton(CloudProjectManager,

--- a/tests/commands/cloud/test_pull.py
+++ b/tests/commands/cloud/test_pull.py
@@ -11,15 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import Tuple, List
 from unittest import mock
 
 from click.testing import CliRunner
 from dependency_injector import providers
 
 from lean.commands import lean
-from lean.components.cloud.pull_manager import PullManager
 from lean.container import container
 from tests.test_helpers import create_api_project, create_fake_lean_cli_directory
 

--- a/tests/commands/cloud/test_pull.py
+++ b/tests/commands/cloud/test_pull.py
@@ -21,26 +21,7 @@ from dependency_injector import providers
 from lean.commands import lean
 from lean.components.cloud.pull_manager import PullManager
 from lean.container import container
-from lean.models.api import QCProject
 from tests.test_helpers import create_api_project, create_fake_lean_cli_directory
-
-
-def _make_cloud_projects_and_libraries(project_count: int, library_count: int) -> Tuple[List[QCProject], List[QCProject]]:
-    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, project_count + 1)]
-    libraries = [create_api_project(i, f"Library/Library {i - project_count}")
-                 for i in range(project_count + 1, project_count + library_count + 1)]
-
-    return cloud_projects, libraries
-
-
-def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject]) -> None:
-    libraries_ids = [library.projectId for library in libraries]
-    project.libraries.extend(libraries_ids)
-
-
-def _add_local_library_to_local_project(project_path: Path, library_path: Path) -> None:
-    library_manager = container.library_manager()
-    library_manager.add_lean_library_to_project(project_path, library_path, False)
 
 
 def test_cloud_pull_pulls_all_non_bootcamp_projects_when_no_options_given() -> None:
@@ -63,7 +44,7 @@ def test_cloud_pull_pulls_all_non_bootcamp_projects_when_no_options_given() -> N
 
     assert result.exit_code == 0
 
-    pull_manager.pull_projects.assert_called_once_with(cloud_projects[:3])
+    pull_manager.pull_projects.assert_called_once_with(cloud_projects[:3], cloud_projects)
 
 
 def test_cloud_pull_pulls_all_projects_when_pull_bootcamp_option_given() -> None:
@@ -86,7 +67,7 @@ def test_cloud_pull_pulls_all_projects_when_pull_bootcamp_option_given() -> None
 
     assert result.exit_code == 0
 
-    pull_manager.pull_projects.assert_called_once_with(cloud_projects)
+    pull_manager.pull_projects.assert_called_once_with(cloud_projects, cloud_projects)
 
 
 def test_cloud_pull_pulls_project_by_id() -> None:
@@ -109,7 +90,7 @@ def test_cloud_pull_pulls_project_by_id() -> None:
 
     assert result.exit_code == 0
 
-    pull_manager.pull_projects.assert_called_once_with([cloud_projects[0]])
+    pull_manager.pull_projects.assert_called_once_with([cloud_projects[0]], cloud_projects)
 
 
 def test_cloud_pull_pulls_project_by_name() -> None:
@@ -132,7 +113,7 @@ def test_cloud_pull_pulls_project_by_name() -> None:
 
     assert result.exit_code == 0
 
-    pull_manager.pull_projects.assert_called_once_with([cloud_projects[0]])
+    pull_manager.pull_projects.assert_called_once_with([cloud_projects[0]], cloud_projects)
 
 
 def test_cloud_pull_aborts_when_project_input_matches_no_cloud_projects() -> None:
@@ -156,170 +137,3 @@ def test_cloud_pull_aborts_when_project_input_matches_no_cloud_projects() -> Non
     assert result.exit_code != 0
 
     pull_manager.pull_projects.assert_not_called()
-
-
-def test_cloud_pull_updates_lean_config() -> None:
-    create_fake_lean_cli_directory()
-
-    def my_side_effect(*args, **kwargs):
-        return True
-
-    cloud_projects = [create_api_project(1, "Project 1")]
-
-    api_client = mock.Mock()
-    api_client.projects.get_all.return_value = cloud_projects
-    container.api_client.override(providers.Object(api_client))
-
-    project_config = mock.Mock()
-
-    project_config_manager = mock.Mock()
-    project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
-
-    project_manager = mock.Mock()
-    project_manager.get_source_files = mock.MagicMock(return_value=[])
-
-    platform_manager = mock.Mock()
-    container.platform_manager.override(providers.Object(platform_manager))
-
-    pull_manager = PullManager(mock.Mock(), api_client, project_manager, project_config_manager, platform_manager)
-    container.pull_manager.override(providers.Object(pull_manager))
-
-    pull_manager.get_local_project_path = mock.MagicMock(side_effect=my_side_effect)
-    pull_manager._pull_files = mock.MagicMock(side_effect=my_side_effect)
-
-    result = CliRunner().invoke(lean, ["cloud", "pull", "--project", "1"])
-
-    assert result.exit_code == 0
-
-    project_config.set.assert_called_with("organization-id", "123")
-
-
-def test_pull_pulls_libraries_referenced_by_the_project() -> None:
-    create_fake_lean_cli_directory()
-
-    cloud_projects, libraries = _make_cloud_projects_and_libraries(3, 5)
-    cloud_projects.extend(libraries)
-
-    test_project = cloud_projects[0]
-    test_project_libraries = libraries[:2]
-    _add_libraries_to_cloud_project(test_project, test_project_libraries)
-
-    test_library = test_project_libraries[0]
-    test_library_library = libraries[2]
-    _add_libraries_to_cloud_project(test_library, [test_library_library])
-
-    api_client = mock.Mock()
-    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
-    api_client.files.get_all = mock.MagicMock(return_value=[])
-    container.api_client.override(providers.Object(api_client))
-
-    library_manager = mock.Mock()
-    library_manager.add_lean_library_to_project = mock.Mock()
-    library_manager.remove_lean_library_from_project = mock.Mock()
-    container.library_manager.override(providers.Object(library_manager))
-
-    result = CliRunner().invoke(lean, ["cloud", "pull", "--project", test_project.projectId])
-
-    assert result.exit_code == 0
-
-    api_client.projects.get_all.assert_called_once()
-    api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries] +
-        [mock.call(library_id) for library_id in test_library.libraries],
-        any_order=True)
-
-    lean_config_manager = container.lean_config_manager()
-    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
-
-    library_manager.add_lean_library_to_project.assert_has_calls(
-        [mock.call(lean_cli_root_dir / test_project.name, lean_cli_root_dir / library.name, False)
-         for library in test_project_libraries] +
-        [mock.call(lean_cli_root_dir / test_library.name, lean_cli_root_dir / test_library_library.name, False)],
-        any_order=True)
-    library_manager.remove_lean_library_from_project.assert_not_called()
-
-
-def test_pull_removes_library_references() -> None:
-    create_fake_lean_cli_directory()
-
-    cloud_projects, libraries = _make_cloud_projects_and_libraries(3, 5)
-    cloud_projects.extend(libraries)
-
-    test_project = create_api_project(1000, "Python Project")
-    cloud_projects.append(test_project)
-
-    lean_config_manager = container.lean_config_manager()
-    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
-
-    # Add library reference to local project to test its removal
-    project_path = lean_cli_root_dir / "Python Project"
-    library_path = lean_cli_root_dir / "Library" / "Python Library"
-    _add_local_library_to_local_project(project_path, library_path)
-
-    api_client = mock.Mock()
-    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
-    api_client.files.get_all = mock.MagicMock(return_value=[])
-    container.api_client.override(providers.Object(api_client))
-
-    library_manager = mock.Mock()
-    library_manager.add_lean_library_to_project = mock.Mock()
-    library_manager.remove_lean_library_from_project = mock.Mock()
-    container.library_manager.override(providers.Object(library_manager))
-
-    result = CliRunner().invoke(lean, ["cloud", "pull", "--project", test_project.projectId])
-
-    assert result.exit_code == 0
-
-    api_client.projects.get_all.assert_called_once()
-    api_client.files.get_all.assert_called_once_with(test_project.projectId)
-
-    library_manager.add_lean_library_to_project.assert_not_called()
-    library_manager.remove_lean_library_from_project.assert_called_once_with(project_path, library_path, False)
-
-
-def test_pull_adds_and_removes_library_references_simultaneously() -> None:
-    create_fake_lean_cli_directory()
-
-    cloud_projects, libraries = _make_cloud_projects_and_libraries(3, 5)
-    cloud_projects.extend(libraries)
-
-    test_project = create_api_project(1000, "Python Project")
-    cloud_projects.append(test_project)
-
-    # Add cloud libraries to cloud project to test additions
-    test_project_libraries = libraries[:2]
-    _add_libraries_to_cloud_project(test_project, test_project_libraries)
-
-    lean_config_manager = container.lean_config_manager()
-    lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
-
-    # Add library reference to local project to test removal
-    project_path = lean_cli_root_dir / "Python Project"
-    library_path = lean_cli_root_dir / "Library" / "Python Library"
-    _add_local_library_to_local_project(project_path, library_path)
-
-    api_client = mock.Mock()
-    api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
-    api_client.files.get_all = mock.MagicMock(return_value=[])
-    container.api_client.override(providers.Object(api_client))
-
-    library_manager = mock.Mock()
-    library_manager.add_lean_library_to_project = mock.Mock()
-    library_manager.remove_lean_library_from_project = mock.Mock()
-    container.library_manager.override(providers.Object(library_manager))
-
-    result = CliRunner().invoke(lean, ["cloud", "pull", "--project", test_project.projectId])
-
-    assert result.exit_code == 0
-
-    api_client.projects.get_all.assert_called_once()
-    api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries],
-        any_order=True)
-
-    library_manager.add_lean_library_to_project.assert_has_calls(
-        [mock.call(lean_cli_root_dir / test_project.name, lean_cli_root_dir / library.name, False)
-         for library in test_project_libraries],
-        any_order=True)
-    library_manager.remove_lean_library_from_project.assert_called_once_with(project_path, library_path, False)
-

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -12,20 +12,23 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List, Any
+from typing import List, Any, Tuple
 from unittest import mock
 
 from lean.components.cloud.pull_manager import PullManager
 from lean.components.config.storage import Storage
+from lean.container import container
 from lean.models.api import QCProject
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
 
 
-def _create_pull_manager(api_client: mock.Mock, project_config_manager: mock.Mock) -> PullManager:
+def _create_pull_manager(api_client: mock.Mock,
+                         project_config_manager: mock.Mock,
+                         library_manager: mock.Mock = mock.Mock()) -> PullManager:
     logger = mock.Mock()
     platform_manager = mock.Mock()
-    project_manager = mock.Mock()
-    return PullManager(logger, api_client, project_manager, project_config_manager, platform_manager)
+    project_manager = container.project_manager()
+    return PullManager(logger, api_client, project_manager, project_config_manager, library_manager, platform_manager)
 
 
 def _assert_pull_manager_adds_property_to_project_config(prop: str,
@@ -36,13 +39,14 @@ def _assert_pull_manager_adds_property_to_project_config(prop: str,
     api_client.files.get_all = mock.MagicMock(return_value=[])
 
     project_config = mock.Mock()
+    project_config.get = mock.MagicMock(return_value=[])
     project_config.set = mock.Mock()
 
     project_config_manager = mock.Mock()
     project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
 
     pull_manager = _create_pull_manager(api_client, project_config_manager)
-    pull_manager.pull_projects(cloud_projects)
+    pull_manager.pull_projects(cloud_projects, cloud_projects)
 
     project_config.set.assert_called_with(prop, expected_value)
 
@@ -77,6 +81,7 @@ def _assert_pull_manager_removes_property_from_project_config(prop: str, cloud_p
     api_client.files.get_all = mock.MagicMock(return_value=[])
 
     project_config = mock.Mock()
+    project_config.get = mock.MagicMock(return_value=[])
     project_config.set = mock.Mock()
     project_config.delete = mock.Mock()
 
@@ -84,7 +89,7 @@ def _assert_pull_manager_removes_property_from_project_config(prop: str, cloud_p
     project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
 
     pull_manager = _create_pull_manager(api_client, project_config_manager)
-    pull_manager.pull_projects(cloud_projects)
+    pull_manager.pull_projects(cloud_projects, cloud_projects)
 
     assert mock.call(prop) in project_config.delete.call_args_list
     assert prop not in [call.args[0] for call in project_config.set.call_args_list]
@@ -117,3 +122,153 @@ def test_pull_manager_removes_python_venv_from_config_when_set_to_default() -> N
     cloud_project.leanPinnedToMaster = True
 
     _assert_pull_manager_removes_property_from_project_config("python-venv", [cloud_project])
+
+
+def _make_cloud_projects_and_libraries(project_count: int,
+                                       library_count: int) -> Tuple[List[QCProject], List[QCProject]]:
+    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, project_count + 1)]
+    libraries = [create_api_project(i, f"Library/Library {i - project_count}")
+                 for i in range(project_count + 1, project_count + library_count + 1)]
+
+    return cloud_projects, libraries
+
+
+def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject]) -> None:
+    libraries_ids = [library.projectId for library in libraries]
+    project.libraries.extend(libraries_ids)
+
+
+def _add_local_library_to_local_project(project_path: Path, library_path: Path) -> None:
+    library_manager = container.library_manager()
+    library_manager.add_lean_library_to_project(project_path, library_path, False)
+
+
+def test_pulls_libraries_referenced_by_the_project() -> None:
+    create_fake_lean_cli_directory()
+
+    cloud_projects, libraries = _make_cloud_projects_and_libraries(3, 5)
+    cloud_projects.extend(libraries)
+
+    test_project = cloud_projects[0]
+    test_project_libraries = libraries[:2]
+    _add_libraries_to_cloud_project(test_project, test_project_libraries)
+
+    test_library = test_project_libraries[0]
+    test_library_library = libraries[2]
+    _add_libraries_to_cloud_project(test_library, [test_library_library])
+
+    api_client = mock.Mock()
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+    api_client.lean.environments = mock.MagicMock(return_value=create_lean_environments())
+
+    library_manager = mock.Mock()
+    library_manager.add_lean_library_to_project = mock.Mock()
+    library_manager.remove_lean_library_from_project = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, container.project_config_manager(), library_manager)
+    pull_manager.pull_projects([test_project], cloud_projects)
+
+    api_client.files.get_all.assert_has_calls(
+        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries] +
+        [mock.call(library_id) for library_id in test_library.libraries],
+        any_order=True)
+
+    library_manager.add_lean_library_to_project.assert_has_calls(
+        [mock.call(Path.cwd() / test_project.name, Path.cwd() / library.name, False)
+         for library in test_project_libraries] +
+        [mock.call(Path.cwd() / test_library.name, Path.cwd() / test_library_library.name, False)],
+        any_order=True)
+    library_manager.remove_lean_library_from_project.assert_not_called()
+
+
+def test_pull_removes_library_references() -> None:
+    create_fake_lean_cli_directory()
+
+    cloud_projects, libraries = _make_cloud_projects_and_libraries(3, 5)
+    cloud_projects.extend(libraries)
+
+    test_project = create_api_project(1000, "Python Project")
+    cloud_projects.append(test_project)
+
+    # Add library reference to local project to test its removal
+    project_path = Path.cwd() / "Python Project"
+    library_path = Path.cwd() / "Library" / "Python Library"
+    _add_local_library_to_local_project(project_path, library_path)
+
+    api_client = mock.Mock()
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+    api_client.lean.environments = mock.MagicMock(return_value=create_lean_environments())
+
+    library_manager = mock.Mock()
+    library_manager.add_lean_library_to_project = mock.Mock()
+    library_manager.remove_lean_library_from_project = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, container.project_config_manager(), library_manager)
+    pull_manager.pull_projects([test_project], cloud_projects)
+
+    api_client.files.get_all.assert_called_once_with(test_project.projectId)
+
+    library_manager.add_lean_library_to_project.assert_not_called()
+    library_manager.remove_lean_library_from_project.assert_called_once_with(project_path, library_path, False)
+
+
+def test_pull_adds_and_removes_library_references_simultaneously() -> None:
+    create_fake_lean_cli_directory()
+
+    cloud_projects, libraries = _make_cloud_projects_and_libraries(3, 5)
+    cloud_projects.extend(libraries)
+
+    test_project = create_api_project(1000, "Python Project")
+    cloud_projects.append(test_project)
+
+    # Add cloud libraries to cloud project to test additions
+    test_project_libraries = libraries[:2]
+    _add_libraries_to_cloud_project(test_project, test_project_libraries)
+
+    # Add library reference to local project to test removal
+    project_path = Path.cwd() / "Python Project"
+    library_path = Path.cwd() / "Library" / "Python Library"
+    _add_local_library_to_local_project(project_path, library_path)
+
+    api_client = mock.Mock()
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+    api_client.lean.environments = mock.MagicMock(return_value=create_lean_environments())
+
+    library_manager = mock.Mock()
+    library_manager.add_lean_library_to_project = mock.Mock()
+    library_manager.remove_lean_library_from_project = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, container.project_config_manager(), library_manager)
+    pull_manager.pull_projects([test_project], cloud_projects)
+
+    api_client.files.get_all.assert_has_calls(
+        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries],
+        any_order=True)
+
+    library_manager.add_lean_library_to_project.assert_has_calls(
+        [mock.call(Path.cwd() / test_project.name, Path.cwd() / library.name, False)
+         for library in test_project_libraries],
+        any_order=True)
+    library_manager.remove_lean_library_from_project.assert_called_once_with(project_path, library_path, False)
+
+
+def test_pull_projects_updates_lean_config() -> None:
+    create_fake_lean_cli_directory()
+
+    cloud_projects = [create_api_project(1, "Project 1")]
+
+    api_client = mock.Mock()
+    api_client.projects.get_all.return_value = cloud_projects
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+
+    project_config = mock.Mock()
+
+    project_config_manager = mock.Mock()
+    project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
+
+    library_manager = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, project_config_manager, library_manager)
+    pull_manager.pull_projects(cloud_projects, cloud_projects)
+
+    project_config.set.assert_called_with("organization-id", "123")

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -294,21 +294,21 @@ def test_pull_projects_restores_csharp_projects_and_its_libraries() -> None:
         any_order=True)
     library_manager.remove_lean_library_from_project.assert_not_called()
 
-    assert mock_try_restore_csharp_project.call_count == 3
-
     test_csharp_library1_path = Path.cwd() / test_csharp_library1.name
     test_csharp_library1_csproj_file_path = (test_csharp_library1_path / f"{test_csharp_library1_path.name}.csproj")
-    assert mock_try_restore_csharp_project.call_args_list[0].args[0] == test_csharp_library1_csproj_file_path
 
     test_csharp_library2_path = Path.cwd() / test_csharp_library2.name
     test_csharp_library2_csproj_file_path = (test_csharp_library2_path / f"{test_csharp_library2_path.name}.csproj")
-    assert mock_try_restore_csharp_project.call_args_list[1].args[0] == test_csharp_library2_csproj_file_path
 
     test_project_path = Path.cwd() / test_project.name
     test_project_csproj_file_path = (test_project_path / f"{test_project_path.name}.csproj")
-    assert mock_try_restore_csharp_project.call_args_list[2].args[0] == test_project_csproj_file_path
 
-    assert all(call.args[-1] is False for call in mock_try_restore_csharp_project.call_args_list)
+    assert mock_try_restore_csharp_project.call_count == 3
+    mock_try_restore_csharp_project.assert_has_calls([
+        mock.call(test_csharp_library1_csproj_file_path, mock.ANY, False),
+        mock.call(test_csharp_library2_csproj_file_path, mock.ANY, False),
+        mock.call(test_project_csproj_file_path, mock.ANY, False)
+    ])
 
 
 def test_pull_projects_updates_lean_config() -> None:


### PR DESCRIPTION
- Restoring C# projects and its libraries on `lean cloud pull`
- Additional: moved library reference management from the pull command function to the `PullManager` so the moment of the restore can be moved from the library references update to after the whole project and libraries is pulled and setup.