### PR TITLE
Feature enforce windows path rules for every os

### DIFF
--- a/lean/components/__init__.py
+++ b/lean/components/__init__.py
@@ -10,3 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+reserved_names = ["CON", "PRN", "AUX", "NUL",
+                    "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+                    "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]

--- a/lean/components/cloud/cloud_project_manager.py
+++ b/lean/components/cloud/cloud_project_manager.py
@@ -18,6 +18,7 @@ from lean.components.cloud.pull_manager import PullManager
 from lean.components.cloud.push_manager import PushManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.path_manager import PathManager
+from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCProject
 
 
@@ -29,7 +30,8 @@ class CloudProjectManager:
                  project_config_manager: ProjectConfigManager,
                  pull_manager: PullManager,
                  push_manager: PushManager,
-                 path_manager: PathManager) -> None:
+                 path_manager: PathManager,
+                 project_manager: ProjectManager) -> None:
         """Creates a new PullManager instance.
 
         :param api_client: the APIClient instance to use when communicating with the cloud
@@ -43,6 +45,7 @@ class CloudProjectManager:
         self._pull_manager = pull_manager
         self._push_manager = push_manager
         self._path_manager = path_manager
+        self._project_manager = project_manager
 
     def get_cloud_project(self, input: str, push: bool) -> QCProject:
         """Retrieves the cloud project to use given a certain input and whether the local project needs to be pushed.
@@ -81,7 +84,7 @@ class CloudProjectManager:
             # This may happen if the input is an id instead of a name
             # If the local directory exists, we push it and return the updated cloud project
             if push:
-                local_path = self._pull_manager.get_local_project_path(cloud_project)
+                local_path = self._project_manager.get_local_project_path(cloud_project.name, cloud_project.projectId)
                 if local_path.exists():
                     self._push_manager.push_projects([local_path])
                     return self._api_client.projects.get(cloud_project.projectId)

--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -13,7 +13,6 @@
 
 from pathlib import Path
 from typing import List, Optional, Tuple
-
 from lean.components.api.api_client import APIClient
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.library_manager import LibraryManager
@@ -22,7 +21,6 @@ from lean.components.util.platform_manager import PlatformManager
 from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCProject, QCLanguage
 from lean.models.utils import LeanLibraryReference
-
 
 class PullManager:
     """The PullManager class is responsible for synchronizing cloud projects to the local drive."""
