### PR TITLE
Feature optimize cloud pull when project rename

### DIFF
--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -294,7 +294,8 @@ def create_project(name: str, language: str) -> None:
     full_path = Path.cwd() / name
 
     if not container.path_manager.is_path_valid(full_path):
-        raise ValueError(f"'{name}' is not a valid path, can not contain [ {', '.join(forbidden_characters)} ], start with dot '.' or empty char ' '")
+        raise MoreInfoError(f"'{name}' is not a valid path, can not contain [ {', '.join(forbidden_characters)} ], start with dot '.' or empty char ' '",
+                         "https://www.lean.io/docs/v2/lean-cli/key-concepts/troubleshooting#02-Common-Errors")
 
     is_library_project = False
     try:

--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -20,6 +20,7 @@ from lean.container import container
 from lean.models.api import QCLanguage
 from lean.models.errors import MoreInfoError
 from lean.components.util.name_extraction import convert_to_class_name
+from lean.components import forbidden_characters
 
 DEFAULT_PYTHON_MAIN = '''
 from AlgorithmImports import *
@@ -293,8 +294,7 @@ def create_project(name: str, language: str) -> None:
     full_path = Path.cwd() / name
 
     if not container.path_manager.is_path_valid(full_path):
-        raise MoreInfoError(f"'{name}' is not a valid path",
-                            "https://www.lean.io/docs/v2/lean-cli/key-concepts/troubleshooting#02-Common-Errors")
+        raise ValueError(f"'{name}' is not a valid path, can not contain [ {', '.join(forbidden_characters)} ], start with dot '.' or empty char ' '")
 
     is_library_project = False
     try:

--- a/lean/components/__init__.py
+++ b/lean/components/__init__.py
@@ -14,3 +14,5 @@
 reserved_names = ["CON", "PRN", "AUX", "NUL",
                     "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
                     "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]
+
+forbidden_characters = ["\\", ":", "*", "?", '"', "<", ">", "|"]

--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -115,11 +115,13 @@ class PullManager:
             project.name = local_project_name
         
         # rename project on disk if we find a directory with the old name (invalid/renamed name)
-        project_path_on_disk = self._project_manager.try_get_project_path_by_cloud_id(project.projectId)
-        if project_path_on_disk:
-            project_name_on_disk = project_path_on_disk.relative_to(Path.cwd()).as_posix()
-            if project_name_on_disk != project.name:
-                self._project_manager.rename_project_and_contents(project_path_on_disk, Path.cwd() / project.name)
+        # only check for old directory if expected directory does not exist
+        if not local_project_path.exists():
+            project_path_on_disk = self._project_manager.try_get_project_path_by_cloud_id(project.projectId)
+            if project_path_on_disk:
+                project_name_on_disk = project_path_on_disk.relative_to(Path.cwd()).as_posix()
+                if project_name_on_disk != project.name:
+                    self._project_manager.rename_project_and_contents(project_path_on_disk, Path.cwd() / project.name)
 
         # Pull the cloud files to the local drive
         self._pull_files(project, local_project_path)

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -184,7 +184,8 @@ class PushManager:
 
         # update project name in cloud in case it was incorrect and renamed locally otherwise update the same name
         update_args["name"] = expected_correct_project_name
-        self._logger.info(f"Renaming project in cloud from '{cloud_project.name}' to '{expected_correct_project_name}'")
+        if cloud_project.name != expected_correct_project_name:
+            self._logger.info(f"Renaming project in cloud from '{cloud_project.name}' to '{expected_correct_project_name}'")
 
         if local_description != cloud_description:
             update_args["description"] = local_description

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -181,10 +181,10 @@ class PushManager:
         update_args = {}
 
         expected_correct_project_name = project.relative_to(Path.cwd()).as_posix()
-        if cloud_project.name != expected_correct_project_name:
-                # update project name in cloud
-                update_args["name"] = expected_correct_project_name
-                self._logger.info(f"Renaming project in cloud from '{cloud_project.name}' to '{expected_correct_project_name}'")
+
+        # update project name in cloud in case it was incorrect and renamed locally otherwise update the same name
+        update_args["name"] = expected_correct_project_name
+        self._logger.info(f"Renaming project in cloud from '{cloud_project.name}' to '{expected_correct_project_name}'")
 
         if local_description != cloud_description:
             update_args["description"] = local_description

--- a/lean/components/util/path_manager.py
+++ b/lean/components/util/path_manager.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from lean.components import reserved_names
+from lean.components import reserved_names, forbidden_characters
 from lean.components.util.platform_manager import PlatformManager
 
 class PathManager:
@@ -65,7 +65,7 @@ class PathManager:
                 if component.upper() == reserved_name or component.upper().startswith(reserved_name + "."):
                     return False
 
-            for forbidden_character in [":", "*", "?", '"', "<", ">", "|"]:
+            for forbidden_character in forbidden_characters:
                 if forbidden_character in component:
                     return False
         return True

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -24,7 +24,7 @@ from lean.components.util.xml_manager import XMLManager
 from lean.constants import PROJECT_CONFIG_FILE_NAME
 from lean.models.api import QCLanguage, QCProject
 from lean.models.utils import LeanLibraryReference
-
+from lean.components import forbidden_characters
 
 class ProjectManager:
     """The ProjectManager class provides utilities for handling a single project."""
@@ -366,7 +366,6 @@ class ProjectManager:
         # Windows, \":*?"<>| are forbidden
         # Windows, \ is a path separator, but \ is not a path separator on QuantConnect
         # We follow the rules of windows for every OS
-        forbidden_characters = ["\\", ":", "*", "?", '"', "<", ">", "|"]
 
         for forbidden_character in forbidden_characters:
             cloud_path = cloud_path.replace(forbidden_character, " ")

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -248,11 +248,11 @@ class ProjectManager:
         :param old_path: the local project to rename
         :param new_path: the new path of the project
         """
-        from shutil import move
         if not old_path.exists():
             raise RuntimeError(f"Failed to rename project. Could not find the specified path {old_path}.")
         if old_path == new_path:
             return
+        from shutil import move
         move(old_path, new_path)
         self._rename_csproj_file(new_path)
 
@@ -704,13 +704,13 @@ class ProjectManager:
 
         :param project_path: the local project path
         """
-        from shutil import move
         csproj_file = next(project_path.glob("*.csproj"), None)
         if not csproj_file:
             return
         new_csproj_file = project_path / f'{project_path.name}.csproj'
         if new_csproj_file.exists():
             return
+        from shutil import move
         move(csproj_file, new_csproj_file)
 
     def _generate_file(self, file: Path, content: str) -> None:

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -24,6 +24,7 @@ from lean.container import container
 from lean.models.api import QCProject, QCLanguage
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
 from tests.test_helpers import create_fake_lean_cli_project
+from lean.components import forbidden_characters
 
 def _create_pull_manager(api_client: mock.Mock,
                          project_config_manager: mock.Mock,
@@ -326,7 +327,7 @@ def test_pull_projects_updates_lean_config() -> None:
                                         any_order=True)
 
 
-@pytest.mark.parametrize("unsupported_character", ["\\", ":", "*", "?", '"', "<", ">", "|"])
+@pytest.mark.parametrize("unsupported_character", forbidden_characters)
 def test_pull_projects_detects_unsupported_paths(unsupported_character: str) -> None:
 
     create_fake_lean_cli_directory()
@@ -367,7 +368,7 @@ def test_pull_projects_detects_unsupported_paths(unsupported_character: str) -> 
     library_manager.remove_lean_library_from_project.assert_not_called()
 
 
-@pytest.mark.parametrize("unsupported_character", ["\\", ":", "*", "?", '"', "<", ">", "|"])
+@pytest.mark.parametrize("unsupported_character", forbidden_characters)
 def test_push_projects_updates_name_in_cloud_if_required(unsupported_character: str) -> None:
     create_fake_lean_cli_directory()
     project_name = "Project 1"
@@ -393,7 +394,7 @@ def test_push_projects_updates_name_in_cloud_if_required(unsupported_character: 
     assert "name" in kwargs and kwargs['name'] == project_name
 
 @pytest.mark.parametrize("test_platform, unsupported_character", [
-    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    *[("linux", char) for char in forbidden_characters],
     ("macos", ":")
 ])
 def test_pull_projects_renames_project_if_required(test_platform: str, unsupported_character: str) -> None:

--- a/tests/components/util/test_push_manager.py
+++ b/tests/components/util/test_push_manager.py
@@ -21,6 +21,7 @@ from lean.container import container
 from lean.models.api import QCLanguage, QCProject
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
 from tests.test_helpers import create_fake_lean_cli_project
+from lean.components import forbidden_characters
 
 def _create_organization_manager() -> mock.Mock:
     organization_manager = mock.Mock()
@@ -416,7 +417,7 @@ def test_push_projects_does_not_push_lean_environment_when_unset() -> None:
 
 
 @pytest.mark.parametrize("test_platform, unsupported_character", [
-    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    *[("linux", char) for char in forbidden_characters],
     ("macos", ":")
 ])
 def test_push_projects_detects_unsupported_paths(test_platform: str, unsupported_character: str) -> None:
@@ -441,7 +442,7 @@ def test_push_projects_detects_unsupported_paths(test_platform: str, unsupported
 
 
 @pytest.mark.parametrize("test_platform, unsupported_character", [
-    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    *[("linux", char) for char in forbidden_characters],
     ("macos", ":")
 ])
 def test_push_projects_renames_project_if_required(test_platform: str, unsupported_character: str) -> None:
@@ -469,7 +470,7 @@ def test_push_projects_renames_project_if_required(test_platform: str, unsupport
     assert (Path.cwd() / expected_correct_project_name).exists()
 
 @pytest.mark.parametrize("test_platform, unsupported_character", [
-    *[("linux", char) for char in ["\\", ":", "*", "?", '"', "<", ">", "|"]],
+    *[("linux", char) for char in forbidden_characters],
     ("macos", ":")
 ])
 def test_push_projects_updates_name_in_cloud_if_required(test_platform: str, unsupported_character: str) -> None:


### PR DESCRIPTION
This PR updates the followings:

- `lean cretae-project` error to be meaningful
- `lean cloud pull` to only check for rename if the expected directory is not present locally.
- `lean cloud push` always sends to project name to API

Tested `lean cloud pull` manually validating that for case:
- cloud name: `proj<>ect`
- local valid name: `proj ect`
- we first update the cloud name to `proj ect`
- then check if any directory with the expected name `proj ect` is already present before assuming that this was renamed in the cloud and we need to search for the local project with the old name `something else project`

![image](https://user-images.githubusercontent.com/28739120/200795158-406940bb-f4ed-490a-b4c8-d3737906f9cb.png)

