### PR TITLE
Change `trading-env` to non-essential config

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Options:
   --zerodha-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
+  --zerodha-history-subscription [true|false]
+                                  Whether you have a history API subscription for Zerodha
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
@@ -895,6 +897,8 @@ Options:
   --zerodha-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
+  --zerodha-history-subscription [true|false]
+                                  Whether you have a history API subscription for Zerodha
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
@@ -970,8 +974,6 @@ Options:
   --ib-enable-delayed-streaming-data BOOLEAN
                                   Whether delayed data may be used when your algorithm subscribes to a security you
                                   don't have a market data subscription for
-  --zerodha-history-subscription [true|false]
-                                  Whether you have a history API subscription for Zerodha
   --iqfeed-iqconnect FILE         The path to the IQConnect binary
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password

--- a/README.md
+++ b/README.md
@@ -252,25 +252,25 @@ Options:
   --tradier-access-token TEXT     Your Tradier access token
   --tradier-environment [live|paper]
                                   Whether the developer sandbox should be used
-  --oanda-environment [Practice|Trade]
-                                  The environment to run in, Practice for fxTrade Practice, Trade for fxTrade
   --oanda-account-id TEXT         Your OANDA account id
   --oanda-access-token TEXT       Your OANDA API token
+  --oanda-environment [Practice|Trade]
+                                  The environment to run in, Practice for fxTrade Practice, Trade for fxTrade
   --bitfinex-api-key TEXT         Your Bitfinex API key
   --bitfinex-api-secret TEXT      Your Bitfinex API secret
-  --gdax-use-sandbox [live|paper]
-                                  Whether the sandbox should be used
   --gdax-api-key TEXT             Your Coinbase Pro API key
   --gdax-api-secret TEXT          Your Coinbase Pro API secret
   --gdax-passphrase TEXT          Your Coinbase Pro API passphrase
+  --gdax-use-sandbox [live|paper]
+                                  Whether the sandbox should be used
   --binance-exchange-name [Binance|BinanceUS]
                                   Binance exchange name [Binance, BinanceUS]
-  --binance-use-testnet [live|paper]
-                                  Whether the testnet should be used
   --binance-api-key TEXT          Your Binance API key
   --binanceus-api-key TEXT        Your Binance API key
   --binance-api-secret TEXT       Your Binance API secret
   --binanceus-api-secret TEXT     Your Binance API secret
+  --binance-use-testnet [live|paper]
+                                  Whether the testnet should be used
   --zerodha-api-key TEXT          Your Kite Connect API key
   --zerodha-access-token TEXT     Your Kite Connect access token
   --zerodha-product-type [mis|cnc|nrml]
@@ -279,8 +279,6 @@ Options:
   --zerodha-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
-  --zerodha-history-subscription [true|false]
-                                  Whether you have a history API subscription for Zerodha
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
@@ -296,19 +294,8 @@ Options:
   --tt-rest-app-key TEXT          Your Trading Technologies REST app key
   --tt-rest-app-secret TEXT       Your Trading Technologies REST app secret
   --tt-rest-environment TEXT      The REST environment to run in
-  --tt-market-data-sender-comp-id TEXT
-                                  The market data sender comp id to use
-  --tt-market-data-target-comp-id TEXT
-                                  The market data target comp id to use
-  --tt-market-data-host TEXT      The host of the market data server
-  --tt-market-data-port TEXT      The port of the market data server
   --tt-order-routing-sender-comp-id TEXT
                                   The order routing sender comp id to use
-  --tt-order-routing-target-comp-id TEXT
-                                  The order routing target comp id to use
-  --tt-order-routing-host TEXT    The host of the order routing server
-  --tt-order-routing-port TEXT    The port of the order routing server
-  --tt-log-fix-messages BOOLEAN   Whether FIX messages should be logged
   --kraken-api-key TEXT           Your Kraken API key
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
@@ -869,7 +856,7 @@ Options:
   -d, --detach                    Run the live deployment in a detached Docker container and return immediately
   --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Atreyu|Trading Technologies|Kraken|FTX]
                                   The brokerage to use
