### PR TITLE
Use one lean cli root folder per organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,11 +443,9 @@ Usage: lean cloud push [OPTIONS]
   This command will delete cloud files which don't have a local counterpart.
 
 Options:
-  --project DIRECTORY     Path to the local project to push (all local projects if not specified)
-  --organization-id TEXT  ID of the organization where the project will be created in. This is ignored if the project
-                          has already been created in the cloud
-  --verbose               Enable debug logging
-  --help                  Show this message and exit.
+  --project DIRECTORY  Path to the local project to push (all local projects if not specified)
+  --verbose            Enable debug logging
+  --help               Show this message and exit.
 ```
 
 _See code: [lean/commands/cloud/push.py](lean/commands/cloud/push.py)_
@@ -578,18 +576,17 @@ Usage: lean data download [OPTIONS]
 
   If --dataset is given the command runs in non-interactive mode. In this mode the CLI does not prompt for input or
   confirmation but only halts when the agreement must be accepted. In non-interactive mode all options specific to the
-  selected dataset as well as --organization are required.
+  selected dataset are required.
 
   See the following url for the data that can be purchased and downloaded with this command:
   https://www.quantconnect.com/datasets
 
 Options:
-  --dataset TEXT       The name of the dataset to download non-interactively
-  --organization TEXT  The name or id of the organization to purchase and download data with
-  --overwrite          Overwrite existing local data
-  --lean-config FILE   The Lean configuration file that should be used (defaults to the nearest lean.json)
-  --verbose            Enable debug logging
-  --help               Show this message and exit.
+  --dataset TEXT      The name of the dataset to download non-interactively
+  --overwrite         Overwrite existing local data
+  --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose           Enable debug logging
+  --help              Show this message and exit.
 ```
 
 _See code: [lean/commands/data/download.py](lean/commands/data/download.py)_
@@ -677,6 +674,7 @@ Usage: lean init [OPTIONS]
   Scaffold a Lean configuration file and data directory.
 
 Options:
