### PR TITLE
Detect pulling collaboration projects and libraries

### DIFF
--- a/lean/components/api/project_client.py
+++ b/lean/components/api/project_client.py
@@ -40,9 +40,6 @@ class ProjectClient:
 
         data = self._api.get("projects/read", payload)
 
-        data["projects"][0]["libraries"] = [{"id": library, "name": "SomeName", "owner": "Some Owner", "hasAccess": "false"}
-                                            for library in data["projects"][0]["libraries"]]
-
         return self._process_project(QCProject(**data["projects"][0]))
 
     def get_all(self, organization_id: Optional[str]) -> List[QCProject]:

--- a/lean/components/api/project_client.py
+++ b/lean/components/api/project_client.py
@@ -40,6 +40,9 @@ class ProjectClient:
 
         data = self._api.get("projects/read", payload)
 
+        data["projects"][0]["libraries"] = [{"id": library, "name": "SomeName", "owner": "Some Owner", "hasAccess": "false"}
+                                            for library in data["projects"][0]["libraries"]]
+
         return self._process_project(QCProject(**data["projects"][0]))
 
     def get_all(self, organization_id: Optional[str]) -> List[QCProject]:

--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -63,15 +63,15 @@ class PullManager:
         libraries = []
         inaccessible_libraries = []
         for library in project.libraries:
-            if library.id in seen_projects:
+            if library.projectId in seen_projects:
                 continue
 
-            if not library.hasAccess:
+            if not library.access:
                 inaccessible_libraries.append(library)
                 continue
 
-            seen_projects.append(library.id)
-            library = self._api_client.projects.get(library.id, project.organizationId)
+            seen_projects.append(library.projectId)
+            library = self._api_client.projects.get(library.projectId, project.organizationId)
             libraries.append(library)
             libs, inaccessible_libs = self._get_libraries(library, seen_projects)
             libraries.extend(libs)
@@ -100,8 +100,9 @@ class PullManager:
                 inaccessible_libraries.extend(libs_not_found)
 
         for library in inaccessible_libraries:
-            self._logger.warn(f"Cannot pull library {library.name} because you don't have access it. Please ask "
-                              f"{library.owner} to add you as a collaborator to the project in order to pull it.")
+            self._logger.warn(f"Cannot pull library '{library.libraryName}' because you don't have access it. "
+                              f"Please ask '{library.ownerName}' to add you as a collaborator to the project "
+                              f"in order to pull it.")
 
         projects_to_pull = sorted(projects_to_pull, key=lambda p: p.name)
         projects_with_paths = []
@@ -236,7 +237,7 @@ class PullManager:
 
     def _update_local_library_references(self, projects: List[Tuple[QCProject, Path]]) -> None:
         for project, path in projects:
-            libraries = [library.id for library in project.libraries]
+            libraries = [library.projectId for library in project.libraries]
             cloud_libraries_paths = [library_path for library, library_path in projects
                                      if library.projectId in libraries]
 

--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -19,7 +19,7 @@ from lean.components.util.library_manager import LibraryManager
 from lean.components.util.logger import Logger
 from lean.components.util.platform_manager import PlatformManager
 from lean.components.util.project_manager import ProjectManager
-from lean.models.api import QCProject, QCLanguage
+from lean.models.api import QCProject, QCLanguage, QCProjectLibrary
 from lean.models.utils import LeanLibraryReference
 
 class PullManager:
@@ -49,22 +49,38 @@ class PullManager:
         self._platform_manager = platform_manager
         self._last_file = None
 
-    def _get_libraries(self, project: QCProject, seen_projects: List[int] = None) -> List[QCProject]:
+    def _get_libraries(self, project: QCProject,
+                       seen_projects: List[int] = None) -> Tuple[List[QCProject], List[QCProjectLibrary]]:
+        """Gets the libraries referenced by the given project.
+
+        :return: two lists including the libraries referenced by the project.
+            The first one containing the library projects that could be fetched and
+            the second list containing the libraries that could not be fetched because the user has no access to them.
+        """
         if seen_projects is None:
             seen_projects = [project.projectId]
 
         libraries = []
-        for library_id in project.libraries:
-            if library_id in seen_projects:
+        inaccessible_libraries = []
+        for library in project.libraries:
+            if library.id in seen_projects:
                 continue
-            seen_projects.append(library_id)
-            library = self._api_client.projects.get(library_id, project.organizationId)
+
+            if not library.hasAccess:
+                inaccessible_libraries.append(library)
+                continue
+
+            seen_projects.append(library.id)
+            library = self._api_client.projects.get(library.id, project.organizationId)
             libraries.append(library)