-  --data-feed [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|FTX|IQFeed|Polygon Data Feed|Custom data only]
+  --data-feed [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Kraken|FTX|IQFeed|Polygon Data Feed|Custom data only]
                                   The data feed to use
   --data-provider [Terminal Link|QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider
@@ -877,32 +864,29 @@ Options:
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
   --ib-password TEXT              Your Interactive Brokers password
-  --ib-enable-delayed-streaming-data BOOLEAN
-                                  Whether delayed data may be used when your algorithm subscribes to a security you
-                                  don't have a market data subscription for
   --tradier-account-id TEXT       Your Tradier account id
   --tradier-access-token TEXT     Your Tradier access token
   --tradier-environment [live|paper]
                                   Whether the developer sandbox should be used
-  --oanda-environment [Practice|Trade]
-                                  The environment to run in, Practice for fxTrade Practice, Trade for fxTrade
   --oanda-account-id TEXT         Your OANDA account id
   --oanda-access-token TEXT       Your OANDA API token
+  --oanda-environment [Practice|Trade]
+                                  The environment to run in, Practice for fxTrade Practice, Trade for fxTrade
   --bitfinex-api-key TEXT         Your Bitfinex API key
   --bitfinex-api-secret TEXT      Your Bitfinex API secret
-  --gdax-use-sandbox [live|paper]
-                                  Whether the sandbox should be used
   --gdax-api-key TEXT             Your Coinbase Pro API key
   --gdax-api-secret TEXT          Your Coinbase Pro API secret
   --gdax-passphrase TEXT          Your Coinbase Pro API passphrase
+  --gdax-use-sandbox [live|paper]
+                                  Whether the sandbox should be used
   --binance-exchange-name [Binance|BinanceUS]
                                   Binance exchange name [Binance, BinanceUS]
-  --binance-use-testnet [live|paper]
-                                  Whether the testnet should be used
   --binance-api-key TEXT          Your Binance API key
   --binanceus-api-key TEXT        Your Binance API key
   --binance-api-secret TEXT       Your Binance API secret
   --binanceus-api-secret TEXT     Your Binance API secret
+  --binance-use-testnet [live|paper]
+                                  Whether the testnet should be used
   --zerodha-api-key TEXT          Your Kite Connect API key
   --zerodha-access-token TEXT     Your Kite Connect access token
   --zerodha-product-type [mis|cnc|nrml]
@@ -911,8 +895,6 @@ Options:
   --zerodha-trading-segment [equity|commodity]
                                   EQUITY if you are trading equities on NSE or BSE, COMMODITY if you are trading
                                   commodities on MCX
-  --zerodha-history-subscription [true|false]
-                                  Whether you have a history API subscription for Zerodha
   --samco-client-id TEXT          Your Samco account Client ID
   --samco-client-password TEXT    Your Samco account password
   --samco-year-of-birth TEXT      Your year of birth (YYYY) registered with Samco
@@ -985,6 +967,11 @@ Options:
                                   Your FTX Account Tier
   --ftxus-account-tier [Tier1|Tier2|Tier3|Tier4|Tier5|Tier6|Tier7|Tier8|Tier9|VIP1|VIP2|MM1|MM2|MM3]
                                   Your FTX Account Tier
+  --ib-enable-delayed-streaming-data BOOLEAN
+                                  Whether delayed data may be used when your algorithm subscribes to a security you
+                                  don't have a market data subscription for
+  --zerodha-history-subscription [true|false]
+                                  Whether you have a history API subscription for Zerodha
   --iqfeed-iqconnect FILE         The path to the IQConnect binary
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password

--- a/lean/models/__init__.py
+++ b/lean/models/__init__.py
@@ -18,7 +18,7 @@ import requests
 from pathlib import Path
 
 json_modules = {}
-file_name = "modules-1.5.json"
+file_name = "modules-1.6.json"
 dirname = os.path.dirname(__file__)
 file_path = os.path.join(dirname, f'../{file_name}')
 

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -13,7 +13,7 @@
 
 from pathlib import Path
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 import click
 import abc
 from lean.components.util.logger import Logger
@@ -376,11 +376,11 @@ class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInp
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
 
-    def factory(config_json_object) -> 'BrokerageEnvConfiguration':
+    def factory(config_json_object) -> Union[PromptUserInput, ChoiceUserInput, ConfirmUserInput]:
         """Creates an instance of the child classes.
 
         :param config_json_object: the json object dict with configuration info
-        :return: An instance of BrokerageEnvConfiguration.
+        :return: An instance of either FilterEnvConfiguration or TradingEnvConfiguration.
         """
         if config_json_object["type"] == "trading-env":
             return TradingEnvConfiguration(config_json_object)
@@ -409,7 +409,7 @@ class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInp
                 f"Undefined input method type {self._input_method}")
 
 
-class TradingEnvConfiguration(BrokerageEnvConfiguration):
+class TradingEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput):
     """This class adds trading-mode/envirionment based user filters.
     
     Normalizes the value of envrionment values(live/paper) for cloud live. 

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -120,8 +120,10 @@ class Configuration(abc.ABC):
             return InfoConfiguration.factory(config_json_object)
         elif config_json_object["type"] in ["input", "internal-input"]:
             return UserInputConfiguration.factory(config_json_object)
-        elif config_json_object["type"] in ["filter-env", "trading-env"]:
+        elif config_json_object["type"] == "filter-env":
             return BrokerageEnvConfiguration.factory(config_json_object)
+        elif config_json_object["type"] == "trading-env":
+            return TradingEnvConfiguration.factory(config_json_object)
         elif config_json_object["type"] == "organization-id":
             return OrganzationIdConfiguration(config_json_object)
         else:
@@ -376,15 +378,13 @@ class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInp
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
 
-    def factory(config_json_object) -> Union[PromptUserInput, ChoiceUserInput, ConfirmUserInput]:
+    def factory(config_json_object) -> 'BrokerageEnvConfiguration':
         """Creates an instance of the child classes.
 
         :param config_json_object: the json object dict with configuration info
