### PR TITLE
Fix log selected organization name in init

### DIFF
--- a/lean/commands/init.py
+++ b/lean/commands/init.py
@@ -66,7 +66,7 @@ def _select_organization() -> Tuple[str, str]:
 
     logger = container.logger
     organization_id = logger.prompt_list("Select the organization to use for this Lean CLI instance", options)
-    return organization_id, next(iter(o.name for o in organizations))
+    return organization_id, next(iter(o.name for o in organizations if o.id == organization_id))
 
 
 def _download_repository(output_path: Path) -> None:


### PR DESCRIPTION
Showing the correct organization name after organization selection in `lean init`