-            libraries.extend(self._get_libraries(library, seen_projects))
+            libs, inaccessible_libs = self._get_libraries(library, seen_projects)
+            libraries.extend(libs)
+            inaccessible_libraries.extend(inaccessible_libs)
 
-        return libraries
+        return libraries, inaccessible_libraries
 
-    def pull_projects(self, projects_to_pull: List[QCProject], all_cloud_projects: Optional[List[QCProject]]) -> None:
+    def pull_projects(self, projects_to_pull: List[QCProject],
+                      all_cloud_projects: Optional[List[QCProject]] = None) -> None:
         """Pulls the given projects from the cloud to the local drive.
 
         This will also pull libraries referenced by the project.
@@ -73,11 +89,19 @@ class PullManager:
         :param all_cloud_projects: all the projects available in the cloud
         """
         if all_cloud_projects is not None:
-            projects_to_pull.extend(self._project_manager.get_cloud_projects_libraries(all_cloud_projects,
-                                                                                       projects_to_pull))
+            projects, inaccessible_libraries = self._project_manager.get_cloud_projects_libraries(all_cloud_projects,
+                                                                                               projects_to_pull)
+            projects_to_pull.extend(projects)
         else:
+            inaccessible_libraries = []
             for project in projects_to_pull:
-                projects_to_pull.extend(self._get_libraries(project, [p.projectId for p in projects_to_pull]))
+                projects, libs_not_found = self._get_libraries(project, [p.projectId for p in projects_to_pull])
+                projects_to_pull.extend(projects)
+                inaccessible_libraries.extend(libs_not_found)
+
+        for library in inaccessible_libraries:
+            self._logger.warn(f"Cannot pull library {library.name} because you don't have access it. Please ask "
+                              f"{library.owner} to add you as a collaborator to the project in order to pull it.")
 
         projects_to_pull = sorted(projects_to_pull, key=lambda p: p.name)
         projects_with_paths = []
@@ -113,7 +137,7 @@ class PullManager:
             self._api_client.projects.update(project.projectId, **{"name": local_project_name})
             self._logger.info(f"Renamed project in cloud from '{project.name}' to '{local_project_name}'")
             project.name = local_project_name
-        
+
         # rename project on disk if we find a directory with the old name (invalid/renamed name)
         # only check for old directory if expected directory does not exist
         if not local_project_path.exists():
@@ -212,8 +236,9 @@ class PullManager:
 
     def _update_local_library_references(self, projects: List[Tuple[QCProject, Path]]) -> None:
         for project, path in projects:
+            libraries = [library.id for library in project.libraries]
             cloud_libraries_paths = [library_path for library, library_path in projects
-                                     if library.projectId in project.libraries]
+                                     if library.projectId in libraries]
 
             # Add cloud library references to local config
             self._add_local_library_references_to_project(path, cloud_libraries_paths)

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -781,10 +781,10 @@ class ProjectManager:
 
         libraries = [cloud_project
                      for library in project.libraries
-                     for cloud_project in cloud_projects if cloud_project.projectId == library.id]
+                     for cloud_project in cloud_projects if cloud_project.projectId == library.projectId]
 
         libraries_ids = [library.projectId for library in libraries]
-        libraries_not_found = [library for library in project.libraries if library.id not in libraries_ids]
+        libraries_not_found = [library for library in project.libraries if library.projectId not in libraries_ids]
 
         referenced_libraries = []
         for library in libraries:

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -72,18 +72,18 @@ class QCLanguage(str, Enum):
 
 
 class QCProjectLibrary(WrappedBaseModel):
-    id: int
-    name: str
-    owner: str
-    hasAccess: bool
+    projectId: int
+    libraryName: str
+    ownerName: str
+    access: bool
 
     def __hash__(self):
-        return hash(self.id)
+        return hash(self.projectId)
 
     def __eq__(self, other: Any):
         if not isinstance(other, type(self)):
             return NotImplemented
-        return self.id == other.id
+        return self.projectId == other.projectId
 
 
 class QCProject(WrappedBaseModel):

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -71,6 +71,21 @@ class QCLanguage(str, Enum):
     Python = "Py"
 
 
+class QCProjectLibrary(WrappedBaseModel):
+    id: int
+    name: str
+    owner: str
+    hasAccess: bool
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other: Any):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.id == other.id
+
+
 class QCProject(WrappedBaseModel):
     projectId: int
     organizationId: str
@@ -85,7 +100,7 @@ class QCProject(WrappedBaseModel):
     leanEnvironment: int
     parameters: List[QCParameter]
     liveResults: QCLiveResults
-    libraries: List[int]
+    libraries: List[QCProjectLibrary]
 
     @validator("parameters", pre=True)
     def process_parameters_dict(cls, value: Any) -> Any:

--- a/tests/components/api/test_clients.py
+++ b/tests/components/api/test_clients.py
@@ -126,7 +126,7 @@ def test_projects_crud() -> None:
         retrieved_project = project_client.get(created_project.projectId)
 
         assert len(retrieved_project.libraries) == 1
-        assert retrieved_project.libraries[0].id == library_project.projectId
+        assert retrieved_project.libraries[0].projectId == library_project.projectId
 
         # Test libraries can be deleted
         project_client.delete_library(created_project.projectId, library_project.projectId)

--- a/tests/components/api/test_clients.py
+++ b/tests/components/api/test_clients.py
@@ -125,7 +125,8 @@ def test_projects_crud() -> None:
         project_client.add_library(created_project.projectId, library_project.projectId)
         retrieved_project = project_client.get(created_project.projectId)
 
-        assert retrieved_project.libraries == [library_project.projectId]
+        assert len(retrieved_project.libraries) == 1
+        assert retrieved_project.libraries[0].id == library_project.projectId
 
         # Test libraries can be deleted
         project_client.delete_library(created_project.projectId, library_project.projectId)

--- a/tests/components/util/test_project_manager.py
+++ b/tests/components/util/test_project_manager.py
@@ -536,15 +536,18 @@ def test_get_cloud_projects_libraries_filters_libraries_that_cannot_be_accessed(
     for i, project in enumerate(projects):
         start = 3 * i
         own_project_libs = cloud_libraries[start:start + 3]
-        own_libraries = [QCProjectLibrary(id=library.projectId, name=library.name, owner="Owner", hasAccess=True)
+        own_libraries = [QCProjectLibrary(projectId=library.projectId,
+                                          libraryName=library.name,
+                                          ownerName="Owner",
+                                          access=True)
                          for library in own_project_libs]
         project.libraries.extend(own_libraries)
         own_project_libraries.extend(own_project_libs)
 
-        collab_libs = [QCProjectLibrary(id=1000 + start + j,
-                                        name=f"Library/Library{1000 + start + j}",
-                                        owner="Another Owner",
-                                        hasAccess=False)
+        collab_libs = [QCProjectLibrary(projectId=1000 + start + j,
+                                        libraryName=f"Library/Library{1000 + start + j}",
+                                        ownerName="Another Owner",
+                                        access=False)
                        for j in range(3)]
         project.libraries.extend(collab_libs)
         collab_libraries.extend(collab_libs)

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -45,7 +45,10 @@ def _make_cloud_projects_and_libraries(project_count: int,
 
 
 def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject], withAccess: bool = True) -> None:
-    libraries = [QCProjectLibrary(id=library.projectId, name=library.name, owner="Owner", hasAccess=withAccess)
+    libraries = [QCProjectLibrary(projectId=library.projectId,
+                                  libraryName=library.name,
+                                  ownerName="Owner",
+                                  access=withAccess)
                  for library in libraries]
     project.libraries.extend(libraries)
 
@@ -159,8 +162,8 @@ def test_pulls_libraries_referenced_by_the_project() -> None:
     pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries] +
-        [mock.call(library.id) for library in test_library.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.projectId) for library in test_project.libraries] +
+        [mock.call(library.projectId) for library in test_library.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -236,7 +239,7 @@ def test_pull_adds_and_removes_library_references_simultaneously() -> None:
     pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.projectId) for library in test_project.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -276,8 +279,8 @@ def test_pull_projects_restores_csharp_projects_and_its_libraries() -> None:
         pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries] +
-        [mock.call(library.id) for library in test_csharp_library1.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.projectId) for library in test_project.libraries] +
+        [mock.call(library.projectId) for library in test_csharp_library1.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -359,7 +362,7 @@ def test_pull_projects_detects_unsupported_paths(unsupported_character: str) -> 
     pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.projectId) for library in test_project.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(

--- a/tests/components/util/test_pull_manager.py
+++ b/tests/components/util/test_pull_manager.py
@@ -21,7 +21,7 @@ from lean.components.cloud.pull_manager import PullManager
 from lean.components.config.storage import Storage
 from lean.components.util.project_manager import ProjectManager
 from lean.container import container
-from lean.models.api import QCProject, QCLanguage
+from lean.models.api import QCProject, QCLanguage, QCProjectLibrary
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project, create_lean_environments
 from tests.test_helpers import create_fake_lean_cli_project
 from lean.components import forbidden_characters
@@ -44,16 +44,17 @@ def _make_cloud_projects_and_libraries(project_count: int,
     return cloud_projects, libraries
 
 
-def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject]) -> None:
-    libraries_ids = [library.projectId for library in libraries]
-    project.libraries.extend(libraries_ids)
+def _add_libraries_to_cloud_project(project: QCProject, libraries: List[QCProject], withAccess: bool = True) -> None:
+    libraries = [QCProjectLibrary(id=library.projectId, name=library.name, owner="Owner", hasAccess=withAccess)
+                 for library in libraries]
+    project.libraries.extend(libraries)
 
 
 def _add_local_library_to_local_project(project_path: Path, library_path: Path) -> None:
     library_manager = container.library_manager
     library_manager.add_lean_library_to_project(project_path, library_path, False)
 