@@ -107,7 +105,18 @@ class PullManager:
         :param project: the cloud project to pull
         :return the actual local path of the project
         """
-        local_project_path = self.get_local_project_path(project)
+        local_project_path = self._project_manager.get_local_project_path(project.name, project.projectId)
+        local_project_name = local_project_path.relative_to(Path.cwd()).as_posix()
+        # Check if cloud project as invalid name, if so update it and inform user
+        if local_project_name != project.name:
+            # update project name in cloud
+            self._api_client.projects.update(project.projectId, **{"name": local_project_name})
+            self._logger.info(f"Renamed project in cloud from '{project.name}' to '{local_project_name}'")
+            # rename project on disk if we find a directory with the old name (invalid name)
+            invalid_local_project_path = local_project_path.parent / project.name
+            if invalid_local_project_path.exists():
+                self._project_manager.rename_project_and_contents(invalid_local_project_path, local_project_name)
+            project.name = local_project_name
 
         # Pull the cloud files to the local drive
         self._pull_files(project, local_project_path)
@@ -163,76 +172,6 @@ class PullManager:
 
         self._last_file = None
         self._project_manager.update_last_modified_time(local_project_path, project.modified)
-
-    def get_local_project_path(self, project: QCProject) -> Path:
-        """Returns the local path where a certain cloud project should be stored.
-
-        If two cloud projects are named "Project", they are pulled to ./Project and ./Project 2.
-
-        :param project: the cloud project to get the project path of
-        :return: the path to the local project directory
-        """
-        local_path = self._format_local_path(project.name)
-
-        current_index = 1
-        while True:
-            path_suffix = "" if current_index == 1 else f" {current_index}"
-            current_path = Path.cwd() / (local_path + path_suffix)
-
-            if not current_path.exists():
-                return current_path
-
-            current_project_config = self._project_config_manager.get_project_config(current_path)
-            if current_project_config.get("cloud-id") == project.projectId:
-                return current_path
-
-            current_index += 1
-
-    def _format_local_path(self, cloud_path: str) -> str:
-        """Converts the given cloud path into a local path which is valid for the current operating system.
-
-        :param cloud_path: the path of the project in the cloud
-        :return: the converted cloud_path so that it is valid locally
-        """
-        # Remove forbidden characters and OS-specific path separator that are not path separators on QuantConnect
-        if self._platform_manager.is_host_windows():
-            # Windows, \":*?"<>| are forbidden
-            # Windows, \ is a path separator, but \ is not a path separator on QuantConnect
-            forbidden_characters = ["\\", ":", "*", "?", '"', "<", ">", "|"]
-        elif self._platform_manager.is_host_macos():
-            # macOS, : is a path separator, but : is not a path separator on QuantConnect
-            forbidden_characters = [":"]
-        else:
-            # Linux, no forbidden characters
-            forbidden_characters = []
-
-        for forbidden_character in forbidden_characters:
-            cloud_path = cloud_path.replace(forbidden_character, " ")
-
-        # On Windows we need to ensure each path component is valid
-        if self._platform_manager.is_host_windows():
-            new_components = []
-
-            for component in cloud_path.split("/"):
-                # Some names are reserved
-                for reserved_name in ["CON", "PRN", "AUX", "NUL",
-                                      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-                                      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]:
-                    # If the component is a reserved name, we add an underscore to it so it can be used
-                    if component.upper() == reserved_name:
-                        component += "_"
-
-                # Components cannot start or end with a space
-                component = component.strip(" ")
-
-                # Components cannot end with a period
-                component = component.rstrip(".")
-
-                new_components.append(component)
-
-            cloud_path = "/".join(new_components)
-
-        return cloud_path
 
     def _add_local_library_references_to_project(self, project_dir: Path, cloud_libraries_paths: List[Path]) -> None:
         if len(cloud_libraries_paths) > 0:

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -178,7 +178,7 @@ class PushManager:
         expected_correct_project_name = project.relative_to(Path.cwd()).as_posix()
         if cloud_project.name != expected_correct_project_name:
                 # update project name in cloud
-                update_args["name"] = local_description
+                update_args["name"] = expected_correct_project_name
                 self._logger.info(f"Renaming project in cloud from '{cloud_project.name}' to '{expected_correct_project_name}'")
 
         if local_description != cloud_description:

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -110,7 +110,8 @@ class PushManager:
             self._project_manager.rename_project_and_contents(project_path, expected_correct_project_path)
             project_path = expected_correct_project_path
             project_name = valid_project_name
-
+            project_config = self._project_config_manager.get_project_config(project_path)
+        
         # Find the cloud project to push the files to
         if cloud_id is not None:
             # Project has cloud id which matches cloud project, update cloud project

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -115,10 +115,6 @@ class PushManager:
         if cloud_id is not None:
             # Project has cloud id which matches cloud project, update cloud project
             cloud_project = self._get_cloud_project(cloud_id)
-            if cloud_project.name != project_name:
-                # update project name in cloud
-                self._api_client.projects.update(cloud_project.projectId, **{"name": project_name})
-                self._logger.info(f"Renamed project in cloud from '{cloud_project.name}' to '{project_name}'")
         else:
             # Project has invalid cloud id or no cloud id at all, create new cloud project
             cloud_project = self._api_client.projects.create(project_name,
@@ -178,6 +174,12 @@ class PushManager:
         cloud_lean_venv = cloud_project.leanEnvironment
 
         update_args = {}
+
+        expected_correct_project_name = project.relative_to(Path.cwd()).as_posix()
+        if cloud_project.name != expected_correct_project_name:
+                # update project name in cloud
+                update_args["name"] = local_description
+                self._logger.info(f"Renaming project in cloud from '{cloud_project.name}' to '{expected_correct_project_name}'")
 
         if local_description != cloud_description:
             update_args["description"] = local_description

--- a/lean/components/util/path_manager.py
+++ b/lean/components/util/path_manager.py
@@ -12,9 +12,9 @@
 # limitations under the License.
 
 from pathlib import Path
-
+from lean.components import reserved_names
 from lean.components.util.platform_manager import PlatformManager
-
+import platform
 
 class PathManager:
     """The PathManager class provides utilities for working with paths."""
@@ -52,20 +52,20 @@ class PathManager:
 
         # On Windows path.exists() doesn't throw for paths like CON/file.txt
         # Trying to create them does raise errors, so we manually validate path components
-        if self._platform_manager.is_system_windows():
+        # We follow the rules of windows for every OS
+        components = path.as_posix().split("/")
+        if platform.system() == "Windows":
             # Skip the first component, which contains the drive name
-            for component in path.as_posix().split("/")[1:]:
-                if component.startswith(" ") or component.endswith(" ") or component.endswith("."):
+            components =  components[1:]
+        for component in components:
+            if component.startswith(" ") or component.endswith(" ") or component.endswith("."):
+                return False
+
+            for reserved_name in reserved_names:
+                if component.upper() == reserved_name or component.upper().startswith(reserved_name + "."):
                     return False
 
-                for reserved_name in ["CON", "PRN", "AUX", "NUL",
-                                      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-                                      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]:
-                    if component.upper() == reserved_name or component.upper().startswith(reserved_name + "."):
-                        return False
-
-                for forbidden_character in [":", "*", "?", '"', "<", ">", "|"]:
-                    if forbidden_character in component:
-                        return False
-
+            for forbidden_character in [":", "*", "?", '"', "<", ">", "|"]:
+                if forbidden_character in component:
+                    return False
         return True

--- a/lean/components/util/path_manager.py
+++ b/lean/components/util/path_manager.py
@@ -14,7 +14,6 @@
 from pathlib import Path
 from lean.components import reserved_names
 from lean.components.util.platform_manager import PlatformManager
-import platform
 
 class PathManager:
     """The PathManager class provides utilities for working with paths."""
@@ -44,6 +43,7 @@ class PathManager:
         :param path: the path to validate
         :return: True if the path is valid on the current operating system, False if not
         """
