### PR TITLE
Bug ignore case

### DIFF
--- a/lean/commands/create_project.py
+++ b/lean/commands/create_project.py
@@ -301,6 +301,9 @@ def create_project(name: str, language: str) -> None:
     try:
         library_dir = container.lean_config_manager.get_cli_root_directory() / "Library"
         is_library_project = library_dir in full_path.parents
+        if is_library_project:
+            # Make sure we always use the same casing 'Library' for the library directory
+            full_path = library_dir / full_path.relative_to(library_dir)
     except:
         # get_cli_root_directory() raises an error if there is no such directory
         pass

--- a/lean/components/util/library_manager.py
+++ b/lean/components/util/library_manager.py
@@ -64,7 +64,7 @@ class LibraryManager:
 
         return (
             len(path_parts) > 0 and
-            path_parts[0] == "Library" and
+            path_parts[0].lower() == "library" and
             relative_path.is_dir() and
             library_language is not None
         )


### PR DESCRIPTION
This PR fixes `library add project` getting ignored because the case was not being ignored 

WIP 

Cloud only considers case sensitive `Library` directory 
 
![image (24)](https://user-images.githubusercontent.com/28739120/201328546-1904d1f7-d53a-4a0d-b6a2-33f8b9b7a6ca.png)