-    
+
 def _assert_pull_manager_adds_property_to_project_config(prop: str,
                                                          expected_value: Any,
                                                          cloud_projects: List[QCProject]) -> None:
@@ -158,8 +159,8 @@ def test_pulls_libraries_referenced_by_the_project() -> None:
     pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries] +
-        [mock.call(library_id) for library_id in test_library.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries] +
+        [mock.call(library.id) for library in test_library.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -235,7 +236,7 @@ def test_pull_adds_and_removes_library_references_simultaneously() -> None:
     pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -275,8 +276,8 @@ def test_pull_projects_restores_csharp_projects_and_its_libraries() -> None:
         pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries] +
-        [mock.call(library_id) for library_id in test_csharp_library1.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries] +
+        [mock.call(library.id) for library in test_csharp_library1.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -358,7 +359,7 @@ def test_pull_projects_detects_unsupported_paths(unsupported_character: str) -> 
     pull_manager.pull_projects([test_project], cloud_projects)
 
     api_client.files.get_all.assert_has_calls(
-        [mock.call(test_project.projectId)] + [mock.call(library_id) for library_id in test_project.libraries],
+        [mock.call(test_project.projectId)] + [mock.call(library.id) for library in test_project.libraries],
         any_order=True)
 
     library_manager.add_lean_library_to_project.assert_has_calls(
@@ -398,7 +399,7 @@ def test_push_projects_updates_name_in_cloud_if_required(unsupported_character: 
     ("macos", ":")
 ])
 def test_pull_projects_renames_project_if_required(test_platform: str, unsupported_character: str) -> None:
-    
+
     if test_platform == "linux" and platform.system() != "Linux":
         pytest.skip("This test requires Linux")
 
@@ -432,3 +433,45 @@ def test_pull_projects_renames_project_if_required(test_platform: str, unsupport
 
     assert not (Path.cwd() / unsupported_name).exists()
     assert (Path.cwd() / project_name).exists()
+
+
+def test_pull_project_doesnt_pull_libraries_the_user_doesnt_have_access_to() -> None:
+    create_fake_lean_cli_directory()
+
+    cloud_projects, libraries = _make_cloud_projects_and_libraries(5, 15)
+    cloud_projects.extend(libraries)
+
+    test_project = cloud_projects[0]
+    test_project_own_libraries = libraries[:2]
+    _add_libraries_to_cloud_project(test_project, test_project_own_libraries)
+    test_project_collab_libraries = libraries[2:4]
+    _add_libraries_to_cloud_project(test_project, test_project_collab_libraries, False)
+
+    test_library = test_project_own_libraries[0]
+    test_library_own_libraries = libraries[4:6]
+    _add_libraries_to_cloud_project(test_library, test_library_own_libraries)
+    test_library_collab_libraries = libraries[4:6]
+    _add_libraries_to_cloud_project(test_library, test_library_collab_libraries, False)
+
+    def api_client_projects_get_side_effect(project_id: int, *args):
+        return next(iter(x for x in cloud_projects if x.projectId == project_id))
+
+    api_client = mock.Mock()
+    api_client.files.get_all = mock.MagicMock(return_value=[])
+    api_client.projects.get = mock.MagicMock(side_effect=api_client_projects_get_side_effect)
+
+    library_manager = mock.Mock()
+    library_manager.add_lean_library_to_project = mock.Mock()
+    library_manager.remove_lean_library_from_project = mock.Mock()
+
+    pull_manager = _create_pull_manager(api_client, container.project_config_manager, library_manager)
+    pull_manager.pull_projects([test_project])
+
+    api_client.files.get_all.assert_called()
+    library_manager.add_lean_library_to_project.assert_has_calls(
+        [mock.call(Path.cwd() / test_project.name, Path.cwd() / library.name, True)
+         for library in test_project_own_libraries] +
+        [mock.call(Path.cwd() / test_library.name, Path.cwd() / library.name, True)
+         for library in test_library_own_libraries],
+        any_order=True)
+    library_manager.remove_lean_library_from_project.assert_not_called()


### PR DESCRIPTION
- Detect inaccessible libraries in collaboration projects on pull.
- Warn the user about it and keep on pulling everything else.