+        import platform
         try:
             # This call fails if the path contains invalid characters
             path.exists()

--- a/lean/components/util/path_manager.py
+++ b/lean/components/util/path_manager.py
@@ -43,7 +43,7 @@ class PathManager:
         :param path: the path to validate
         :return: True if the path is valid on the current operating system, False if not
         """
-        import platform
+        from platform import system
         try:
             # This call fails if the path contains invalid characters
             path.exists()
@@ -54,7 +54,7 @@ class PathManager:
         # Trying to create them does raise errors, so we manually validate path components
         # We follow the rules of windows for every OS
         components = path.as_posix().split("/")
-        if platform.system() == "Windows":
+        if system() == "Windows":
             # Skip the first component, which contains the drive name
             components =  components[1:]
         for component in components:

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -14,7 +14,9 @@
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
-
+import os
+import glob
+from lean.components import reserved_names
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.logger import Logger
@@ -176,6 +178,98 @@ class ProjectManager:
             rmtree(project_dir)
         except FileNotFoundError:
             raise RuntimeError(f"Failed to delete project. Could not find the specified path {project_dir}.")
+
+
+    def get_local_project_path(self, project_name: str, cloud_id: Optional[int] = None, local_id: Optional[int] = None) -> Path:
+        """Returns the local path where a certain cloud project should be stored.
+
+        If two cloud projects are named "Project", they are pulled to ./Project and ./Project 2.
+
+        If you push a project with unsupported cloud name, a supported project name would be assigned.
+
+        :param project_name: the cloud project to get the project path of
+        :param cloud_id: the cloud project to get the project path of
+        :param local_id: the cloud project to get the project path of
+        :return: the path to the local project directory
+        """
+
+        if cloud_id is not None and local_id is not None:
+            raise ValueError("Cannot specify both cloud_id and local_id")
+        
+        if cloud_id is None and local_id is None:
+            raise ValueError("Must specify either cloud_id or local_id")
+
+        local_path = self._format_local_path(project_name)
+
+        current_index = 1
+        while True:
+            path_suffix = "" if current_index == 1 else f" {current_index}"
+            current_path = Path.cwd() / (local_path + path_suffix)
+
+            if not current_path.exists():
+                return current_path
+
+            if cloud_id is not None:
+                current_project_config = self._project_config_manager.get_project_config(current_path)
+                if current_project_config.get("cloud-id") == cloud_id:
+                    return current_path
+
+            if local_id is not None:
+                current_project_config = self._project_config_manager.get_project_config(current_path)
+                if current_project_config.get("local-id") == local_id:
+                    return current_path
+
+            current_index += 1
+
+    def _format_local_path(self, cloud_path: str) -> str:
+        """Converts the given cloud path into a local path which is valid for the current operating system.
+
+        :param cloud_path: the path of the project in the cloud
+        :return: the converted cloud_path so that it is valid locally
+        """
+        # Remove forbidden characters and OS-specific path separator that are not path separators on QuantConnect
+        # Windows, \":*?"<>| are forbidden
+        # Windows, \ is a path separator, but \ is not a path separator on QuantConnect
+        # We follow the rules of windows for every OS
+        forbidden_characters = ["\\", ":", "*", "?", '"', "<", ">", "|"]
+
+        for forbidden_character in forbidden_characters:
+            cloud_path = cloud_path.replace(forbidden_character, " ")
+
+        # On Windows we need to ensure each path component is valid
+        # We follow the rules of windows for every OS
+        new_components = []
+
+        for component in cloud_path.split("/"):
+            # Some names are reserved
+            for reserved_name in reserved_names:
+                # If the component is a reserved name, we add an underscore to it so it can be used
+                if component.upper() == reserved_name:
+                    component += "_"
+
+            # Components cannot start or end with a space
+            component = component.strip(" ")
+
+            # Components cannot end with a period
+            component = component.rstrip(".")
+
+            new_components.append(component)
+
+        cloud_path = "/".join(new_components)
+
+        return cloud_path
+        
+
+    def rename_project_and_contents(self, old_path: Path, new_path: Path,) -> None:
+        """Renames a project and updates the project config.
+
+        :param old_path: the local project to rename
+        :param new_path: the new path of the project
+        """
+        if not old_path.exists():
+            raise RuntimeError(f"Failed to rename project. Could not find the specified path {old_path}.")
+        os.rename(old_path, new_path)
+        self._rename_csproj_file(new_path)
 
     def get_projects_by_name_or_id(self, cloud_projects: List[QCProject],
                                    project: Optional[Union[str, int]]) -> List[QCProject]:
@@ -580,6 +674,20 @@ class ProjectManager:
 
         # Save the modified XML tree
         self._generate_file(debugger_file, self._xml_manager.to_string(root))
+
+    def _rename_csproj_file(self, project_path: Path) -> None:
+        """Renames the csproj file in the project to name the project name.
+
+        :param project_path: the local project path
+        """
+        csproj_files = glob.glob("*.csproj")
+        if not len(csproj_files):
+            return
+        csproj_file = Path(csproj_files[0])
+        new_csproj_file = project_path / f'{project_path.name}.csproj'
+        if new_csproj_file.exists():
+            return
+        os.rename(csproj_file, new_csproj_file)
 
     def _generate_file(self, file: Path, content: str) -> None:
         """Writes to a file, which is created if it doesn't exist yet, and normalized the content before doing so.

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -103,7 +103,10 @@ class ProjectManager:
         while len(directories) > 0:
             directory = directories.pop(0)
 