+  --organization TEXT             The name or id of the organization the Lean CLI will be scaffolded for
   -l, --language [python|csharp]  The default language to use for new projects
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
@@ -862,7 +860,6 @@ Options:
                                   The data feed to use
   --data-provider [Terminal Link|QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider
-  --organization TEXT             The name or id of the organization
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
   --ib-password TEXT              Your Interactive Brokers password

--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -22,7 +22,7 @@ from lean.models.api import (QCEmailNotificationMethod, QCNode, QCNotificationMe
 from lean.models.json_module import LiveInitialStateInput
 from lean.models.logger import Option
 from lean.models.brokerages.cloud.cloud_brokerage import CloudBrokerage
-from lean.models.configuration import InternalInputUserInput, OrganzationIdConfiguration
+from lean.models.configuration import InternalInputUserInput
 from lean.models.click_options import options_from_json
 from lean.models.brokerages.cloud import all_cloud_brokerages
 from lean.commands.cloud.live.live import live
@@ -146,7 +146,7 @@ def _configure_notifications(logger: Logger) -> Tuple[bool, bool, List[QCNotific
 
         while True:
             _log_notification_methods(notify_methods)
-            if not click.confirm("Do you want to add another notification method?", default=False):
+            if not confirm("Do you want to add another notification method?", default=False):
                 break
             notify_methods.append(_prompt_notification_method())
 
@@ -244,7 +244,7 @@ def deploy(project: str,
         essential_properties_value = {brokerage_instance.convert_variable_to_lean_key(prop) : kwargs[prop] for prop in essential_properties}
         brokerage_instance.update_configs(essential_properties_value)
         # now required properties can be fetched as per data provider from esssential properties
-        required_properties = [brokerage_instance.convert_lean_key_to_variable(prop) for prop in brokerage_instance.get_required_properties([OrganzationIdConfiguration, InternalInputUserInput])]
+        required_properties = [brokerage_instance.convert_lean_key_to_variable(prop) for prop in brokerage_instance.get_required_properties([InternalInputUserInput])]
         ensure_options(required_properties)
         required_properties_value = {brokerage_instance.convert_variable_to_lean_key(prop) : kwargs[prop] for prop in required_properties}
         brokerage_instance.update_configs(required_properties_value)

--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -43,10 +43,12 @@ def pull(project: Optional[str], pull_bootcamp: bool) -> None:
     projects_to_pull = []
     all_projects = None
 
+    organization_id = container.organization_manager.try_get_working_organization_id()
+
     if project_id is not None:
-        projects_to_pull.append(api_client.projects.get(project_id))
+        projects_to_pull.append(api_client.projects.get(project_id, organization_id))
     else:
-        all_projects = api_client.projects.get_all()
+        all_projects = api_client.projects.get_all(organization_id)
         project_manager = container.project_manager
         projects_to_pull = project_manager.get_projects_by_name_or_id(all_projects, project_name)
 

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -19,7 +19,6 @@ from click import command, option
 from lean.click import LeanCommand, PathParameter
 from lean.constants import PROJECT_CONFIG_FILE_NAME
 from lean.container import container
-from lean.models.errors import AbortOperation
 
 
 @command(cls=LeanCommand)

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -33,11 +33,6 @@ def push(project: Optional[Path]) -> None:
 
     This command will delete cloud files which don't have a local counterpart.
     """
-    try:
-        organization_id = container.organization_manager.get_working_organization_id()
-    except AbortOperation:
-        return
-
     push_manager = container.push_manager
 
     # Parse which projects need to be pushed
@@ -47,7 +42,7 @@ def push(project: Optional[Path]) -> None:
         if not project_config.file.exists():
             raise RuntimeError(f"'{project}' is not a Lean project")
 
-        push_manager.push_project(project, organization_id)
+        push_manager.push_project(project)
     else:
         projects_to_push = [p.parent for p in Path.cwd().rglob(PROJECT_CONFIG_FILE_NAME)]
-        push_manager.push_projects(projects_to_push, organization_id)
+        push_manager.push_projects(projects_to_push)

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -19,23 +19,25 @@ from click import command, option
 from lean.click import LeanCommand, PathParameter
 from lean.constants import PROJECT_CONFIG_FILE_NAME
 from lean.container import container
+from lean.models.errors import AbortOperation
 
 
 @command(cls=LeanCommand)
 @option("--project",
-              type=PathParameter(exists=True, file_okay=False, dir_okay=True),
-              help="Path to the local project to push (all local projects if not specified)")
-@option("--organization-id",
-              type=str,
-              help="ID of the organization where the project will be created in. This is ignored if the project has "
-                   "already been created in the cloud")
-def push(project: Optional[Path], organization_id: Optional[str]) -> None:
+        type=PathParameter(exists=True, file_okay=False, dir_okay=True),
+        help="Path to the local project to push (all local projects if not specified)")
+def push(project: Optional[Path]) -> None:
     """Push local projects to QuantConnect.
 
     This command overrides the content of cloud files with the content of their respective local counterparts.
 
     This command will delete cloud files which don't have a local counterpart.
     """
+    try:
+        organization_id = container.organization_manager.get_working_organization_id()
+    except AbortOperation:
+        return
+
     push_manager = container.push_manager
 
     # Parse which projects need to be pushed

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -153,22 +153,6 @@ def _display_products(organization: QCFullOrganization, products: List[Product])
     logger.info(f"Organization balance: {organization.credit.balance:,.0f} QCC")
 
 
-def _select_organization() -> QCFullOrganization:
-    """Asks the user for the organization that should be used.
-
-    :return: the selected organization
-    """
-    api_client = container.api_client
-
-    organizations = api_client.organizations.get_all()
-    options = [Option(id=organization.id, label=organization.name) for organization in organizations]
-
-    logger = container.logger
-    organization_id = logger.prompt_list("Select the organization to purchase and download data with", options)
-
-    return api_client.organizations.get(organization_id)
-
-
 def _select_products_interactive(organization: QCFullOrganization, datasets: List[Dataset]) -> List[Product]:
     """Asks the user for the products that should be purchased and downloaded.
 
@@ -308,7 +292,7 @@ def _get_organization() -> QCFullOrganization:
     :return: The working organization in the current Lean CLI folder
     """
     organization_manager = container.organization_manager
-    organization_id = organization_manager.get_working_organization_id()
+    organization_id = organization_manager.try_get_working_organization_id()
 
     api_client = container.api_client
     return api_client.organizations.get(organization_id)
@@ -403,6 +387,7 @@ def _get_available_datasets(organization: QCFullOrganization) -> List[Dataset]:
                                           requires_security_master=datasource["requiresSecurityMaster"]))
 
     return available_datasets
+
 
 @command(cls=LeanCommand, requires_lean_config=True, allow_unknown_options=True)
 @option("--dataset", type=str, help="The name of the dataset to download non-interactively")

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -287,7 +287,7 @@ def _confirm_payment(organization: QCFullOrganization, products: List[Product]) 
 
 
 def _get_organization() -> QCFullOrganization:
-    """Gets the working organization/
+    """Gets the working organization
 
     :return: The working organization in the current Lean CLI folder
     """

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from typing import Iterable, List, Optional
-from click import command, option, confirm, pass_context, Context, Abort
+from click import command, option, confirm, pass_context, Context
 
 from lean.click import LeanCommand, ensure_options
 from lean.container import container
@@ -408,10 +408,7 @@ def download(ctx: Context, dataset: Optional[str], overwrite: bool, **kwargs) ->
     See the following url for the data that can be purchased and downloaded with this command:
     https://www.quantconnect.com/datasets
     """
-    try:
-        organization = _get_organization()
-    except Abort:
-        return
+    organization = _get_organization()
 
     is_interactive = dataset is None
     if not is_interactive:

--- a/lean/commands/delete_project.py
+++ b/lean/commands/delete_project.py
@@ -27,9 +27,11 @@ def delete_project(project: str) -> None:
 
     The project is selected by name or cloud id.
     """
+    organization_id = container.organization_manager.try_get_working_organization_id()
+
     # Remove project from cloud
     api_client = container.api_client
-    all_projects = api_client.projects.get_all()
+    all_projects = api_client.projects.get_all(organization_id)
     project_manager = container.project_manager
     logger = container.logger
 

--- a/lean/commands/init.py
+++ b/lean/commands/init.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from typing import Optional, Tuple
 
 from click import command, option, Choice, confirm, prompt
 
@@ -19,6 +20,53 @@ from lean.click import LeanCommand
 from lean.constants import DEFAULT_DATA_DIRECTORY_NAME, DEFAULT_LEAN_CONFIG_FILE_NAME
 from lean.container import container
 from lean.models.errors import MoreInfoError
+from lean.models.logger import Option
+
+
+def _get_organization_id(user_input: str) -> Tuple[str, str]:
+    """Get the id of a given organization if the user_input is an organization name.
+
+    Raises an error if no organization with a matching name or id can be found.
+
+    If the user_input is an id (and it exists), it will be returned.
+
+    :param user_input: the input given by the user
+    :return: the organization id and name
+    """
+    from re import match
+    api_client = container.api_client
+
+    if match("^[a-f0-9]{32}$", user_input) is not None:
+        # user input cloud be an id
+        try:
+            # We look up the organization to make sure the user is a member of it
+            organization = api_client.organizations.get(user_input)
+            return organization.id, organization.name
+        except:
+            pass
+
+    organizations = api_client.organizations.get_all()
+    organization = next((o for o in organizations if o.id == user_input or o.name == user_input), None)
+
+    if organization is None:
+        raise RuntimeError(f"You are not a member of an organization with name or id '{user_input}'")
+
+    return organization.id, organization.name
+
+
+def _select_organization() -> Tuple[str, str]:
+    """Asks the user for the organization that should be used.
+
+    :return: the selected organization id
+    """
+    api_client = container.api_client
+
+    organizations = api_client.organizations.get_all()
+    options = [Option(id=organization.id, label=organization.name) for organization in organizations]
+
+    logger = container.logger
+    organization_id = logger.prompt_list("Select the organization to use for this Lean CLI instance", options)
+    return organization_id, next(iter(o.name for o in organizations))
 
 
 def _download_repository(output_path: Path) -> None:
@@ -69,14 +117,27 @@ def _download_repository(output_path: Path) -> None:
 
 
 @command(cls=LeanCommand)
+@option("--organization", type=str, help="The name or id of the organization the Lean CLI will be scaffolded for")
 @option("--language", "-l",
-              type=Choice(container.cli_config_manager.default_language.allowed_values, case_sensitive=False),
-              help="The default language to use for new projects")
-def init(language: str) -> None:
+        type=Choice(container.cli_config_manager.default_language.allowed_values, case_sensitive=False),
+        help="The default language to use for new projects")
+def init(organization: Optional[str], language: Optional[str]) -> None:
     """Scaffold a Lean configuration file and data directory."""
 
     from shutil import copytree
     from zipfile import ZipFile
+
+    # Select and set organization
+
+    if organization is not None:
+        organization_id, organization_name = _get_organization_id(organization)
+    else:
+        organization_id, organization_name = _select_organization()
+
+    logger = container.logger
+    logger.info(f'Using selected organization "{organization_name}"')
+
+    # Set default language
 
     current_dir = Path.cwd()
     data_dir = current_dir / DEFAULT_DATA_DIRECTORY_NAME
@@ -88,8 +149,6 @@ def init(language: str) -> None:
             relative_path = path.relative_to(current_dir)
             raise MoreInfoError(f"{relative_path} already exists, please run this command in an empty directory",
                                 "https://www.lean.io/docs/v2/lean-cli/initialization/directory-structure#02-lean-init")
-
-    logger = container.logger
 
     # Warn the user if the current directory is not empty
     if next(current_dir.iterdir(), None) is not None:
@@ -119,12 +178,16 @@ def init(language: str) -> None:
     with lean_config_path.open("w+", encoding="utf-8") as file:
         file.write(config)
 
+    # Add the organization id to the lean config
+    lean_config_manager.set_properties({'organization-id': organization_id})
+
     # Prompt for some general configuration if not set yet
     cli_config_manager = container.cli_config_manager
     if cli_config_manager.default_language.get_value() is None:
-        default_language = language if language is not None else prompt("What should the default language for new projects be?",
-                                        default=cli_config_manager.default_language.default_value,
-                                        type=Choice(cli_config_manager.default_language.allowed_values))
+        default_language = language if language is not None else prompt(
+            "What should the default language for new projects be?",
+            default=cli_config_manager.default_language.default_value,
+            type=Choice(cli_config_manager.default_language.allowed_values))
         cli_config_manager.default_language.set_value(default_language)
 
     logger.info(f"""

--- a/lean/commands/init.py
+++ b/lean/commands/init.py
@@ -31,7 +31,7 @@ def _get_organization_id(user_input: str) -> Tuple[str, str]:
     If the user_input is an id (and it exists), it will be returned.
 
     :param user_input: the input given by the user
-    :return: the organization id and name
+    :return the organization id and name
     """
     from re import match
     api_client = container.api_client

--- a/lean/commands/init.py
+++ b/lean/commands/init.py
@@ -179,7 +179,8 @@ def init(organization: Optional[str], language: Optional[str]) -> None:
         file.write(config)
 
     # Add the organization id to the lean config
-    lean_config_manager.set_properties({'organization-id': organization_id})
+    organization_manager = container.organization_manager
+    organization_manager.configure_working_organization_id(organization_id)
 
     # Prompt for some general configuration if not set yet
     cli_config_manager = container.cli_config_manager

--- a/lean/commands/lean.py
+++ b/lean/commands/lean.py
@@ -42,5 +42,5 @@ def lean() -> None:
     if organization_manager.get_working_organization_id() is None:
         raise RuntimeError(
             "This is an old Lean CLI root folder.\n"
-            "From now on, a Lean CLI root folder must be created for each organization for improved organization.\n"
-            "Please create a new folder for each organization you are a member of and run `lean init` in it.")
+            "From now on, a Lean CLI root folder must be created for each organization for improved usability.\n"
+            "For each organization you'd like to use with the CLI, please create a new folder and run `lean init`.")

--- a/lean/components/api/project_client.py
+++ b/lean/components/api/project_client.py
@@ -27,24 +27,33 @@ class ProjectClient:
         """
         self._api = api_client
 
-    def get(self, project_id: int) -> QCProject:
+    def get(self, project_id: int, organization_id: Optional[str]) -> QCProject:
         """Returns the details of a project.
 
         :param project_id: the id of the project to retrieve the details of
+        :param organization_id: the id of the organization where the project is located
         :return: the details of the specified project
         """
-        data = self._api.get("projects/read", {
-            "projectId": project_id
-        })
+        payload = {"projectId": project_id}
+        if organization_id is not None:
+            payload["organizationId"] = organization_id
+
+        data = self._api.get("projects/read", payload)
 
         return self._process_project(QCProject(**data["projects"][0]))
 
-    def get_all(self) -> List[QCProject]:
+    def get_all(self, organization_id: Optional[str]) -> List[QCProject]:
         """Returns all the projects the user has access to.
 
         :return: a list containing all the projects the user has access to
+        :param organization_id: the id of the organization where the projects are located
         """
-        data = self._api.get("projects/read")
+        payload = {}
+        if organization_id is not None:
+            payload["organizationId"] = organization_id
+
+        data = self._api.get("projects/read", payload)
+
         return [self._process_project(QCProject(**project)) for project in data["projects"]]
 
     def create(self, name: str, language: QCLanguage, organization_id: Optional[str]) -> QCProject:

--- a/lean/components/cloud/cloud_project_manager.py
+++ b/lean/components/cloud/cloud_project_manager.py
@@ -17,6 +17,7 @@ from lean.components.api.api_client import APIClient
 from lean.components.cloud.pull_manager import PullManager
 from lean.components.cloud.push_manager import PushManager
 from lean.components.config.project_config_manager import ProjectConfigManager
+from lean.components.util.organization_manager import OrganizationManager
 from lean.components.util.path_manager import PathManager
 from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCProject
@@ -31,7 +32,8 @@ class CloudProjectManager:
                  pull_manager: PullManager,
                  push_manager: PushManager,
                  path_manager: PathManager,
-                 project_manager: ProjectManager) -> None:
+                 project_manager: ProjectManager,
+                 organization_manager: OrganizationManager) -> None:
         """Creates a new PullManager instance.
 
         :param api_client: the APIClient instance to use when communicating with the cloud
@@ -39,6 +41,7 @@ class CloudProjectManager:
         :param pull_manager: the PullManager instance to use
         :param push_manager: the PushManager instance to use
         :param path_manager: the PathManager instance to use when validating paths
+        :param organization_manager: the OrganizationManager instance to use to get the working organization id
         """
         self._api_client = api_client
         self._project_config_manager = project_config_manager
@@ -46,6 +49,7 @@ class CloudProjectManager:
         self._push_manager = push_manager
         self._path_manager = path_manager
         self._project_manager = project_manager
+        self._organization_manager = organization_manager
 
     def get_cloud_project(self, input: str, push: bool) -> QCProject:
         """Retrieves the cloud project to use given a certain input and whether the local project needs to be pushed.
@@ -58,25 +62,27 @@ class CloudProjectManager:
         :param push: True if the local counterpart of the cloud project needs to be pushed
         :return: the cloud project to use
         """
+        organization_id = self._organization_manager.try_get_working_organization_id()
+
         # If the given input is a valid project directory, we try to use that project
         local_path = Path.cwd() / input
         if self._project_config_manager.try_get_project_config(local_path, self._path_manager):
             if push:
-                self._push_manager.push_project([local_path])
+                self._push_manager.push_projects([local_path])
 
                 cloud_id = self._project_config_manager.get_project_config(local_path).get("cloud-id")
                 if cloud_id is None:
                     raise RuntimeError("Something went wrong while pushing the project to the cloud")
 
-                return self._api_client.projects.get(cloud_id)
+                return self._api_client.projects.get(cloud_id, organization_id)
             else:
                 cloud_id = self._project_config_manager.get_project_config(local_path).get("cloud-id")
                 if cloud_id is not None:
-                    return self._api_client.projects.get(cloud_id)
+                    return self._api_client.projects.get(cloud_id, organization_id)
 
         # If the given input is not a valid project directory, we look for a cloud project with a matching name or id
         # If there are multiple, we use the first one
-        for cloud_project in self._api_client.projects.get_all():
+        for cloud_project in self._api_client.projects.get_all(organization_id):
             if str(cloud_project.projectId) != input and cloud_project.name != input:
                 continue
 
@@ -87,7 +93,7 @@ class CloudProjectManager:
                 local_path = self._project_manager.get_local_project_path(cloud_project.name, cloud_project.projectId)
                 if local_path.exists():
                     self._push_manager.push_projects([local_path])
-                    return self._api_client.projects.get(cloud_project.projectId)
+                    return self._api_client.projects.get(cloud_project.projectId, organization_id)
 
             return cloud_project
 

--- a/lean/components/cloud/cloud_project_manager.py
+++ b/lean/components/cloud/cloud_project_manager.py
@@ -62,7 +62,7 @@ class CloudProjectManager:
         local_path = Path.cwd() / input
         if self._project_config_manager.try_get_project_config(local_path, self._path_manager):
             if push:
-                self._push_manager.push_projects([local_path])
+                self._push_manager.push_project([local_path])
 
                 cloud_id = self._project_config_manager.get_project_config(local_path).get("cloud-id")
                 if cloud_id is None:

--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -58,7 +58,7 @@ class PullManager:
             if library_id in seen_projects:
                 continue
             seen_projects.append(library_id)
-            library = self._api_client.projects.get(library_id)
+            library = self._api_client.projects.get(library_id, project.organizationId)
             libraries.append(library)
             libraries.extend(self._get_libraries(library, seen_projects))
 

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -12,9 +12,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List, Optional, Dict
-
-from click import Abort
+from typing import List, Dict
 
 from lean.components.api.api_client import APIClient
 from lean.components.config.project_config_manager import ProjectConfigManager
@@ -121,7 +119,7 @@ class PushManager:
         # Find the cloud project to push the files to
         if cloud_id is not None:
             # Project has cloud id which matches cloud project, update cloud project
-            cloud_project = self._get_cloud_project(cloud_id)
+            cloud_project = self._get_cloud_project(cloud_id, organization_id)
         else:
             # Project has invalid cloud id or no cloud id at all, create new cloud project
             cloud_project = self._api_client.projects.create(project_name,
@@ -211,10 +209,10 @@ class PushManager:
             self._api_client.projects.update(cloud_project.projectId, **update_args)
             self._logger.info(f"Successfully updated {' and '.join(update_args.keys())} for '{cloud_project.name}'")
 
-    def _get_cloud_project(self, project_id: int) -> QCProject:
+    def _get_cloud_project(self, project_id: int, organization_id: str) -> QCProject:
         project = next(iter(p for p in self._cloud_projects if p.projectId == project_id), None)
         if project is None:
-            project = self._api_client.projects.get(project_id)
+            project = self._api_client.projects.get(project_id, organization_id)
             self._cloud_projects.append(project)
 
         return project

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -67,10 +67,7 @@ class PushManager:
         if len(projects_to_push) == 0:
             return
 
-        try:
-            organization_id = self._organization_manager.get_working_organization_id()
-        except Abort:
-            return
+        organization_id = self._organization_manager.try_get_working_organization_id()
 
         for index, path in enumerate(projects_to_push, start=1):
             relative_path = path.relative_to(Path.cwd())

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -13,13 +13,15 @@
 
 from pathlib import Path
 from typing import List, Optional, Dict
+
+from click import Abort
+
 from lean.components.api.api_client import APIClient
 from lean.components.config.project_config_manager import ProjectConfigManager
 from lean.components.util.logger import Logger
 from lean.components.util.organization_manager import OrganizationManager
 from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCLanguage, QCProject
-from lean.models.errors import AbortOperation
 from lean.models.utils import LeanLibraryReference
 
 class PushManager:
@@ -67,7 +69,7 @@ class PushManager:
 
         try:
             organization_id = self._organization_manager.get_working_organization_id()
-        except AbortOperation:
+        except Abort:
             return
 
         for index, path in enumerate(projects_to_push, start=1):
@@ -91,12 +93,12 @@ class PushManager:
 
         return local_libraries_cloud_ids
 
-    def _push_project(self, project_path: Path, organization_id: Optional[str]) -> None:
+    def _push_project(self, project_path: Path, organization_id: str) -> None:
         """Pushes a single local project to the cloud.
 
         Raises an error with a descriptive message if the project cannot be pushed.
 
-        :param project: the local project to push
+        :param project_path: the local project to push
         :param organization_id: the id of the organization to push the project to
         """
         project_name = project_path.relative_to(Path.cwd()).as_posix()

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -183,7 +183,7 @@ class LeanRunner:
         # Install the required modules when they're needed
         if lean_config.get("data-provider", None) == "QuantConnect.Lean.Engine.DataFeeds.DownloaderDataProvider" \
             and lean_config.get("data-downloader", None) == "TerminalLinkDataDownloader":
-            self._module_manager.install_module(TERMINAL_LINK_PRODUCT_ID, lean_config["organization-id"])
+            self._module_manager.install_module(TERMINAL_LINK_PRODUCT_ID, lean_config["job-organization-id"])
 
         # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
         data_dir = self._lean_config_manager.get_data_directory()

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -183,7 +183,7 @@ class LeanRunner:
         # Install the required modules when they're needed
         if lean_config.get("data-provider", None) == "QuantConnect.Lean.Engine.DataFeeds.DownloaderDataProvider" \
             and lean_config.get("data-downloader", None) == "TerminalLinkDataDownloader":
-            self._module_manager.install_module(TERMINAL_LINK_PRODUCT_ID, lean_config["job-organization-id"])
+            self._module_manager.install_module(TERMINAL_LINK_PRODUCT_ID, lean_config["organization-id"])
 
         # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
         data_dir = self._lean_config_manager.get_data_directory()

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -36,10 +36,7 @@ def _get_configs_for_options(env: str) -> List[Configuration]:
     for module in brokerage:
         for config in module.get_all_input_configs([InternalInputUserInput, InfoConfiguration]):
             if config._id in run_options:
-                if (config._id in config_with_module_id
-                    and config_with_module_id[config._id] == module._id)\
-                    or config.is_type_organization_id:      # Allow only 1 organization for brokerage, data feeds and provider at an instance
-                    # config of same module
+                if config._id in config_with_module_id and config_with_module_id[config._id] == module._id:
                     continue
                 else:
                     raise ValueError(f'Options names should be unique. Duplicate key present: {config._id}')

--- a/lean/components/util/organization_manager.py
+++ b/lean/components/util/organization_manager.py
@@ -52,7 +52,9 @@ class OrganizationManager:
         organization_id = self.get_working_organization_id()
 
         if organization_id is None:
-            raise RuntimeError("The working organization for this Lean CLI folder could not be determined.")
+            raise RuntimeError(
+                "The working organization for this Lean CLI folder could not be determined.\n"
+                "Make sure you run `lean init` on an empty folder for each organization you are a member of")
 
         return organization_id
 

--- a/lean/components/util/organization_manager.py
+++ b/lean/components/util/organization_manager.py
@@ -30,13 +30,18 @@ class OrganizationManager:
         self._logger = logger
         self._lean_config_manager = lean_config_manager
 
+        self._working_organization_id = None
+
     def get_working_organization_id(self) -> Optional[str]:
         """Gets the id of the working organization in the current Lean CLI directory.
 
         :return: the id of the working organization. None if the organization id was not found in the lean config
         """
-        lean_config = self._lean_config_manager.get_lean_config()
-        return lean_config.get("organization-id")
+        if self._working_organization_id is None:
+            lean_config = self._lean_config_manager.get_lean_config()
+            self._working_organization_id = lean_config.get("organization-id")
+
+        return self._working_organization_id
 
     def try_get_working_organization_id(self) -> Optional[str]:
         """Gets the id of the working organization in the current Lean CLI directory.
@@ -58,3 +63,4 @@ class OrganizationManager:
         :param organization_id: the working organization di
         """
         self._lean_config_manager.set_properties({"organization-id": organization_id})
+        self._working_organization_id = organization_id

--- a/lean/components/util/organization_manager.py
+++ b/lean/components/util/organization_manager.py
@@ -1,0 +1,61 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Any, Dict
+
+from lean.components.config.lean_config_manager import LeanConfigManager
+from lean.components.util.logger import Logger
+from lean.models.errors import AbortOperation
+
+
+class OrganizationManager:
+    """The OrganizationManager class provides utilities to handle the working organization."""
+
+    def __init__(self, logger: Logger, lean_config_manager: LeanConfigManager) -> None:
+        """Creates a new OrganizationManager instance.
+
+        :param logger: the logger to use to log messages with
+        :param lean_config_manager: the LeanConfigManager to use to manipulate the lean configuration file
+        """
+        self._logger = logger
+        self._lean_config_manager = lean_config_manager
+
+    def get_working_organization_id(self, lean_config: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        """Gets the id of the working organization in the current Lean CLI directory.
+
+        It gets the organization id from the given lean config (if passed).
+        Otherwise, it will get it from the lean config manager.
+
+        :return: the id of the working organization or None to use the default/preferred organization
+        :raises: Abort: if the user is using an old CLI folder and wants to abort the operation.
+        """
+
+        from click import confirm
+
+        lean_config_to_use = lean_config if lean_config is not None else self._lean_config_manager.get_lean_config()
+        organization_id = lean_config_to_use.get("organization-id")
+
+        if organization_id is not None:
+            return organization_id
+
+        proceed = confirm(
+            "This is an old Lean CLI root folder. "
+            "Please create a new folder for each organization you are a member of  and run `lean init` in it.\n"
+            "You can continue using the CLI here but your preferred organization is going to be used from now on.\n"
+            "Do you wish to continue?",
+            default=False)
+
+        if not proceed:
+            raise AbortOperation()
+
+        return None

--- a/lean/components/util/organization_manager.py
+++ b/lean/components/util/organization_manager.py
@@ -11,9 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Any, Dict
+from typing import Optional
 
-from lean.components.api.api_client import APIClient
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.util.logger import Logger
 
@@ -21,7 +20,7 @@ from lean.components.util.logger import Logger
 class OrganizationManager:
     """The OrganizationManager class provides utilities to handle the working organization."""
 
-    def __init__(self, logger: Logger, api_client: APIClient, lean_config_manager: LeanConfigManager) -> None:
+    def __init__(self, logger: Logger, lean_config_manager: LeanConfigManager) -> None:
         """Creates a new OrganizationManager instance.
 
         :param logger: the logger to use to log messages with
@@ -29,56 +28,33 @@ class OrganizationManager:
         :param lean_config_manager: the LeanConfigManager to use to manipulate the lean configuration file
         """
         self._logger = logger
-        self._api_client = api_client
         self._lean_config_manager = lean_config_manager
 
-    def get_working_organization_id(self, lean_config: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    def get_working_organization_id(self) -> Optional[str]:
         """Gets the id of the working organization in the current Lean CLI directory.
 
-        It gets the organization id from the given lean config (if passed).
-        Otherwise, it will get it from the lean config manager.
-
-        :return: the id of the working organization or None to use the default/preferred organization
-        :raises: Abort: if the user is using an old CLI folder and wants to abort the operation.
+        :return: the id of the working organization. None if the organization id was not found in the lean config
         """
+        lean_config = self._lean_config_manager.get_lean_config()
+        return lean_config.get("organization-id")
 
-        from click import confirm
+    def try_get_working_organization_id(self) -> Optional[str]:
+        """Gets the id of the working organization in the current Lean CLI directory.
 
-        lean_config_to_use = lean_config if lean_config is not None else self._lean_config_manager.get_lean_config()
-        organization_id = lean_config_to_use.get("organization-id")
+        :return: the id of the working organization
+        :raises RuntimeError: if the working organization is not found in the lean config
+        """
+        organization_id = self.get_working_organization_id()
 
-        if organization_id is not None:
-            return organization_id
+        if organization_id is None:
+            raise RuntimeError("The working organization for this Lean CLI folder could not be determined.")
 
-        confirm(
-            "This is an old Lean CLI root folder. "
-            "Please create a new folder for each organization you are a member of  and run `lean init` in it.\n"
-            "You can continue using the CLI here but your preferred organization is going to be used from now on.\n"
-            "Do you wish to continue?",
-            default=False,
-            abort=True)
+        return organization_id
 
-        # Proceed with the operation using the preferred organization
-        organizations = self._api_client.organizations.get_all()
-        organization = next(iter(organization for organization in organizations if organization.preferred), None)
-
-        if organization is None:
-            raise RuntimeError("No preferred organization was found. Please try again later.")
-
-        return organization.id
-
-    def configure_working_organization_id(self, organization_id: str,
-                                          lean_config: Optional[Dict[str, Any]] = None) -> None:
+    def configure_working_organization_id(self, organization_id: str) -> None:
         """
         Configures the working organization id in the Lean config
 
-        It will save the organization id either in the given Lean config or using the lean config manager.
-
         :param organization_id: the working organization di
-        :param lean_config: the optional lean config where the organization should be saved to
         """
-        if lean_config is not None:
-            lean_config["organization-id"] = organization_id
-            return
-
         self._lean_config_manager.set_properties({"organization-id": organization_id})

--- a/lean/components/util/organization_manager.py
+++ b/lean/components/util/organization_manager.py
@@ -59,3 +59,19 @@ class OrganizationManager:
             raise AbortOperation()
 
         return None
+
+    def configure_working_organization_id(self, organization_id: str,
+                                          lean_config: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Configures the working organization id in the Lean config
+
+        It will save the organization id either in the given Lean config or using the lean config manager.
+
+        :param organization_id: the working organization di
+        :param lean_config: the optional lean config where the organization should be saved to
+        """
+        if lean_config is not None:
+            lean_config["organization-id"] = organization_id
+            return
+
+        self._lean_config_manager.set_properties({"organization-id": organization_id})

--- a/lean/container.py
+++ b/lean/container.py
@@ -31,6 +31,7 @@ from lean.components.util.library_manager import LibraryManager
 from lean.components.util.logger import Logger
 from lean.components.util.market_hours_database import MarketHoursDatabase
 from lean.components.util.name_generator import NameGenerator
+from lean.components.util.organization_manager import OrganizationManager
 from lean.components.util.path_manager import PathManager
 from lean.components.util.platform_manager import PlatformManager
 from lean.components.util.project_manager import ProjectManager
@@ -138,6 +139,8 @@ class Container:
         self.market_hours_database = MarketHoursDatabase(self.lean_config_manager)
 
         self.update_manager = UpdateManager(self.logger, self.http_client, self.cache_storage, self.docker_manager)
+
+        self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
 
 
 container = Container()

--- a/lean/container.py
+++ b/lean/container.py
@@ -110,7 +110,7 @@ class Container:
 
         self.organization_manager = organization_manager
         if not self.organization_manager:
-            self.organization_manager = OrganizationManager(self.logger, self.api_client, self.lean_config_manager)
+            self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
 
         self.cloud_runner = cloud_runner
         if not cloud_runner:

--- a/lean/container.py
+++ b/lean/container.py
@@ -110,7 +110,7 @@ class Container:
 
         self.organization_manager = organization_manager
         if not self.organization_manager:
-            self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
+            self.organization_manager = OrganizationManager(self.logger, self.api_client, self.lean_config_manager)
 
         self.cloud_runner = cloud_runner
         if not cloud_runner:

--- a/lean/container.py
+++ b/lean/container.py
@@ -49,8 +49,14 @@ class Container:
     def __init__(self):
         self.initialize()
 
-    def initialize(self, docker_manager=None, api_client=None, lean_runner=None, cloud_runner=None, push_manager=None,
-                   organization_manager:Union[OrganizationManager, Any]=None):
+    def initialize(self,
+                   docker_manager: Union[DockerManager, Any] = None,
+                   api_client: Union[APIClient, Any] = None,
+                   lean_runner: Union[LeanRunner, Any] = None,
+                   cloud_runner: Union[CloudRunner, Any] = None,
+                   push_manager: Union[PushManager, Any] = None,
+                   organization_manager: Union[OrganizationManager, Any] = None,
+                   project_config_manager: Union[ProjectConfigManager, Any] = None):
         """The Container class wires all reusable components together."""
         self.logger = Logger()
 
@@ -77,7 +83,10 @@ class Container:
 
         self.module_manager = ModuleManager(self.logger, self.api_client, self.http_client)
 
-        self.project_config_manager = ProjectConfigManager(self.xml_manager)
+        self.project_config_manager = project_config_manager
+        if not self.project_config_manager:
+            self.project_config_manager = ProjectConfigManager(self.xml_manager)
+
         self.lean_config_manager = LeanConfigManager(self.logger,
                                                      self.cli_config_manager,
                                                      self.project_config_manager,
@@ -99,6 +108,10 @@ class Container:
                                               self.path_manager,
                                               self.xml_manager)
 
+        self.organization_manager = organization_manager
+        if not self.organization_manager:
+            self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
+
         self.cloud_runner = cloud_runner
         if not cloud_runner:
             self.cloud_runner = CloudRunner(self.logger, self.api_client, self.task_manager)
@@ -114,7 +127,8 @@ class Container:
             self.push_manager = PushManager(self.logger,
                                             self.api_client,
                                             self.project_manager,
-                                            self.project_config_manager)
+                                            self.project_config_manager,
+                                            self.organization_manager)
         self.data_downloader = DataDownloader(self.logger, self.api_client, self.lean_config_manager)
         self.cloud_project_manager = CloudProjectManager(self.api_client,
                                           self.project_config_manager,
@@ -142,10 +156,6 @@ class Container:
         self.market_hours_database = MarketHoursDatabase(self.lean_config_manager)
 
         self.update_manager = UpdateManager(self.logger, self.http_client, self.cache_storage, self.docker_manager)
-
-        self.organization_manager = organization_manager
-        if not self.organization_manager:
-            self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
 
 
 container = Container()

--- a/lean/container.py
+++ b/lean/container.py
@@ -131,11 +131,12 @@ class Container:
                                             self.organization_manager)
         self.data_downloader = DataDownloader(self.logger, self.api_client, self.lean_config_manager)
         self.cloud_project_manager = CloudProjectManager(self.api_client,
-                                          self.project_config_manager,
-                                          self.pull_manager,
-                                          self.push_manager,
-                                          self.path_manager,
-                                          self.project_manager)
+                                                         self.project_config_manager,
+                                                         self.pull_manager,
+                                                         self.push_manager,
+                                                         self.path_manager,
+                                                         self.project_manager,
+                                                         self.organization_manager)
 
         self.docker_manager = docker_manager
         if not self.docker_manager:

--- a/lean/container.py
+++ b/lean/container.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union, Any
+
 from lean.components.api.api_client import APIClient
 from lean.components.cloud.cloud_project_manager import CloudProjectManager
 from lean.components.cloud.cloud_runner import CloudRunner
@@ -47,7 +49,8 @@ class Container:
     def __init__(self):
         self.initialize()
 
-    def initialize(self, docker_manager=None, api_client=None, lean_runner=None, cloud_runner=None, push_manager=None):
+    def initialize(self, docker_manager=None, api_client=None, lean_runner=None, cloud_runner=None, push_manager=None,
+                   organization_manager:Union[OrganizationManager, Any]=None):
         """The Container class wires all reusable components together."""
         self.logger = Logger()
 
@@ -68,43 +71,43 @@ class Container:
         self.api_client = api_client
         if not self.api_client:
             self.api_client = APIClient(self.logger,
-                                 self.http_client,
-                                 user_id=self.cli_config_manager.user_id.get_value(),
-                                 api_token=self.cli_config_manager.api_token.get_value())
+                                        self.http_client,
+                                        user_id=self.cli_config_manager.user_id.get_value(),
+                                        api_token=self.cli_config_manager.api_token.get_value())
 
         self.module_manager = ModuleManager(self.logger, self.api_client, self.http_client)
 
         self.project_config_manager = ProjectConfigManager(self.xml_manager)
         self.lean_config_manager = LeanConfigManager(self.logger,
-                                        self.cli_config_manager,
-                                        self.project_config_manager,
-                                        self.module_manager,
-                                        self.cache_storage)
+                                                     self.cli_config_manager,
+                                                     self.project_config_manager,
+                                                     self.module_manager,
+                                                     self.cache_storage)
         self.output_config_manager = OutputConfigManager(self.lean_config_manager)
         self.optimizer_config_manager = OptimizerConfigManager(self.logger)
 
         self.project_manager = ProjectManager(self.logger,
-                                    self.project_config_manager,
-                                    self.lean_config_manager,
-                                    self.path_manager,
-                                    self.xml_manager,
-                                    self.platform_manager)
+                                              self.project_config_manager,
+                                              self.lean_config_manager,
+                                              self.path_manager,
+                                              self.xml_manager,
+                                              self.platform_manager)
         self.library_manager = LibraryManager(self.logger,
-                                    self.project_manager,
-                                    self.project_config_manager,
-                                    self.lean_config_manager,
-                                    self.path_manager,
-                                    self.xml_manager)
+                                              self.project_manager,
+                                              self.project_config_manager,
+                                              self.lean_config_manager,
+                                              self.path_manager,
+                                              self.xml_manager)
 
         self.cloud_runner = cloud_runner
         if not cloud_runner:
             self.cloud_runner = CloudRunner(self.logger, self.api_client, self.task_manager)
         self.pull_manager = PullManager(self.logger,
-                                 self.api_client,
-                                 self.project_manager,
-                                 self.project_config_manager,
-                                 self.library_manager,
-                                 self.platform_manager)
+                                        self.api_client,
+                                        self.project_manager,
+                                        self.project_config_manager,
+                                        self.library_manager,
+                                        self.platform_manager)
 
         self.push_manager = push_manager
         if not push_manager:
@@ -127,20 +130,22 @@ class Container:
         self.lean_runner = lean_runner
         if not self.lean_runner:
             self.lean_runner = LeanRunner(self.logger,
-                                    self.project_config_manager,
-                                    self.lean_config_manager,
-                                    self.output_config_manager,
-                                    self.docker_manager,
-                                    self.module_manager,
-                                    self.project_manager,
-                                    self.temp_manager,
-                                    self.xml_manager)
+                                          self.project_config_manager,
+                                          self.lean_config_manager,
+                                          self.output_config_manager,
+                                          self.docker_manager,
+                                          self.module_manager,
+                                          self.project_manager,
+                                          self.temp_manager,
+                                          self.xml_manager)
 
         self.market_hours_database = MarketHoursDatabase(self.lean_config_manager)
 
         self.update_manager = UpdateManager(self.logger, self.http_client, self.cache_storage, self.docker_manager)
 
-        self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
+        self.organization_manager = organization_manager
+        if not self.organization_manager:
+            self.organization_manager = OrganizationManager(self.logger, self.lean_config_manager)
 
 
 container = Container()

--- a/lean/models/click_options.py
+++ b/lean/models/click_options.py
@@ -82,7 +82,7 @@ def get_options_attributes(configuration: Configuration, default_lean_config_key
 
 
 def get_default_key(configuration: Configuration):
-    return "job-organization-id" if configuration.is_type_organization_id else configuration._id
+    return configuration._id
 
 
 def options_from_json(configurations: List[Configuration]):

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -98,8 +98,6 @@ class Configuration(ABC):
         self._is_type_configurations_env: bool = type(
             self) is ConfigurationsEnvConfiguration
         self._is_type_trading_env: bool = type(self) is TradingEnvConfiguration
-        self.is_type_organization_id: bool = type(
-            self) is OrganzationIdConfiguration
         self._log_message: str = ""
         if "log-message" in config_json_object.keys():
             self._log_message = config_json_object["log-message"]
@@ -124,8 +122,6 @@ class Configuration(ABC):
             return BrokerageEnvConfiguration.factory(config_json_object)
         elif config_json_object["type"] == "trading-env":
             return TradingEnvConfiguration.factory(config_json_object)
-        elif config_json_object["type"] == "organization-id":
-            return OrganzationIdConfiguration(config_json_object)
         else:
             raise ValueError(
                 f'Undefined input method type {config_json_object["type"]}')
@@ -363,13 +359,6 @@ class PromptPasswordUserInput(UserInputConfiguration):
         :return: The value provided by the user.
         """
         return logger.prompt_password(self._prompt_info, default_value)
-
-
-class OrganzationIdConfiguration(PromptUserInput):
-    """This class is used for job-organzation-id configurations"""
-
-    def __init__(self, config_json_object):
-        super().__init__(config_json_object)
 
 
 class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput):

--- a/lean/models/errors.py
+++ b/lean/models/errors.py
@@ -53,9 +53,3 @@ class AuthenticationError(MoreInfoError):
         """Creates a new AuthenticationError instance."""
         super().__init__("Invalid credentials, please log in using `lean login`",
                          "https://www.lean.io/docs/v2/lean-cli/initialization/authenticating-accounts#02-Log-In")
-
-
-class AbortOperation(Exception):
-    """An error to signal that an operation should be aborted."""
-    pass
-

--- a/lean/models/errors.py
+++ b/lean/models/errors.py
@@ -53,3 +53,9 @@ class AuthenticationError(MoreInfoError):
         """Creates a new AuthenticationError instance."""
         super().__init__("Invalid credentials, please log in using `lean login`",
                          "https://www.lean.io/docs/v2/lean-cli/initialization/authenticating-accounts#02-Log-In")
+
+
+class AbortOperation(Exception):
+    """An error to signal that an operation should be aborted."""
+    pass
+

--- a/lean/models/lean_config_configurer.py
+++ b/lean/models/lean_config_configurer.py
@@ -58,8 +58,6 @@ class LeanConfigConfigurer(JsonModule, ABC):
         """Configures the credentials in the Lean config for this brokerage and saves them persistently to disk.
         :param lean_config: the Lean configuration dict to write to
         """
-        if self._installs:
-            lean_config["job-organization-id"] = self.get_organzation_id()
         for configuration in self._lean_configs:
             value = None
             if configuration._is_type_configurations_env:

--- a/lean/models/lean_config_configurer.py
+++ b/lean/models/lean_config_configurer.py
@@ -58,6 +58,8 @@ class LeanConfigConfigurer(JsonModule, ABC):
         """Configures the credentials in the Lean config for this brokerage and saves them persistently to disk.
         :param lean_config: the Lean configuration dict to write to
         """
+        if self._installs:
+            lean_config["job-organization-id"] = container.organization_manager.try_get_working_organization_id()
         for configuration in self._lean_configs:
             value = None
             if configuration._is_type_configurations_env:

--- a/tests/commands/cloud/test_push.py
+++ b/tests/commands/cloud/test_push.py
@@ -83,7 +83,7 @@ def test_cloud_push_pushes_single_project_when_project_option_given() -> None:
 
     assert result.exit_code == 0
 
-    push_manager.push_project.assert_called_once_with(Path.cwd() / "Python Project", None)
+    push_manager.push_project.assert_called_once_with(Path.cwd() / "Python Project")
 
 
 def test_cloud_push_aborts_when_given_directory_is_not_lean_project() -> None:
@@ -138,7 +138,7 @@ def test_cloud_push_updates_lean_config() -> None:
     project_manager.get_source_files = mock.MagicMock(return_value=[])
     project_manager.get_project_libraries = mock.MagicMock(return_value=[])
 
-    push_manager = PushManager(mock.Mock(), api_client, project_manager, project_config_manager)
+    push_manager = PushManager(mock.Mock(), api_client, project_manager, project_config_manager, mock.Mock())
 
     init_container(push_manager_to_use=push_manager, api_client_to_use=api_client)
 

--- a/tests/commands/cloud/test_push.py
+++ b/tests/commands/cloud/test_push.py
@@ -12,24 +12,21 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Optional
 from unittest import mock
 from datetime import datetime
 
-import pytest
 from click.testing import CliRunner
 
 from lean.commands import lean
 from lean.components.cloud.push_manager import PushManager
-from lean.container import container
-from lean.models.api import QCFullFile, QCLanguage
+from lean.models.api import QCFullFile
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project
 from tests.conftest import initialize_container
 
 
 def init_container(**kwargs) -> None:
     organization_manager = mock.Mock()
-    organization_manager.get_working_organization_id = mock.MagicMock(return_value=None)
+    organization_manager.get_working_organization_id = mock.MagicMock(return_value="abc")
 
     if "organization_manager_to_use" not in kwargs:
         kwargs["organization_manager_to_use"] = organization_manager

--- a/tests/commands/cloud/test_push.py
+++ b/tests/commands/cloud/test_push.py
@@ -27,6 +27,16 @@ from tests.test_helpers import create_fake_lean_cli_directory, create_api_projec
 from tests.conftest import initialize_container
 
 
+def init_container(**kwargs) -> None:
+    organization_manager = mock.Mock()
+    organization_manager.get_working_organization_id = mock.MagicMock(return_value=None)
+
+    if "organization_manager_to_use" not in kwargs:
+        kwargs["organization_manager_to_use"] = organization_manager
+
+    initialize_container(**kwargs)
+
+
 def test_cloud_push_pushes_all_projects_when_no_options_given() -> None:
     create_fake_lean_cli_directory()
 
@@ -40,7 +50,7 @@ def test_cloud_push_pushes_all_projects_when_no_options_given() -> None:
     api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
 
     push_manager = mock.Mock()
-    initialize_container(api_client_to_use=api_client, push_manager_to_use=push_manager)
+    init_container(api_client_to_use=api_client, push_manager_to_use=push_manager)
 
     result = CliRunner().invoke(lean, ["cloud", "push"])
 
@@ -67,7 +77,7 @@ def test_cloud_push_pushes_single_project_when_project_option_given() -> None:
     api_client.projects.get_all = mock.MagicMock(return_value=cloud_projects)
 
     push_manager = mock.Mock()
-    initialize_container(api_client_to_use=api_client, push_manager_to_use=push_manager)
+    init_container(api_client_to_use=api_client, push_manager_to_use=push_manager)
 
     result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Python Project"])
 
@@ -80,7 +90,7 @@ def test_cloud_push_aborts_when_given_directory_is_not_lean_project() -> None:
     create_fake_lean_cli_directory()
 
     push_manager = mock.Mock()
-    initialize_container(push_manager_to_use=push_manager)
+    init_container(push_manager_to_use=push_manager)
 
     (Path.cwd() / "Empty Project").mkdir()
 
@@ -95,29 +105,13 @@ def test_cloud_push_aborts_when_given_directory_does_not_exist() -> None:
     create_fake_lean_cli_directory()
 
     push_manager = mock.Mock()
-    initialize_container(push_manager_to_use=push_manager)
+    init_container(push_manager_to_use=push_manager)
 
     result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Empty Project"])
 
     assert result.exit_code != 0
 
     push_manager.push_projects.assert_not_called()
-
-
-@pytest.mark.parametrize("organization_id", ["d6e62db42593c72e67a534513413b692", None])
-def test_cloud_push_creates_project_with_optional_organization_id(organization_id: Optional[str]) -> None:
-    create_fake_lean_cli_directory()
-
-    path = "Python Project"
-    cloud_project = create_api_project(1, path)
-
-    with mock.patch.object(container.api_client.projects, 'create', return_value=create_api_project(1, path)) as mock_create_project:
-        organization_id_option = ["--organization-id", organization_id] if organization_id is not None else []
-        result = CliRunner().invoke(lean, ["cloud", "push", "--project", path, *organization_id_option])
-
-    assert result.exit_code == 0
-
-    mock_create_project.assert_called_once_with(path, QCLanguage.Python, organization_id)
 
 
 def test_cloud_push_updates_lean_config() -> None:
@@ -146,7 +140,7 @@ def test_cloud_push_updates_lean_config() -> None:
 
     push_manager = PushManager(mock.Mock(), api_client, project_manager, project_config_manager)
 
-    initialize_container(push_manager_to_use=push_manager, api_client_to_use=api_client)
+    init_container(push_manager_to_use=push_manager, api_client_to_use=api_client)
 
     result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Python Project"])
 

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -172,9 +172,7 @@ def test_init_prompts_for_organization_if_option_not_passed() -> None:
 
     assert result.exit_code == 0
 
-    mock_prompt_list.assert_called()
-    assert any("Select the organization" in call.args[0] for call in mock_prompt_list.call_args_list)
-
+    mock_prompt_list.assert_called_with("Select the organization to use for this Lean CLI instance", mock.ANY)
     assert_organization_id_is_in_lean_config(organization.id)
 
 

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -23,8 +23,9 @@ from responses import RequestsMock
 
 from lean.commands import lean
 from lean.components.util.logger import Logger
+from lean.components.util.organization_manager import OrganizationManager
 from lean.container import container
-from lean.models.api import QCFullOrganization, QCMinimalOrganization
+from lean.models.api import QCMinimalOrganization
 
 
 @pytest.fixture(autouse=True)
@@ -74,13 +75,18 @@ def _get_test_organization() -> QCMinimalOrganization:
 
 @pytest.fixture(autouse=True, scope="function")
 def set_mock_organizations(set_unauthenticated) -> None:
-    def mock_get_organization(org_id: str) -> QCFullOrganization:
+    def mock_get_organization(org_id: str) -> QCMinimalOrganization:
         return next(iter(o for o in _get_all_organizations() if o.id == org_id), None)
 
     # container.api_client is already a mock from set_unauthenticated()
     api_client = container.api_client
     api_client.organizations.get_all.side_effect = _get_all_organizations
     api_client.organizations.get.side_effect = mock_get_organization
+
+
+@pytest.fixture(autouse=True, scope="function")
+def reset_organization_manager() -> None:
+    container.organization_manager = OrganizationManager(mock.Mock(), container.lean_config_manager)
 
 
 def test_init_aborts_when_config_file_already_exists() -> None:

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -42,7 +42,7 @@ def create_fake_environment(name: str, live_mode: bool) -> None:
     "ib-agent-description": "Individual",
     "ib-trading-mode": "paper",
     "ib-enable-delayed-streaming-data": "no",
-    "organization": "abc",
+    "organization-id": "abc",
 
     "environments": {{
         "{name}": {{
@@ -227,7 +227,6 @@ brokerage_required_options = {
         "ib-account": "DU1234567",
         "ib-password": "hunter2",
         "ib-enable-delayed-streaming-data": "no",
-        "organization": "abc",
     },
     "Tradier": {
         "tradier-account-id": "123",
@@ -254,7 +253,6 @@ brokerage_required_options = {
         "binance-api-key": "123",
         "binance-api-secret": "456",
         "binance-use-testnet": "paper",
-        "organization": "abc",
     },
     "Zerodha": {
         "zerodha-api-key": "123",
@@ -262,7 +260,6 @@ brokerage_required_options = {
         "zerodha-product-type": "mis",
         "zerodha-trading-segment": "equity",
         "zerodha-history-subscription": "false",
-        "organization": "abc",
     },
     "Samco": {
         "samco-client-id": "123",
@@ -270,7 +267,6 @@ brokerage_required_options = {
         "samco-year-of-birth": "2000",
         "samco-product-type": "mis",
         "samco-trading-segment": "equity",
-        "organization": "abc",
     },
     "Atreyu": {
         "atreyu-host": "abc",
@@ -281,7 +277,6 @@ brokerage_required_options = {
         "atreyu-client-id": "abc",
         "atreyu-broker-mpid": "abc",
         "atreyu-locate-rqd": "abc",
-        "organization": "abc",
     },
     "Terminal Link": {
         "terminal-link-environment": "Beta",
@@ -294,13 +289,11 @@ brokerage_required_options = {
         "terminal-link-emsx-notes": "abc",
         "terminal-link-emsx-handling": "abc",
         "terminal-link-emsx-user-time-zone": "abc",
-        "organization": "abc",
     },
     "Kraken": {
         "kraken-api-key": "abc",
         "kraken-api-secret": "abc",
         "kraken-verification-tier": "starter",
-        "organization": "abc",
     },
     "FTX": {
         "ftxus-api-key": "abc",
@@ -310,10 +303,8 @@ brokerage_required_options = {
         "ftx-api-secret": "abc",
         "ftx-account-tier": "tier1",
         "ftx-exchange-name": "FTX",
-        "organization": "abc",
     },
     "Trading Technologies": {
-        "organization": "abc",
         "tt-user-name": "abc",
         "tt-session-password": "abc",
         "tt-account-name": "abc",
@@ -545,7 +536,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_brokerage_settings(b
                 file.write(json.dumps({
                     **missing_options_config,
                     "data-folder": "data",
-                    "job-organization-id": "abc"
+                    "organization-id": "abc"
                 }))
 
             if brokerage == "Binance":
@@ -610,7 +601,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_data_feed_settings(d
                 file.write(json.dumps({
                     **missing_options_config,
                     "data-folder": "data",
-                    "job-organization-id": "abc"
+                    "organization-id": "abc"
                 }))
 
             if data_feed == "FTX":
@@ -660,7 +651,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_multiple_data_feed_s
                 file.write(json.dumps({
                     **missing_options_config,
                     "data-folder": "data",
-                    "job-organization-id": "abc"
+                    "organization-id": "abc"
                 }))
 
             if data_feed1 == "FTX" or data_feed2 == "FTX":

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -536,7 +536,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_brokerage_settings(b
                 file.write(json.dumps({
                     **missing_options_config,
                     "data-folder": "data",
-                    "organization-id": "abc"
+                    "job-organization-id": "abc"
                 }))
 
             if brokerage == "Binance":
@@ -601,7 +601,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_data_feed_settings(d
                 file.write(json.dumps({
                     **missing_options_config,
                     "data-folder": "data",
-                    "organization-id": "abc"
+                    "job-organization-id": "abc"
                 }))
 
             if data_feed == "FTX":
@@ -651,7 +651,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_multiple_data_feed_s
                 file.write(json.dumps({
                     **missing_options_config,
                     "data-folder": "data",
-                    "organization-id": "abc"
+                    "job-organization-id": "abc"
                 }))
 
             if data_feed1 == "FTX" or data_feed2 == "FTX":

--- a/tests/components/cloud/test_cloud_project_manager.py
+++ b/tests/components/cloud/test_cloud_project_manager.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from datetime import datetime
+from pathlib import Path
 from unittest import mock
 
 from lean.container import container
@@ -27,13 +28,20 @@ def test_get_cloud_project_pushing_new_project():
     cloud_project.description = ""
 
     api_client = mock.Mock()
+    api_client.projects.get_all.return_value = [cloud_project]
     api_client.projects.get.return_value = cloud_project
-    api_client.projects.create.return_value = cloud_project
-    api_client.files.get_all.return_value = []
-    api_client.files.create.return_value = QCMinimalFile(name="file.py", content="", modified=datetime.now())
-    api_client.lean.environments.return_value = create_lean_environments()
 
-    initialize_container(api_client_to_use=api_client)
+    push_manager = mock.Mock()
+    push_manager.push_projects = mock.Mock()
+
+    project_config = mock.Mock()
+    project_config.get = mock.MagicMock(return_value=cloud_project.projectId)
+    project_config_manager = mock.Mock()
+    project_config_manager.try_get_project_config = mock.MagicMock(return_value=None)
+    project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)
+
+    initialize_container(api_client_to_use=api_client, push_manager_to_use=push_manager,
+                         project_config_manager_to_use=project_config_manager)
 
     cloud_project_manager = container.cloud_project_manager
     created_cloud_project = cloud_project_manager.get_cloud_project("Python Project", push=True)
@@ -41,3 +49,4 @@ def test_get_cloud_project_pushing_new_project():
     assert created_cloud_project == cloud_project
 
     api_client.projects.get.assert_called_with(cloud_project.projectId)
+    push_manager.push_projects.assert_called_once_with([Path.cwd() / "Python Project"])

--- a/tests/components/cloud/test_cloud_project_manager.py
+++ b/tests/components/cloud/test_cloud_project_manager.py
@@ -48,5 +48,5 @@ def test_get_cloud_project_pushing_new_project():
 
     assert created_cloud_project == cloud_project
 
-    api_client.projects.get.assert_called_with(cloud_project.projectId)
+    api_client.projects.get.assert_called_with(cloud_project.projectId, "abc")
     push_manager.push_projects.assert_called_once_with([Path.cwd() / "Python Project"])

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -34,7 +34,6 @@ from tests.test_helpers import create_fake_lean_cli_directory
 
 ENGINE_IMAGE = DockerImage.parse(DEFAULT_ENGINE_IMAGE)
 
-
 def create_lean_runner(docker_manager: mock.Mock) -> LeanRunner:
     logger = mock.Mock()
     logger.debug_logging_enabled = False

--- a/tests/components/util/test_organization_manager.py
+++ b/tests/components/util/test_organization_manager.py
@@ -65,3 +65,32 @@ def test_organization_manager_prompts_user_if_lean_config_does_not_have_the_orga
 
     mock_click_confirm.assert_called_once()
     assert "continue?" in mock_click_confirm.call_args.args[0]
+
+
+def test_organization_manager_sets_working_organization_to_given_config():
+    organization_id = "abc123"
+    lean_config = {}
+
+    lean_config_manager = mock.Mock()
+    lean_config_manager.set_properties = mock.Mock()
+
+    organization_manager = _create_organization_manager(lean_config_manager)
+
+    organization_manager.configure_working_organization_id(organization_id, lean_config)
+
+    assert "organization-id" in lean_config and lean_config["organization-id"] == organization_id
+    lean_config_manager.set_properties.assert_not_called()
+
+
+def test_organization_manager_sets_working_organization_using_lean_config_manager():
+    organization_id = "abc123"
+    lean_config_updates = {"organization-id": organization_id}
+
+    lean_config_manager = mock.Mock()
+    lean_config_manager.set_properties = mock.Mock()
+
+    organization_manager = _create_organization_manager(lean_config_manager)
+
+    organization_manager.configure_working_organization_id(organization_id)
+
+    lean_config_manager.set_properties.assert_called_once_with(lean_config_updates)

--- a/tests/components/util/test_organization_manager.py
+++ b/tests/components/util/test_organization_manager.py
@@ -1,0 +1,67 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+from typing import Optional, Dict, Any
+from unittest import mock
+
+import pytest
+
+from lean.components.util.organization_manager import OrganizationManager
+from lean.models.errors import AbortOperation
+
+
+def _create_organization_manager(lean_config_manager: mock.Mock = mock.Mock()) -> OrganizationManager:
+    logger = mock.Mock()
+    return OrganizationManager(logger, lean_config_manager)
+
+
+@pytest.mark.parametrize("use_lean_config_manager", [True, False])
+def test_organization_manager_gets_organization_id_from_lean_config(use_lean_config_manager: bool) -> None:
+    organization_id = "abc123"
+    lean_config = {'organization-id': organization_id}
+
+    lean_config_manager = mock.Mock()
+    lean_config_manager.get_lean_config = mock.MagicMock(return_value=lean_config)
+
+    organization_manager = _create_organization_manager(lean_config_manager)
+
+    if use_lean_config_manager:
+        lean_config = None
+
+    assert organization_manager.get_working_organization_id(lean_config) == organization_id
+
+    if use_lean_config_manager:
+        lean_config_manager.get_lean_config.assert_called()
+    else:
+        lean_config_manager.get_lean_config.assert_not_called()
+
+
+@pytest.mark.parametrize("proceed", [True, False])
+def test_organization_manager_prompts_user_if_lean_config_does_not_have_the_organization_id(proceed: bool) -> None:
+    lean_config_manager = mock.Mock()
+    lean_config_manager.get_lean_config = mock.MagicMock(return_value={})
+
+    organization_manager = _create_organization_manager(lean_config_manager)
+
+    def get_organization_id():
+        return organization_manager.get_working_organization_id()
+
+    with mock.patch('click.confirm', return_value=proceed) as mock_click_confirm:
+        if proceed:
+            assert get_organization_id() is None
+        else:
+            with pytest.raises(AbortOperation):
+                get_organization_id()
+
+    mock_click_confirm.assert_called_once()
+    assert "continue?" in mock_click_confirm.call_args.args[0]

--- a/tests/components/util/test_organization_manager.py
+++ b/tests/components/util/test_organization_manager.py
@@ -13,21 +13,17 @@
 
 from unittest import mock
 
-import click
 import pytest
 
 from lean.components.util.organization_manager import OrganizationManager
-from lean.models.api import QCMinimalOrganization
 
 
-def _create_organization_manager(api_client: mock.Mock = mock.Mock(),
-                                 lean_config_manager: mock.Mock = mock.Mock()) -> OrganizationManager:
+def _create_organization_manager(lean_config_manager: mock.Mock = mock.Mock()) -> OrganizationManager:
     logger = mock.Mock()
-    return OrganizationManager(logger, api_client, lean_config_manager)
+    return OrganizationManager(logger, lean_config_manager)
 
 
-@pytest.mark.parametrize("use_lean_config_manager", [True, False])
-def test_organization_manager_gets_organization_id_from_lean_config(use_lean_config_manager: bool) -> None:
+def test_organization_manager_gets_organization_id_from_lean_config() -> None:
     organization_id = "abc123"
     lean_config = {'organization-id': organization_id}
 
@@ -36,59 +32,21 @@ def test_organization_manager_gets_organization_id_from_lean_config(use_lean_con
 
     organization_manager = _create_organization_manager(lean_config_manager=lean_config_manager)
 
-    if use_lean_config_manager:
-        lean_config = None
-
-    assert organization_manager.get_working_organization_id(lean_config) == organization_id
-
-    if use_lean_config_manager:
-        lean_config_manager.get_lean_config.assert_called()
-    else:
-        lean_config_manager.get_lean_config.assert_not_called()
+    assert organization_manager.get_working_organization_id() == organization_id
+    lean_config_manager.get_lean_config.assert_called()
 
 
-@pytest.mark.parametrize("proceed", [True, False])
-def test_organization_manager_prompts_user_if_lean_config_does_not_have_the_organization_id(proceed: bool) -> None:
-    api_client = mock.Mock()
-    api_client.organizations.get_all = mock.MagicMock(return_value=[
-        QCMinimalOrganization(id="abc", name="abc", type="type", ownerName="You", members=1, preferred=True)
-    ])
-
+def test_try_get_id_aborts_if_organization_id_is_not_in_the_lean_config() -> None:
     lean_config_manager = mock.Mock()
     lean_config_manager.get_lean_config = mock.MagicMock(return_value={})
 
-    organization_manager = _create_organization_manager(api_client=api_client, lean_config_manager=lean_config_manager)
-
-    def get_organization_id():
-        return organization_manager.get_working_organization_id()
-
-    with mock.patch('click.confirm', return_value=proceed) as mock_click_confirm:
-        if proceed:
-            assert get_organization_id() == "abc"
-        else:
-            with pytest.raises(click.Abort):
-                get_organization_id()
-
-    mock_click_confirm.assert_called_once()
-    assert "continue?" in mock_click_confirm.call_args.args[0]
-
-
-def test_organization_manager_sets_working_organization_to_given_config():
-    organization_id = "abc123"
-    lean_config = {}
-
-    lean_config_manager = mock.Mock()
-    lean_config_manager.set_properties = mock.Mock()
-
     organization_manager = _create_organization_manager(lean_config_manager=lean_config_manager)
 
-    organization_manager.configure_working_organization_id(organization_id, lean_config)
-
-    assert "organization-id" in lean_config and lean_config["organization-id"] == organization_id
-    lean_config_manager.set_properties.assert_not_called()
+    with pytest.raises(RuntimeError):
+        organization_manager.try_get_working_organization_id()
 
 
-def test_organization_manager_sets_working_organization_using_lean_config_manager():
+def test_organization_manager_sets_working_organization_id_in_lean_config():
     organization_id = "abc123"
     lean_config_updates = {"organization-id": organization_id}
 

--- a/tests/components/util/test_push_manager.py
+++ b/tests/components/util/test_push_manager.py
@@ -24,7 +24,7 @@ from tests.test_helpers import create_fake_lean_cli_project
 
 def _create_organization_manager() -> mock.Mock:
     organization_manager = mock.Mock()
-    organization_manager.get_working_organization_id = mock.MagicMock(return_value=None)
+    organization_manager.try_get_working_organization_id = mock.MagicMock(return_value=None)
     return organization_manager
 
 
@@ -69,7 +69,7 @@ def test_push_project_uses_gets_organization_id_from_organization_manager() -> N
     push_manager = _create_push_manager(api_client, project_manager, organization_manager)
     push_manager.push_project(project_path)
 
-    organization_manager.get_working_organization_id.assert_called_once()
+    organization_manager.try_get_working_organization_id.assert_called_once()
 
 
 def test_push_projects_pushes_libraries_referenced_by_the_projects() -> None:

--- a/tests/components/util/test_push_manager.py
+++ b/tests/components/util/test_push_manager.py
@@ -24,7 +24,7 @@ from tests.test_helpers import create_fake_lean_cli_project
 
 def _create_organization_manager() -> mock.Mock:
     organization_manager = mock.Mock()
-    organization_manager.try_get_working_organization_id = mock.MagicMock(return_value=None)
+    organization_manager.try_get_working_organization_id = mock.MagicMock(return_value="abc")
     return organization_manager
 
 
@@ -127,9 +127,9 @@ def test_push_projects_pushes_libraries_referenced_by_the_projects() -> None:
                                                       any_order=True)
 
     api_client.projects.create.assert_has_calls([
-        mock.call(csharp_library_path.relative_to(lean_cli_root_dir).as_posix(), QCLanguage.CSharp, None),
-        mock.call(python_library_path.relative_to(lean_cli_root_dir).as_posix(), QCLanguage.Python, None),
-        mock.call(project_path.relative_to(lean_cli_root_dir).as_posix(), QCLanguage.Python, None)
+        mock.call(csharp_library_path.relative_to(lean_cli_root_dir).as_posix(), QCLanguage.CSharp, "abc"),
+        mock.call(python_library_path.relative_to(lean_cli_root_dir).as_posix(), QCLanguage.Python, "abc"),
+        mock.call(project_path.relative_to(lean_cli_root_dir).as_posix(), QCLanguage.Python, "abc")
     ], any_order=True)
 
     expected_update_call_arguments = [
@@ -232,7 +232,7 @@ def test_push_projects_adds_and_removes_libraries_simultaneously() -> None:
 
     api_client = mock.Mock()
 
-    def projects_get_side_effect(proj_id: int) -> QCProject:
+    def projects_get_side_effect(proj_id: int, organization_id: int) -> QCProject:
         return [p for p in [cloud_project, python_library_cloud_project, csharp_library_cloud_project]
                 if proj_id == p.projectId][0]
 
@@ -251,7 +251,7 @@ def test_push_projects_adds_and_removes_libraries_simultaneously() -> None:
 
     api_client.projects.create.assert_called_once_with(python_library_path.relative_to(lean_cli_root_dir).as_posix(),
                                                        QCLanguage.Python,
-                                                       None)
+                                                       "abc")
 
     expected_update_call_arguments = [
         {'project_id': python_library_id, 'libraries': []},

--- a/tests/components/util/test_push_manager.py
+++ b/tests/components/util/test_push_manager.py
@@ -22,13 +22,54 @@ from lean.models.api import QCLanguage, QCProject
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
 from tests.test_helpers import create_fake_lean_cli_project
 
-def _create_push_manager(api_client: mock.Mock, project_manager: mock.Mock) -> PushManager:
+def _create_organization_manager() -> mock.Mock:
+    organization_manager = mock.Mock()
+    organization_manager.get_working_organization_id = mock.MagicMock(return_value=None)
+    return organization_manager
+
+
+def _create_push_manager(api_client: mock.Mock, project_manager: mock.Mock,
+                         organization_manager: mock.Mock() = None) -> PushManager:
     logger = mock.Mock()
-    return PushManager(logger, api_client, project_manager, container.project_config_manager)
+    if organization_manager is None:
+        organization_manager = _create_organization_manager()
+
+    return PushManager(logger, api_client, project_manager, container.project_config_manager, organization_manager)
 
 
 def _get_base_cloud_projects() -> List[QCProject]:
     return [create_api_project(i, f"Project: number {i}") for i in range(1, 6)]
+
+
+def test_push_project_uses_gets_organization_id_from_organization_manager() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    project_manager = mock.Mock()
+    project_manager.get_project_libraries = mock.MagicMock(return_value=[])
+    project_manager.get_source_files = mock.MagicMock(return_value=[])
+
+    project_id = 1000
+    cloud_projects = [create_api_project(project_id, project_path.name)]
+    api_client = mock.Mock()
+
+    def create_project(proj_name, *args):
+        return next(iter(p for p in cloud_projects if p.name == proj_name))
+
+    def get_project(proj_id, *args):
+        return next(iter(p for p in cloud_projects if p.projectId == proj_id))
+
+    api_client.projects.create = mock.MagicMock(side_effect=create_project)
+    api_client.projects.get = mock.MagicMock(side_effect=get_project)
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+
+    organization_manager = _create_organization_manager()
+
+    push_manager = _create_push_manager(api_client, project_manager, organization_manager)
+    push_manager.push_project(project_path)
+
+    organization_manager.get_working_organization_id.assert_called_once()
 
 
 def test_push_projects_pushes_libraries_referenced_by_the_projects() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,8 @@ from lean.container import container
 
 
 def initialize_container(docker_manager_to_use=None, lean_runner_to_use=None, api_client_to_use=None,
-                         cloud_runner_to_use=None, push_manager_to_use=None, organization_manager_to_use=None):
+                         cloud_runner_to_use=None, push_manager_to_use=None, organization_manager_to_use=None,
+                         project_config_manager_to_use=None):
     api_client = mock.MagicMock()
     api_client.is_authenticated.return_value = True
     api_client.organizations.get_all.return_value = [
@@ -54,11 +55,16 @@ def initialize_container(docker_manager_to_use=None, lean_runner_to_use=None, ap
     if organization_manager_to_use:
         organization_manager = organization_manager_to_use
 
+    project_config_manager = None
+    if project_config_manager_to_use:
+        project_config_manager = project_config_manager_to_use
+
     # Reset all singletons so Path instances get recreated
     # Path instances are bound to the filesystem that was active at the time of their creation
     # When the filesystem changes, old Path instances bound to previous filesystems may cause weird behavior
 
-    container.initialize(docker_manager, api_client, lean_runner, cloud_runner, push_manager, organization_manager)
+    container.initialize(docker_manager, api_client, lean_runner, cloud_runner, push_manager, organization_manager,
+                         project_config_manager)
 
     return container
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from lean.container import container
 
 
 def initialize_container(docker_manager_to_use=None, lean_runner_to_use=None, api_client_to_use=None,
-                         cloud_runner_to_use=None, push_manager_to_use=None):
+                         cloud_runner_to_use=None, push_manager_to_use=None, organization_manager_to_use=None):
     api_client = mock.MagicMock()
     api_client.is_authenticated.return_value = True
     api_client.organizations.get_all.return_value = [
@@ -50,11 +50,15 @@ def initialize_container(docker_manager_to_use=None, lean_runner_to_use=None, ap
     if push_manager_to_use:
         push_manager = push_manager_to_use
 
+    organization_manager = None
+    if organization_manager_to_use:
+        organization_manager = organization_manager_to_use
+
     # Reset all singletons so Path instances get recreated
     # Path instances are bound to the filesystem that was active at the time of their creation
     # When the filesystem changes, old Path instances bound to previous filesystems may cause weird behavior
 
-    container.initialize(docker_manager, api_client, lean_runner, cloud_runner, push_manager)
+    container.initialize(docker_manager, api_client, lean_runner, cloud_runner, push_manager, organization_manager)
 
     return container
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,9 +51,12 @@ def initialize_container(docker_manager_to_use=None, lean_runner_to_use=None, ap
     if push_manager_to_use:
         push_manager = push_manager_to_use
 
-    organization_manager = None
     if organization_manager_to_use:
         organization_manager = organization_manager_to_use
+    else:
+        organization_manager = mock.Mock()
+        organization_manager.get_working_organization_id = mock.MagicMock(return_value="abc")
+        organization_manager.try_get_working_organization_id = mock.MagicMock(return_value="abc")
 
     project_config_manager = None
     if project_config_manager_to_use:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -74,18 +74,25 @@ def _write_fake_directory(files: dict) -> None:
             file.write(content)
 
 
+def _get_lean_config_file_content() -> str:
+    return """
+{
+    // data-folder documentation
+    "data-folder": "data",
+
+    // organization-id documentation
+    "organization-id": "abc"
+}
+"""
+
+
 def create_fake_lean_cli_directory() -> None:
     """Creates a directory structure similar to the one created by `lean init` with a Python and a C# project,
     and a Python and a C# library"""
     (Path.cwd() / "data").mkdir()
 
     files = {
-        (Path.cwd() / "lean.json"): """
-{
-    // data-folder documentation
-    "data-folder": "data"
-}
-        """,
+        (Path.cwd() / "lean.json"): _get_lean_config_file_content(),
         **_get_python_project_files(Path.cwd() / "Python Project"),
         **_get_csharp_project_files(Path.cwd() / "CSharp Project"),
         **_get_fake_libraries()
@@ -120,12 +127,7 @@ def create_fake_lean_cli_directory_with_subdirectories(depth: int) -> None:
     csharp_project_dir = Path.cwd() / sub_dirs / "CSharp Project"
 
     files = {
-        (Path.cwd() / "lean.json"): """
-{
-    // data-folder documentation
-    "data-folder": "data"
-}
-        """,
+        (Path.cwd() / "lean.json"): _get_lean_config_file_content(),
         **_get_python_project_files(python_project_dir),
         **_get_csharp_project_files(csharp_project_dir),
         **_get_fake_libraries()


### PR DESCRIPTION
This changes will make the CLI use the root `lean init` folder for a single organization:

- The user will have to run `lean init` in a single directory for each organization they belong to (and want to use the CLI with):
    - On init, the user has to give the ID or name of the organization to use (or select it interactively).
- The organization ID is stored in the `lean.json` file and it will be used by every command that needs it (using the `OrganizationManager`, if possible).
- Users using a previous CLI version (no `organization-id` in the `lean.json` file) will get a message informing them of the changes and what to do to keep using the CLI.

**Note:** the check for existence of the organization id the lean config file on every command adds a small overhad of around 6ms, which is acceptable considering that it is expected to be removed in the near future.