### PR TITLE
Unify `organization` options for live local brokerages and data feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,33 +873,28 @@ Options:
                                   The data feed to use
   --data-provider [Terminal Link|QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider
-  --ib-organization TEXT          The name or id of the organization with the Interactive Brokers module subscription
+  --organization TEXT             The name or id of the organization
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
   --ib-password TEXT              Your Interactive Brokers password
   --ib-enable-delayed-streaming-data BOOLEAN
                                   Whether delayed data may be used when your algorithm subscribes to a security you
                                   don't have a market data subscription for
-  --tradier-organization TEXT     The name or id of the organization with the Tradier module subscription
   --tradier-account-id TEXT       Your Tradier account id
   --tradier-access-token TEXT     Your Tradier access token
   --tradier-environment [live|paper]
                                   Whether the developer sandbox should be used
-  --oanda-organization TEXT       The name or id of the organization with the Oanda module subscription
   --oanda-environment [Practice|Trade]
                                   The environment to run in, Practice for fxTrade Practice, Trade for fxTrade
   --oanda-account-id TEXT         Your OANDA account id
   --oanda-access-token TEXT       Your OANDA API token
-  --bitfinex-organization TEXT    The name or id of the organization with the Bitfinex module subscription
   --bitfinex-api-key TEXT         Your Bitfinex API key
   --bitfinex-api-secret TEXT      Your Bitfinex API secret
-  --gdax-organization TEXT        The name or id of the organization with the Coinbase Pro module subscription
   --gdax-use-sandbox [live|paper]
                                   Whether the sandbox should be used
   --gdax-api-key TEXT             Your Coinbase Pro API key
   --gdax-api-secret TEXT          Your Coinbase Pro API secret
   --gdax-passphrase TEXT          Your Coinbase Pro API passphrase
-  --binance-organization TEXT     The name or id of the organization with the Binance module subscription
   --binance-exchange-name [Binance|BinanceUS]
                                   Binance exchange name [Binance, BinanceUS]
   --binance-use-testnet [live|paper]
@@ -908,7 +903,6 @@ Options:
   --binanceus-api-key TEXT        Your Binance API key
   --binance-api-secret TEXT       Your Binance API secret
   --binanceus-api-secret TEXT     Your Binance API secret
-  --zerodha-organization TEXT     The name or id of the organization with the zerodha module subscription
   --zerodha-api-key TEXT          Your Kite Connect API key
   --zerodha-access-token TEXT     Your Kite Connect access token
   --zerodha-product-type [mis|cnc|nrml]
@@ -919,7 +913,6 @@ Options:
                                   commodities on MCX
   --zerodha-history-subscription [true|false]
                                   Whether you have a history API subscription for Zerodha
-  --samco-organization TEXT       The name or id of the organization with the samco module subscription
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
@@ -929,8 +922,6 @@ Options:
   --samco-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
-  --terminal-link-organization TEXT
-                                  The name or id of the organization with the Terminal Link module subscription
   --terminal-link-environment [Production|Beta]
                                   The environment to run in
   --terminal-link-server-host TEXT
@@ -953,7 +944,6 @@ Options:
                                   The EMSX handling to use
   --terminal-link-allow-modification BOOLEAN
                                   Whether modification is allowed
-  --atreyu-organization TEXT      The name or id of the organization with the Atreyu module subscription
   --atreyu-host TEXT              The host of the Atreyu server
   --atreyu-req-port INTEGER       The Atreyu request port
   --atreyu-sub-port INTEGER       The Atreyu subscribe port
@@ -962,7 +952,6 @@ Options:
   --atreyu-client-id TEXT         Your Atreyu client id
   --atreyu-broker-mpid TEXT       The broker MPID to use
   --atreyu-locate-rqd TEXT        The locate rqd to use
-  --tt-organization TEXT          The name or id of the organization with the Trading Technologies module subscription
   --tt-user-name TEXT             Your Trading Technologies username
   --tt-session-password TEXT      Your Trading Technologies session password
   --tt-account-name TEXT          Your Trading Technologies account name
@@ -982,12 +971,10 @@ Options:
   --tt-order-routing-host TEXT    The host of the order routing server
   --tt-order-routing-port TEXT    The port of the order routing server
   --tt-log-fix-messages BOOLEAN   Whether FIX messages should be logged
-  --kraken-organization TEXT      The name or id of the organization with the kraken module subscription
   --kraken-api-key TEXT           Your Kraken API key
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
-  --ftx-organization TEXT         The name or id of the organization with the FTX module subscription
   --ftx-exchange-name [FTX|FTXUS]
                                   FTX exchange name [FTX, FTXUS]
   --ftx-api-key TEXT              Your FTX API key
@@ -1004,8 +991,6 @@ Options:
   --iqfeed-productName TEXT       The product name of your IQFeed developer account
   --iqfeed-version TEXT           The product version of your IQFeed developer account
   --polygon-api-key TEXT          Your Polygon data feed API Key
-  --quantconnect-organization TEXT
-                                  The name or id of the organization with the QuantConnect datafeed module subscription
   --release                       Compile C# projects in release configuration instead of debug
   --image TEXT                    The LEAN engine image to use (defaults to quantconnect/lean:latest)
   --python-venv TEXT              The path of the python virtual environment to be used

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -41,7 +41,8 @@ def _get_configs_for_options(env: str) -> List[Configuration]:
         for config in module.get_all_input_configs([InternalInputUserInput, InfoConfiguration]):
             if config._id in run_options:
                 if (config._id in config_with_module_id 
-                    and config_with_module_id[config._id] == module._id):
+                    and config_with_module_id[config._id] == module._id)\
+                    or config.is_type_organization_id:      # Allow only 1 organization for brokerage, data feeds and provider at an instance
                     # config of same module
                     continue
                 else:

--- a/lean/models/__init__.py
+++ b/lean/models/__init__.py
@@ -18,7 +18,7 @@ import requests
 from pathlib import Path
 
 json_modules = {}
-file_name = "modules-1.4.json"
+file_name = "modules-1.5.json"
 dirname = os.path.dirname(__file__)
 file_path = os.path.join(dirname, f'../{file_name}')
 

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -43,7 +43,7 @@ def create_fake_environment(name: str, live_mode: bool) -> None:
     "ib-agent-description": "Individual",
     "ib-trading-mode": "paper",
     "ib-enable-delayed-streaming-data": "no",
-    "ib-organization": "abc",
+    "organization": "abc",
 
     "environments": {{
         "{name}": {{
@@ -248,7 +248,7 @@ brokerage_required_options = {
         "ib-account": "DU1234567",
         "ib-password": "hunter2",
         "ib-enable-delayed-streaming-data": "no",
-        "ib-organization": "abc",
+        "organization": "abc",
     },
     "Tradier": {
         "tradier-account-id": "123",
@@ -275,7 +275,7 @@ brokerage_required_options = {
         "binance-api-key": "123",
         "binance-api-secret": "456",
         "binance-use-testnet": "paper",
-        "binance-organization": "abc",
+        "organization": "abc",
     },
     "Zerodha": {
         "zerodha-api-key": "123",
@@ -283,7 +283,7 @@ brokerage_required_options = {
         "zerodha-product-type": "mis",
         "zerodha-trading-segment": "equity",
         "zerodha-history-subscription": "false",
-        "zerodha-organization": "abc",
+        "organization": "abc",
     },
     "Samco": {
         "samco-client-id": "123",
@@ -291,7 +291,7 @@ brokerage_required_options = {
         "samco-year-of-birth": "2000",
         "samco-product-type": "mis",
         "samco-trading-segment": "equity",
-        "samco-organization": "abc",
+        "organization": "abc",
     },
     "Atreyu": {
         "atreyu-host": "abc",
@@ -302,7 +302,7 @@ brokerage_required_options = {
         "atreyu-client-id": "abc",
         "atreyu-broker-mpid": "abc",
         "atreyu-locate-rqd": "abc",
-        "atreyu-organization": "abc",
+        "organization": "abc",
     },
     "Terminal Link": {
         "terminal-link-environment": "Beta",
@@ -315,13 +315,13 @@ brokerage_required_options = {
         "terminal-link-emsx-notes": "abc",
         "terminal-link-emsx-handling": "abc",
         "terminal-link-emsx-user-time-zone": "abc",
-        "terminal-link-organization": "abc",
+        "organization": "abc",
     },
     "Kraken": {
         "kraken-api-key": "abc",
         "kraken-api-secret": "abc",
         "kraken-verification-tier": "starter",
-        "kraken-organization": "abc",
+        "organization": "abc",
     },
     "FTX": {
         "ftxus-api-key": "abc",
@@ -331,10 +331,10 @@ brokerage_required_options = {
         "ftx-api-secret": "abc",
         "ftx-account-tier": "tier1",
         "ftx-exchange-name": "FTX",
-        "ftx-organization": "abc",
+        "organization": "abc",
     },
     "Trading Technologies": {
-        "tt-organization": "abc",
+        "organization": "abc",
         "tt-user-name": "abc",
         "tt-session-password": "abc",
         "tt-account-name": "abc",


### PR DESCRIPTION
To unify the `<brokerage/data feed>-organization` options into a single option.
closes #183 
Required `docs/v2/Lean CLI/API Reference` docs change.