-            project_config = self._project_config_manager.try_get_project_config(directory, self._path_manager)
+            try:
+                project_config = self._project_config_manager.get_project_config(directory)
+            except:
+                continue
             if project_config and project_config.get("cloud-id", None) == cloud_id:
                 return directory
             else:

--- a/lean/container.py
+++ b/lean/container.py
@@ -116,7 +116,8 @@ class Container:
                                           self.project_config_manager,
                                           self.pull_manager,
                                           self.push_manager,
-                                          self.path_manager)
+                                          self.path_manager,
+                                          self.project_manager)
 
         self.docker_manager = docker_manager
         if not self.docker_manager:

--- a/lean/models/__init__.py
+++ b/lean/models/__init__.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from time import time
 
 json_modules = {}
-file_name = "modules-1.7.json"
+file_name = "modules-1.8.json"
 directory = Path(__file__).parent
 file_path = directory.parent / file_name
 

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -11,11 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import platform
 from pathlib import Path
 from typing import List, Any, Tuple
 from unittest import mock
-
+import platform
 import pytest
 
 from lean.components.cloud.pull_manager import PullManager
@@ -24,7 +23,7 @@ from lean.components.util.project_manager import ProjectManager
 from lean.container import container
 from lean.models.api import QCProject, QCLanguage
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
-
+from tests.test_helpers import create_fake_lean_cli_project
 
 def _create_pull_manager(api_client: mock.Mock,
                          project_config_manager: mock.Mock,
@@ -35,6 +34,25 @@ def _create_pull_manager(api_client: mock.Mock,
     return PullManager(logger, api_client, project_manager, project_config_manager, library_manager, platform_manager)
 
 
+def _make_cloud_projects_and_libraries(project_count: int,
+                                       library_count: int) -> Tuple[List[QCProject], List[QCProject]]:
+    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, project_count + 1)]
+    libraries = [create_api_project(i, f"Library/Library {i - project_count}")
+                 for i in range(project_count + 1, project_count + library_count + 1)]
+
+    return cloud_projects, libraries
+
+
+def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject]) -> None:
+    libraries_ids = [library.projectId for library in libraries]
+    project.libraries.extend(libraries_ids)
+
+
+def _add_local_library_to_local_project(project_path: Path, library_path: Path) -> None:
+    library_manager = container.library_manager
+    library_manager.add_lean_library_to_project(project_path, library_path, False)
+
+    
 def _assert_pull_manager_adds_property_to_project_config(prop: str,
                                                          expected_value: Any,
                                                          cloud_projects: List[QCProject]) -> None:
@@ -111,25 +129,6 @@ def test_pull_manager_removes_lean_engine_from_config_when_lean_pinned_to_master
     cloud_project.leanPinnedToMaster = True
 
     _assert_pull_manager_removes_property_from_project_config("lean-engine", [cloud_project])
-
-
-def _make_cloud_projects_and_libraries(project_count: int,
-                                       library_count: int) -> Tuple[List[QCProject], List[QCProject]]:
-    cloud_projects = [create_api_project(i, f"Project {i}") for i in range(1, project_count + 1)]
-    libraries = [create_api_project(i, f"Library/Library {i - project_count}")
-                 for i in range(project_count + 1, project_count + library_count + 1)]
-
-    return cloud_projects, libraries
-
-
-def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject]) -> None:
-    libraries_ids = [library.projectId for library in libraries]
-    project.libraries.extend(libraries_ids)
-
-
-def _add_local_library_to_local_project(project_path: Path, library_path: Path) -> None:
-    library_manager = container.library_manager
-    library_manager.add_lean_library_to_project(project_path, library_path, False)
 
 
 def test_pulls_libraries_referenced_by_the_project() -> None:
@@ -327,16 +326,8 @@ def test_pull_projects_updates_lean_config() -> None:
                                         any_order=True)
 
 
-@pytest.mark.parametrize("test_platform, unsupported_character", [
-    *[("windows", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
-    ("macos", ":")
-])
-def test_pull_projects_detects_unsupported_paths(test_platform: str, unsupported_character: str) -> None:
-    if test_platform == "windows" and platform.system() != "Windows":
-        pytest.skip("This test requires Windows")
-
-    if test_platform == "macos" and platform.system() != "Darwin":
-        pytest.skip("This test requires MacOS")
+@pytest.mark.parametrize("unsupported_character", ["\\", ":", "*", "?", '"', "<", ">", "|"])
+def test_pull_projects_detects_unsupported_paths(unsupported_character: str) -> None:
 
     create_fake_lean_cli_directory()
 
@@ -374,3 +365,66 @@ def test_pull_projects_detects_unsupported_paths(test_platform: str, unsupported
          for library_name in expected_library_names_in_paths],
         any_order=True)
     library_manager.remove_lean_library_from_project.assert_not_called()
+
+
+@pytest.mark.parametrize("unsupported_character", ["\\", ":", "*", "?", '"', "<", ">", "|"])
+def test_push_projects_updates_name_in_cloud_if_required(unsupported_character: str) -> None:
+    create_fake_lean_cli_directory()
+    project_name = "Project 1"
+    cloud_projects = [create_api_project(1, project_name + unsupported_character)]
+
+    api_client = mock.Mock()
+    api_client.projects.get_all.return_value = cloud_projects
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+
+    project_config = mock.Mock()
+    project_config.get = mock.MagicMock(return_value=[])    # get("libraries")
+
+    project_config_manager = mock.Mock()
+    project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
+
+    library_manager = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, project_config_manager, library_manager)
+    pull_manager.pull_projects(cloud_projects, cloud_projects)
+
+    api_client.projects.update.assert_called_once()
+    args, kwargs = api_client.projects.update.call_args
+    assert "name" in kwargs and kwargs['name'] == project_name
+
+@pytest.mark.parametrize("test_platform, unsupported_character", [
+    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    ("macos", ":")
+])
+def test_pull_projects_renames_project_if_required(test_platform: str, unsupported_character: str) -> None:
+    
+    if test_platform == "linux" and platform.system() != "Linux":
+        pytest.skip("This test requires Linux")
+
+    if test_platform == "macos" and platform.system() != "Darwin":
+        pytest.skip("This test requires MacOS")
+
+    project_name = "Project 1"
+    unsupported_name  = project_name + unsupported_character
+    cloud_projects = [create_api_project(1, unsupported_name)]
+    create_fake_lean_cli_project(unsupported_name, "csharp")
+
+    assert (Path.cwd() / unsupported_name).exists()
+
+    api_client = mock.Mock()
+    api_client.projects.get_all.return_value = cloud_projects
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+
+    project_config = mock.Mock()
+    project_config.get = mock.MagicMock(return_value=[])    # get("libraries")
+
+    project_config_manager = mock.Mock()
+    project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
+
+    library_manager = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, project_config_manager, library_manager)
+    pull_manager.pull_projects(cloud_projects, cloud_projects)
+
+    assert not (Path.cwd() / unsupported_name).exists()
+    assert (Path.cwd() / project_name).exists()

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -414,9 +414,10 @@ def test_pull_projects_renames_project_if_required(test_platform: str, unsupport
     api_client = mock.Mock()
     api_client.projects.get_all.return_value = cloud_projects
     api_client.files.get_all = mock.MagicMock(return_value=[])
+    api_client.projects.create = mock.MagicMock(return_value=cloud_projects[0])
 
     project_config = mock.Mock()
-    project_config.get = mock.MagicMock(return_value=[])    # get("libraries")
+    project_config.get = mock.MagicMock(return_value=[])
 
     project_config_manager = mock.Mock()
     project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -408,7 +408,9 @@ def test_pull_projects_renames_project_if_required(test_platform: str, unsupport
     unsupported_name  = project_name + unsupported_character
     cloud_projects = [create_api_project(1, unsupported_name)]
     create_fake_lean_cli_project(unsupported_name, "csharp")
-
+    project_path = Path.cwd() / unsupported_name
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("cloud-id", cloud_projects[0].projectId)
     assert (Path.cwd() / unsupported_name).exists()
 
     api_client = mock.Mock()

--- a/tests/components/util/test_push_manager.py
+++ b/tests/components/util/test_push_manager.py
@@ -419,10 +419,12 @@ def test_push_projects_renames_project_if_required(test_platform: str, unsupport
     assert (project_path).exists()
 
     api_client = mock.Mock()
+    cloud_project = create_api_project(100, expected_correct_project_name)
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
 
     push_manager = _create_push_manager(api_client, container.project_manager)
     push_manager.push_projects([project_path])
-
+    assert not (Path.cwd() / project_path).exists()
     assert (Path.cwd() / expected_correct_project_name).exists()
 
 @pytest.mark.parametrize("test_platform, unsupported_character", [
@@ -459,4 +461,6 @@ def test_push_projects_updates_name_in_cloud_if_required(test_platform: str, uns
     push_manager = _create_push_manager(api_client, container.project_manager)
     push_manager.push_projects([project_path])
 
-    api_client.projects.update.assert_has_calls([mock.call(project_id, name=expected_correct_project_name)], any_order=True)
+    api_client.projects.update.assert_called_once()
+    args, kwargs = api_client.projects.update.call_args
+    assert kwargs['name'] == expected_correct_project_name

--- a/tests/components/util/test_push_manager.py
+++ b/tests/components/util/test_push_manager.py
@@ -14,12 +14,13 @@
 from pathlib import Path
 from typing import List
 from unittest import mock
-
+import pytest
+import platform
 from lean.components.cloud.push_manager import PushManager
 from lean.container import container
 from lean.models.api import QCLanguage, QCProject
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
-
+from tests.test_helpers import create_fake_lean_cli_project
 
 def _create_push_manager(api_client: mock.Mock, project_manager: mock.Mock) -> PushManager:
     logger = mock.Mock()
@@ -36,6 +37,9 @@ def test_push_projects_pushes_libraries_referenced_by_the_projects() -> None:
     lean_config_manager = container.lean_config_manager
     lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
 
+    def get_local_project_path(project_name, *args):
+        return lean_cli_root_dir / project_name
+
     project_path = lean_cli_root_dir / "Python Project"
     python_library_relative_path = "Library/Python Library"
     csharp_library_relative_path = "Library/CSharp Library"
@@ -49,6 +53,7 @@ def test_push_projects_pushes_libraries_referenced_by_the_projects() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[csharp_library_path, python_library_path])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
 
     project_id = 1000
     python_library_id = 1001
@@ -105,6 +110,9 @@ def test_push_projects_removes_libraries_in_the_cloud() -> None:
     lean_config_manager = container.lean_config_manager
     lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
 
+    def get_local_project_path(project_name, *args):
+        return lean_cli_root_dir / project_name
+
     project_path = lean_cli_root_dir / "Python Project"
     python_library_relative_path = "Library/Python Library"
     python_library_path = lean_cli_root_dir / python_library_relative_path
@@ -112,7 +120,8 @@ def test_push_projects_removes_libraries_in_the_cloud() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
-
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
+    
     project_id = 1000
     python_library_id = 1001
     cloud_project = create_api_project(project_id, project_path.name)
@@ -149,6 +158,9 @@ def test_push_projects_adds_and_removes_libraries_simultaneously() -> None:
     lean_config_manager = container.lean_config_manager
     lean_cli_root_dir = lean_config_manager.get_cli_root_directory()
 
+    def get_local_project_path(project_name, *args):
+        return lean_cli_root_dir / project_name
+
     project_path = lean_cli_root_dir / "Python Project"
     python_library_relative_path = "Library/Python Library"
     csharp_library_relative_path = "Library/CSharp Library"
@@ -161,6 +173,7 @@ def test_push_projects_adds_and_removes_libraries_simultaneously() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[python_library_path])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
 
     project_id = 1000
     python_library_id = 1001
@@ -216,6 +229,9 @@ def test_push_projects_pushes_lean_engine_version() -> None:
 
     project_path = Path.cwd() / "Python Project"
 
+    def get_local_project_path(project_name, *args):
+        return Path.cwd() / project_name
+
     project_id = 1000
     cloud_project = create_api_project(project_id, project_path.name)
 
@@ -234,6 +250,7 @@ def test_push_projects_pushes_lean_engine_version() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
 
     push_manager = _create_push_manager(api_client, project_manager)
     push_manager.push_projects([project_path])
@@ -248,6 +265,9 @@ def test_push_projects_pushes_lean_engine_version_to_default() -> None:
     create_fake_lean_cli_directory()
 
     project_path = Path.cwd() / "Python Project"
+
+    def get_local_project_path(project_name, *args):
+        return Path.cwd() / project_name
 
     project_id = 1000
     cloud_project = create_api_project(project_id, project_path.name)
@@ -267,6 +287,7 @@ def test_push_projects_pushes_lean_engine_version_to_default() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
 
     push_manager = _create_push_manager(api_client, project_manager)
     push_manager.push_projects([project_path])
@@ -281,6 +302,9 @@ def test_push_projects_pushes_lean_environment() -> None:
     create_fake_lean_cli_directory()
 
     project_path = Path.cwd() / "Python Project"
+
+    def get_local_project_path(project_name, *args):
+        return Path.cwd() / project_name
 
     project_id = 1000
     cloud_project = create_api_project(project_id, project_path.name)
@@ -301,6 +325,7 @@ def test_push_projects_pushes_lean_environment() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
 
     push_manager = _create_push_manager(api_client, project_manager)
     push_manager.push_projects([project_path])
@@ -315,6 +340,9 @@ def test_push_projects_does_not_push_lean_environment_when_unset() -> None:
     create_fake_lean_cli_directory()
 
     project_path = Path.cwd() / "Python Project"
+
+    def get_local_project_path(project_name, *args):
+        return Path.cwd() / project_name
 
     project_id = 1000
     cloud_project = create_api_project(project_id, project_path.name)
@@ -335,6 +363,7 @@ def test_push_projects_does_not_push_lean_environment_when_unset() -> None:
     project_manager = mock.Mock()
     project_manager.get_project_libraries = mock.MagicMock(return_value=[])
     project_manager.get_source_files = mock.MagicMock(return_value=[])
+    project_manager.get_local_project_path = mock.MagicMock(side_effect=get_local_project_path)
 
     push_manager = _create_push_manager(api_client, project_manager)
     push_manager.push_projects([project_path])
@@ -343,3 +372,91 @@ def test_push_projects_does_not_push_lean_environment_when_unset() -> None:
     args, kwargs = api_client.projects.update.call_args
     assert args[0] == project_id
     assert "python_venv" not in kwargs
+
+
+@pytest.mark.parametrize("test_platform, unsupported_character", [
+    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    ("macos", ":")
+])
+def test_push_projects_detects_unsupported_paths(test_platform: str, unsupported_character: str) -> None:
+    
+    if test_platform == "linux" and platform.system() != "Linux":
+        pytest.skip("This test requires Linux")
+
+    if test_platform == "macos" and platform.system() != "Darwin":
+        pytest.skip("This test requires MacOS")
+
+    expected_correct_project_name = "Python Project"
+    project_name  = expected_correct_project_name + unsupported_character
+    project_path = Path.cwd() / project_name
+    create_fake_lean_cli_project(project_name, "python")
+
+    api_client = mock.Mock()
+
+    push_manager = _create_push_manager(api_client, container.project_manager)
+    push_manager.push_projects([project_path])
+
+    api_client.projects.create.assert_called_once()
+
+
+@pytest.mark.parametrize("test_platform, unsupported_character", [
+    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    ("macos", ":")
+])
+def test_push_projects_renames_project_if_required(test_platform: str, unsupported_character: str) -> None:
+    
+    if test_platform == "linux" and platform.system() != "Linux":
+        pytest.skip("This test requires Linux")
+
+    if test_platform == "macos" and platform.system() != "Darwin":
+        pytest.skip("This test requires MacOS")
+
+    expected_correct_project_name = "Python Project"
+    project_name  = expected_correct_project_name + unsupported_character
+    project_path = Path.cwd() / project_name
+    create_fake_lean_cli_project(project_name, "python")
+
+    assert (project_path).exists()
+
+    api_client = mock.Mock()
+
+    push_manager = _create_push_manager(api_client, container.project_manager)
+    push_manager.push_projects([project_path])
+
+    assert (Path.cwd() / expected_correct_project_name).exists()
+
+@pytest.mark.parametrize("test_platform, unsupported_character", [
+    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    ("macos", ":")
+])
+def test_push_projects_updates_name_in_cloud_if_required(test_platform: str, unsupported_character: str) -> None:
+    
+    if test_platform == "linux" and platform.system() != "Linux":
+        pytest.skip("This test requires Linux")
+
+    if test_platform == "macos" and platform.system() != "Darwin":
+        pytest.skip("This test requires MacOS")
+
+    expected_correct_project_name = "Python Project"
+    project_name  = expected_correct_project_name + unsupported_character
+    project_path = Path.cwd() / project_name
+    create_fake_lean_cli_project(project_name, "python")
+
+    project_id = 1000
+    cloud_project = create_api_project(project_id, project_name)
+
+    project_config_manager = container.project_config_manager
+    project_config = project_config_manager.get_project_config(project_path)
+    project_config.set("cloud-id", project_id)
+    project_config.set("description", cloud_project.description)
+
+    api_client = mock.Mock()
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+    api_client.lean.environments = mock.MagicMock(return_value=create_lean_environments())
+    api_client.projects.get = mock.MagicMock(return_value=cloud_project)
+    api_client.projects.update = mock.Mock()
+
+    push_manager = _create_push_manager(api_client, container.project_manager)
+    push_manager.push_projects([project_path])
+
+    api_client.projects.update.assert_has_calls([mock.call(project_id, name=expected_correct_project_name)], any_order=True)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -93,6 +93,22 @@ def create_fake_lean_cli_directory() -> None:
 
     _write_fake_directory(files)
 
+def create_fake_lean_cli_project(name: str, language: str) -> None:
+    """Creates a directory structure similar to the one created by `lean init` with a given project info"""
+    (Path.cwd() / "data").mkdir()
+
+    files = {
+        (Path.cwd() / "lean.json"): """
+{
+    // data-folder documentation
+    "data-folder": "data"
+}
+        """,
+    }
+    project_data = _get_python_project_files(Path.cwd() / name) if language.lower() == "python" else _get_csharp_project_files(Path.cwd() / name)
+    files.update(project_data)
+
+    _write_fake_directory(files)
 
 def create_fake_lean_cli_directory_with_subdirectories(depth: int) -> None:
     """Creates a directory structure similar to the one created by `lean init` with a Python and a C# project,


### PR DESCRIPTION
This PR adds the following:
- Updates the path validation to follow windows file system rules across all OSes
- Updates push command to support project rename
- Updates pull command to support project rename

Tested manually using `lean cloud pull` / `lean cloud push` commands. Also added unit tests for validation
