### PR TITLE
Remove redundant dll import in C# research

### DIFF
--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -125,12 +125,6 @@ def research(project: Path,
         "mode": "rw"
     }
 
-    # Add references to all DLLs in QuantConnect.csx so custom C# libraries can be imported with using statements
-    run_options["commands"].append(" && ".join([
-        'find . -maxdepth 1 -iname "*.dll" | xargs -I _ echo \'#r "_"\' | cat - QuantConnect.csx > NewQuantConnect.csx',
-        "mv NewQuantConnect.csx QuantConnect.csx"
-    ]))
-
     # Allow notebooks to be embedded in iframes
     run_options["commands"].append("mkdir -p ~/.jupyter")
     run_options["commands"].append(

--- a/tests/commands/test_research.py
+++ b/tests/commands/test_research.py
@@ -26,7 +26,6 @@ from tests.test_helpers import create_fake_lean_cli_directory
 
 RESEARCH_IMAGE = DockerImage.parse(DEFAULT_RESEARCH_IMAGE)
 
-
 def test_research_runs_research_container() -> None:
     create_fake_lean_cli_directory()
 


### PR DESCRIPTION
Excessive DLLs import was causing timeout when running `#load QuantConnect.csx`, which was essential for initializing C# research. Removing them can solve it.

closes #168 