### PR TITLE
Using projects/update endpoint to push files and libraries

### DIFF
--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -36,6 +36,8 @@ def push(project: Optional[Path], organization_id: Optional[str]) -> None:
 
     This command will delete cloud files which don't have a local counterpart.
     """
+    push_manager = container.push_manager()
+
     # Parse which projects need to be pushed
     if project is not None:
         project_config_manager = container.project_config_manager()
@@ -43,9 +45,7 @@ def push(project: Optional[Path], organization_id: Optional[str]) -> None:
         if not project_config.file.exists():
             raise RuntimeError(f"'{project}' is not a Lean project")
 
-        projects_to_push = [project]
+        push_manager.push_project(project, organization_id)
     else:
         projects_to_push = [p.parent for p in Path.cwd().rglob(PROJECT_CONFIG_FILE_NAME)]
-
-    push_manager = container.push_manager()
-    push_manager.push_projects(projects_to_push, organization_id)
+        push_manager.push_projects(projects_to_push, organization_id)

--- a/lean/components/api/project_client.py
+++ b/lean/components/api/project_client.py
@@ -71,7 +71,9 @@ class ProjectClient:
                description: Optional[str] = None,
                parameters: Optional[Dict[str, str]] = None,
                lean_engine: Optional[int] = None,
-               python_venv: Optional[int] = None) -> None:
+               python_venv: Optional[int] = None,
+               files: Optional[List[Dict[str, str]]] = None,
+               libraries: Optional[List[int]] = None) -> None:
         """Updates an existing project.
 
         :param project_id: the id of the project to update
@@ -80,6 +82,8 @@ class ProjectClient:
         :param parameters: the new parameters of the project, or None if the parameters shouldn't be changed
         :param lean_engine: the lean engine id for the project, or None if the lean engine shouldn't be changed
         :param python_venv: the python venv id for the project, or None if the python venv shouldn't be changed
+        :param files: the list of files for the project
+        :param libraries: the list of libraries referenced by the project
         """
         request_parameters = {
             "projectId": project_id
@@ -93,11 +97,9 @@ class ProjectClient:
 
         if parameters is not None:
             if len(parameters) > 0:
-                index = 0
-                for key, value in parameters.items():
+                for index, (key, value) in enumerate(parameters.items()):
                     request_parameters[f"parameters[{index}][key]"] = key
                     request_parameters[f"parameters[{index}][value]"] = value
-                    index += 1
             else:
                 request_parameters["parameters"] = ""
 
@@ -106,6 +108,21 @@ class ProjectClient:
 
         if python_venv is not None:
             request_parameters["leanEnvironment"] = python_venv
+
+        if files is not None:
+            if len(files) > 0:
+                for index, file in enumerate(files):
+                    request_parameters[f"files[{index}][name]"] = file["name"]
+                    request_parameters[f"files[{index}][content]"] = file["content"]
+            else:
+                request_parameters["files"] = []
+
+        if libraries is not None:
+            if len(libraries) > 0:
+                for index, library in enumerate(libraries):
+                    request_parameters[f"libraries[{index}]"] = library
+            else:
+                request_parameters["libraries"] = []
 
         self._api.post("projects/update", request_parameters, data_as_json=False)
 

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -227,8 +227,8 @@ class ProjectManager:
         project_config = self._project_config_manager.get_project_config(project_dir)
         libraries_in_config = project_config.get("libraries", [])
         libraries = [LeanLibraryReference(**library).path.expanduser().resolve() for library in libraries_in_config]
-
         referenced_libraries = []
+
         for library_path in libraries:
             # Avoid infinite recursion
             if library_path in seen_projects:
@@ -236,10 +236,9 @@ class ProjectManager:
 
             seen_projects.append(library_path)
             referenced_libraries.extend(self._get_project_libraries(library_path, seen_projects))
+            referenced_libraries.append(library_path)
 
-        libraries.extend(referenced_libraries)
-
-        return list(dict.fromkeys(libraries))
+        return referenced_libraries
 
     def restore_csharp_project(self, csproj_file: Path, no_local: bool) -> None:
         """Restores a C# project if requested with the no_local flag and if dotnet is on the user's PATH.


### PR DESCRIPTION
Using projects/update endpoint to push files and libraries, which will allow us to improve the performance of the push command even more.

## Push times after the improvements 

### Newly created project

Pushing newly created porjects takes now less than 50% of the time than it took after #206 

#### Push 1:
```
lean-cli\root> lean cloud push --project .\test_projects\Proyecto04
[1/1] Pushing 'test_projects\Proyecto04'
Successfully created cloud project 'test_projects/Proyecto04'
Successfully updated files and libraries for 'test_projects/Proyecto04'
Finished pushing in 1.3429644107818604 seconds
```

#### Push 2:
```
lean-cli\root> lean cloud push --project .\test_projects\Proyecto04
[1/1] Pushing 'test_projects\Proyecto04'
Successfully created cloud project 'test_projects/Proyecto04'
Successfully updated files and libraries for 'test_projects/Proyecto04'
Finished pushing in 1.2238121032714844 seconds
```

#### Push 3:
```
lean-cli\root> lean cloud push --project .\test_projects\Proyecto04
[1/1] Pushing 'test_projects\Proyecto04'
Successfully created cloud project 'test_projects/Proyecto04'
Successfully updated cloud file 'test_projects/Proyecto04/main.py'
Successfully updated cloud file 'test_projects/Proyecto04/research.ipynb'
Finished pulling projects in 1.2492599487304688 seconds
```