-        :return: An instance of either FilterEnvConfiguration or TradingEnvConfiguration.
+        :return: An instance of either BrokerageEnvConfiguration
         """
-        if config_json_object["type"] == "trading-env":
-            return TradingEnvConfiguration(config_json_object)
-        elif config_json_object["type"] == "filter-env":
+        if config_json_object["type"] == "filter-env":
             return FilterEnvConfiguration(config_json_object)
         else:
             raise ValueError(
@@ -417,6 +417,18 @@ class TradingEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput
 
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
+    
+    def factory(config_json_object) -> 'TradingEnvConfiguration':
+        """Creates an instance of the child classes.
+
+        :param config_json_object: the json object dict with configuration info
+        :return: An instance of TradingEnvConfiguration.
+        """
+        if config_json_object["type"] == "trading-env":
+            return TradingEnvConfiguration(config_json_object)
+        else:
+            raise ValueError(
+                f'Undefined input method type {config_json_object["type"]}')
 
     def AskUserForInput(self, default_value, logger: Logger):
         """Prompts user to provide input while validating the type of input

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -13,7 +13,7 @@
 
 from pathlib import Path
 import re
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 import click
 import abc
 from lean.components.util.logger import Logger
@@ -382,7 +382,7 @@ class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInp
         """Creates an instance of the child classes.
 
         :param config_json_object: the json object dict with configuration info
-        :return: An instance of either BrokerageEnvConfiguration
+        :return: An instance of BrokerageEnvConfiguration
         """
         if config_json_object["type"] == "filter-env":
             return FilterEnvConfiguration(config_json_object)

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -34,13 +34,6 @@ brokerage_required_options = {
         "tt-rest-environment": "abc",
         "tt-order-routing-sender-comp-id": "abc",
     },
-    "Zerodha": {
-        "zerodha-api-key": "123",
-        "zerodha-access-token": "456",
-        "zerodha-product-type": "mis",
-        "zerodha-trading-segment": "equity",
-        "organization": "abc",
-    }
 }
 
 def test_cloud_live_stop() -> None:

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -22,6 +22,27 @@ from lean.models.api import QCEmailNotificationMethod, QCWebhookNotificationMeth
 from tests.test_helpers import create_fake_lean_cli_directory, create_qc_nodes
 from tests.commands.test_live import brokerage_required_options
 
+brokerage_required_options = {
+    **brokerage_required_options,
+    "Trading Technologies": {
+        "organization": "abc",
+        "tt-user-name": "abc",
+        "tt-session-password": "abc",
+        "tt-account-name": "abc",
+        "tt-rest-app-key": "abc",
+        "tt-rest-app-secret": "abc",
+        "tt-rest-environment": "abc",
+        "tt-order-routing-sender-comp-id": "abc",
+    },
+    "Zerodha": {
+        "zerodha-api-key": "123",
+        "zerodha-access-token": "456",
+        "zerodha-product-type": "mis",
+        "zerodha-trading-segment": "equity",
+        "organization": "abc",
+    }
+}
+
 def test_cloud_live_stop() -> None:
     create_fake_lean_cli_directory()
 

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -282,7 +282,8 @@ brokerage_required_options = {
         "zerodha-access-token": "456",
         "zerodha-product-type": "mis",
         "zerodha-trading-segment": "equity",
-        "zerodha-history-subscription": "false"
+        "zerodha-history-subscription": "false",
+        "organization": "abc",
     },
     "Samco": {
         "samco-client-id": "123",

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -282,8 +282,7 @@ brokerage_required_options = {
         "zerodha-access-token": "456",
         "zerodha-product-type": "mis",
         "zerodha-trading-segment": "equity",
-        "zerodha-history-subscription": "false",
-        "organization": "abc",
+        "zerodha-history-subscription": "false"
     },
     "Samco": {
         "samco-client-id": "123",


### PR DESCRIPTION
#### Current behavior
`BrokerageConfiguration` is an essential input config for a module, so as its child class `TradingEnvConfiguration`. So, it is required even if the module was used as data-feed, in which that was unnecessary.

#### Solution
Change the hierarchial structure of `TradingEnvConfiguration` and `BrokerageConfiguration` from inheritance to same level, such that `TradingEnvConfiguration` would become non-essential input. Then its necessarily would solely dependent on the `filter` property of the config. 

#### Issue
closes #184 