### PR TITLE
Optimization estimate option in `optimize` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Usage: lean cloud live deploy [OPTIONS] PROJECT
   --notify-insights.
 
 Options:
-  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Trading Technologies|Kraken|FTX]
+  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Trading Technologies|Kraken]
                                   The brokerage to use
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -302,16 +302,6 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
-  --ftx-exchange-name [FTX|FTXUS]
-                                  FTX exchange name [FTX, FTXUS]
-  --ftx-api-key TEXT              Your FTX API key
-  --ftxus-api-key TEXT            Your FTX API key
-  --ftx-api-secret TEXT           Your FTX API secret
-  --ftxus-api-secret TEXT         Your FTX API secret
-  --ftx-account-tier [Tier1|Tier2|Tier3|Tier4|Tier5|Tier6|VIP1|VIP2|VIP3|MM1|MM2|MM3]
-                                  Your FTX Account Tier
-  --ftxus-account-tier [Tier1|Tier2|Tier3|Tier4|Tier5|Tier6|Tier7|Tier8|Tier9|VIP1|VIP2|MM1|MM2|MM3]
-                                  Your FTX Account Tier
   --node TEXT                     The name or id of the live node to run on
   --auto-restart BOOLEAN          Whether automatic algorithm restarting must be enabled
   --notify-order-events BOOLEAN   Whether notifications must be sent for order events
@@ -855,9 +845,9 @@ Options:
   --environment TEXT              The environment to use
   --output DIRECTORY              Directory to store results in (defaults to PROJECT/live/TIMESTAMP)
   -d, --detach                    Run the live deployment in a detached Docker container and return immediately
-  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Atreyu|Trading Technologies|Kraken|FTX]
+  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Atreyu|Trading Technologies|Kraken]
                                   The brokerage to use
-  --data-feed [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Kraken|FTX|IQFeed|Polygon Data Feed|Custom data only]
+  --data-feed [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Kraken|IQFeed|Polygon Data Feed|Custom data only]
                                   The data feed to use
   --data-provider [Terminal Link|QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider
@@ -959,20 +949,10 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
-  --ftx-exchange-name [FTX|FTXUS]
-                                  FTX exchange name [FTX, FTXUS]
-  --ftx-api-key TEXT              Your FTX API key
-  --ftxus-api-key TEXT            Your FTX API key
-  --ftx-api-secret TEXT           Your FTX API secret
-  --ftxus-api-secret TEXT         Your FTX API secret
-  --ftx-account-tier [Tier1|Tier2|Tier3|Tier4|Tier5|Tier6|VIP1|VIP2|VIP3|MM1|MM2|MM3]
-                                  Your FTX Account Tier
-  --ftxus-account-tier [Tier1|Tier2|Tier3|Tier4|Tier5|Tier6|Tier7|Tier8|Tier9|VIP1|VIP2|MM1|MM2|MM3]
-                                  Your FTX Account Tier
   --ib-enable-delayed-streaming-data BOOLEAN
                                   Whether delayed data may be used when your algorithm subscribes to a security you
                                   don't have a market data subscription for
-  --iqfeed-iqconnect FILE         The path to the IQConnect binary
+  --iqfeed-iqconnect TEXT         The path to the IQConnect binary
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-productName TEXT       The product name of your IQFeed developer account
@@ -1165,6 +1145,9 @@ Usage: lean optimize [OPTIONS] PROJECT
   - --constraint "<statistic> <operator> <value>"
   - --constraint "Sharpe Ratio >= 0.5" --constraint "Drawdown < 0.25"
 
+  If --estimate is given, the optimization will not be executed.
+  The runtime estimate for the optimization will be calculated and outputted.
+
   By default the official LEAN engine image is used. You can override this using the --image option. Alternatively you
   can set the default engine image for all commands using `lean config set engine-image <image>`.
 
@@ -1182,6 +1165,9 @@ Options:
   --release                       Compile C# projects in release configuration instead of debug
   --image TEXT                    The LEAN engine image to use (defaults to quantconnect/lean:latest)
   --update                        Pull the LEAN engine image before running the optimizer
+  --estimate                      Estimate optimization runtime without running it
+  --max-concurrent-backtests INTEGER RANGE
+                                  Maximum number of concurrent backtests to run  [x>=1]
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -25,7 +25,7 @@ from lean.models.errors import MoreInfoError
 from lean.models.optimizer import OptimizationTarget
 
 
-def get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
+def _get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
     from re import findall
     from dateutil.parser import isoparse
 
@@ -61,7 +61,6 @@ def get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
     latest_backtest_logs = latest_backtest_log_file.read_text(encoding="utf-8")
     timestamps = findall(r"(.+) TRACE:: .*\n", latest_backtest_logs)
 
-    # return datetime.strptime(timestamps[-1]) - datetime.strptime(timestamps[0])
     return isoparse(timestamps[-1]) - isoparse(timestamps[0])
 
 
@@ -176,7 +175,7 @@ def optimize(project: Path,
 
     latest_backtest_runtime = timedelta(0)
     if estimate:
-        latest_backtest_runtime = get_latest_backtest_runtime(algorithm_file.parent)
+        latest_backtest_runtime = _get_latest_backtest_runtime(algorithm_file.parent)
 
     if output is None:
         output = algorithm_file.parent / "optimizations" / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")

--- a/tests/commands/test_optimize.py
+++ b/tests/commands/test_optimize.py
@@ -15,6 +15,7 @@ import json
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 
 from lean.commands import lean
@@ -516,3 +517,239 @@ def test_optimize_runs_custom_image_when_given_as_option() -> None:
     args, kwargs = docker_manager.run_image.call_args
 
     assert args[0] == DockerImage(name="custom/lean", tag="456")
+
+
+@pytest.mark.parametrize("max_concurrent_backtests", range(1, 4))
+def test_optimize_uses_the_given_max_concurrent_backtests(max_concurrent_backtests: int) -> None:
+    create_fake_lean_cli_directory()
+
+    docker_manager = mock.Mock()
+    docker_manager.run_image.side_effect = run_image
+    container.initialize(docker_manager=docker_manager)
+    container.optimizer_config_manager = _get_optimizer_config_manager_mock()
+
+    Storage(str(Path.cwd() / "Python Project" / "config.json")).set("parameters", {"param1": "1"})
+
+    result = CliRunner().invoke(lean, ["optimize", "Python Project",
+                                       "--max-concurrent-backtests", max_concurrent_backtests])
+
+    assert result.exit_code == 0
+
+    docker_manager.run_image.assert_called_once()
+    args, kwargs = docker_manager.run_image.call_args
+
+    mount = next(m for m in kwargs["mounts"] if m["Target"] == "/Lean/Optimizer.Launcher/bin/Debug/config.json")
+    config = json.loads(Path(mount["Source"]).read_text(encoding="utf-8"))
+
+    assert config["maximum-concurrent-backtests"] == max_concurrent_backtests
+
+
+def test_optimize_estimate_fails_if_no_backtests_have_been_run() -> None:
+    create_fake_lean_cli_directory()
+
+    result = CliRunner().invoke(lean, ["optimize", "Python Project", "--estimate"])
+
+    assert result.exit_code != 0
+
+    expected_message = "Please run at least one backtest for this project in order to run an optimization estimate"
+    assert expected_message in result.exception.args[0]
+
+
+@pytest.mark.parametrize("max_concurrent_backtests, expected_runtime", [(2, "0:01:10.568375"),
+                                                                        (3, "0:00:47.045583"),
+                                                                        (4, "0:00:35.284188")])
+def test_optimize_estimate_properly_calculates_runtime(max_concurrent_backtests: int, expected_runtime: str) -> None:
+    create_fake_lean_cli_directory()
+
+    backtest_log_file = Path.cwd() / "Python Project" / "backtests" / "2020-01-01_00-00-00" / "log.txt"
+    backtest_log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with backtest_log_file.open("w+", encoding="utf-8") as logs:
+        logs.write("""
+2022-11-25T15:04:37.6556705Z TRACE:: Config.Get(): Configuration key not found. Key: data-directory - Using default value: ../../../Data/
+2022-11-25T15:04:37.6623325Z TRACE:: Config.Get(): Configuration key not found. Key: version-id - Using default value:
+2022-11-25T15:04:37.6669692Z TRACE:: Config.Get(): Configuration key not found. Key: cache-location - Using default value: /Lean/Data
+2022-11-25T15:04:37.6683605Z TRACE:: Engine.Main(): LEAN ALGORITHMIC TRADING ENGINE v2.5.0.0 Mode: DEBUG (64bit) Host: abreu
+2022-11-25T15:04:37.6809416Z TRACE:: Engine.Main(): Started 3:04 PM
+2022-11-25T15:04:37.6910935Z TRACE:: Config.Get(): Configuration key not found. Key: lean-manager-type - Using default value: LocalLeanManager
+2022-11-25T15:04:37.7399317Z TRACE:: JobQueue.NextJob(): Selected ParametrizedAlgorithm.dll
+2022-11-25T15:04:37.8757698Z TRACE:: Config.GetValue(): scheduled-event-leaky-bucket-capacity - Using default value: 120
+2022-11-25T15:04:37.8764057Z TRACE:: Config.GetValue(): scheduled-event-leaky-bucket-time-interval-minutes - Using default value: 1440
+2022-11-25T15:04:37.8768633Z TRACE:: Config.GetValue(): scheduled-event-leaky-bucket-refill-amount - Using default value: 18
+2022-11-25T15:04:37.8804663Z TRACE:: Config.GetValue(): storage-limit - Using default value: 10737418240
+2022-11-25T15:04:37.8811283Z TRACE:: Config.GetValue(): storage-permissions - Using default value: 3
+2022-11-25T15:04:37.8819123Z TRACE:: Config.Get(): Configuration key not found. Key: backtest-name - Using default value: local
+2022-11-25T15:04:37.8853002Z TRACE:: Config.Get(): Configuration key not found. Key: job-organization-id - Using default value:
+2022-11-25T15:04:37.8859221Z TRACE:: Config.Get(): Configuration key not found. Key: python-venv - Using default value:
+2022-11-25T15:04:37.8882173Z TRACE:: Config.Get(): Configuration key not found. Key: data-permission-manager - Using default value: DataPermissionManager
+2022-11-25T15:04:37.9367442Z TRACE:: AlgorithmManager.CreateTokenBucket(): Initializing LeakyBucket: Capacity: 120 RefillAmount: 18 TimeInterval: 1440
+2022-11-25T15:04:37.9400835Z TRACE:: Config.GetValue(): algorithm-manager-time-loop-maximum - Using default value: 20
+2022-11-25T15:04:37.9534255Z TRACE:: Engine.Run(): Resource limits '0' CPUs. 2147483647 MB RAM.
+2022-11-25T15:04:37.9551149Z TRACE:: TextSubscriptionDataSourceReader.SetCacheSize(): Setting cache size to 71582788 items
+2022-11-25T15:04:38.4999911Z TRACE:: Config.GetValue(): algorithm-creation-timeout - Using default value: 90
+2022-11-25T15:04:38.5064153Z TRACE:: Loader.TryCreateILAlgorithm(): Loading only the algorithm assembly
+2022-11-25T15:04:38.5110230Z TRACE:: Config.GetValue(): ema-fast - Using default value: 100
+2022-11-25T15:04:38.5116188Z TRACE:: Config.GetValue(): ema-slow - Using default value: 200
+2022-11-25T15:04:38.5249196Z TRACE:: Config.GetValue(): api-data-update-period - Using default value: 1
+2022-11-25T15:04:38.6560232Z TRACE:: Loader.TryCreateILAlgorithm(): Loaded ParametrizedAlgorithm
+2022-11-25T15:04:38.6858198Z TRACE:: LocalObjectStore.Initialize(): Storage Root: /Storage. StorageFileCount 9999999. StorageLimit 10240MB
+2022-11-25T15:04:38.7197877Z TRACE:: HistoryProviderManager.Initialize(): history providers [SubscriptionDataReaderHistoryProvider]
+2022-11-25T15:04:38.7259645Z TRACE:: BacktestingSetupHandler.Setup(): Setting up job: UID: 200374, PID: 912831163, Version: 2.5.0.0, Source: WebIDE
+2022-11-25T15:04:38.7342927Z TRACE:: Config.Get(): Configuration key not found. Key: security-data-feeds - Using default value:
+2022-11-25T15:04:39.0841083Z TRACE:: BaseSetupHandler.SetupCurrencyConversions():
+Account Type: Margin
+
+Symbol      Quantity    Conversion = Value in USD
+USD: $      100000.00 @       1.00 = $100000.0
+-------------------------------------------------
+CashBook Total Value:                $100000.0
+
+2022-11-25T15:04:39.0891304Z TRACE:: SetUp Backtesting: User: 200374 ProjectId: 912831163 AlgoId: 1347518945
+2022-11-25T15:04:39.0912471Z TRACE:: Dates: Start: 10/07/2013 End: 10/08/2013 Cash: ¤100,000.00 MaximumRuntime: 100.00:00:00 MaxOrders: 2147483647
+2022-11-25T15:04:39.0953964Z TRACE:: BacktestingResultHandler(): Sample Period Set: 04.00
+2022-11-25T15:04:39.0981582Z TRACE:: Time.TradeableDates(): Security Count: 1
+2022-11-25T15:04:39.1067040Z TRACE:: Config.GetValue(): forward-console-messages - Using default value: True
+2022-11-25T15:04:39.1115510Z TRACE:: JOB HANDLERS:
+         DataFeed:             QuantConnect.Lean.Engine.DataFeeds.FileSystemDataFeed
+         Setup:                QuantConnect.Lean.Engine.Setup.BacktestingSetupHandler
+         RealTime:             QuantConnect.Lean.Engine.RealTime.BacktestingRealTimeHandler
+         Results:              QuantConnect.Lean.Engine.Results.BacktestingResultHandler
+         Transactions:         QuantConnect.Lean.Engine.TransactionHandlers.BacktestingTransactionHandler
+         Alpha:                QuantConnect.Lean.Engine.Alphas.DefaultAlphaHandler
+         Object Store:         QuantConnect.Lean.Engine.Storage.LocalObjectStore
+         History Provider:     QuantConnect.Lean.Engine.HistoricalData.HistoryProviderManager
+         Brokerage:            QuantConnect.Brokerages.Backtesting.BacktestingBrokerage
+         Data Provider:        QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider
+
+2022-11-25T15:04:39.1704075Z TRACE:: Debug: Launching analysis for 1347518945 with LEAN Engine v2.5.0.0
+2022-11-25T15:04:39.1950135Z TRACE:: Event Name "Daily Sampling", scheduled to run.
+2022-11-25T15:04:39.1985939Z TRACE:: AlgorithmManager.Run(): Begin DataStream - Start: 10/7/2013 12:00:00 AM Stop: 10/8/2013 11:59:59 PM Time: 10/7/2013 12:00:00 AM Warmup: False
+2022-11-25T15:04:39.2701271Z TRACE:: Config.GetValue(): data-feed-workers-count - Using default value: 8
+2022-11-25T15:04:39.2715890Z TRACE:: Config.GetValue(): data-feed-max-work-weight - Using default value: 400
+2022-11-25T15:04:39.2722741Z TRACE:: WeightedWorkScheduler(): will use 8 workers and MaxWorkWeight is 400
+2022-11-25T15:04:39.4354501Z TRACE:: UniverseSelection.AddPendingInternalDataFeeds(): Adding internal benchmark data feed SPY,#0,SPY,Hour,TradeBar,Trade,Adjusted,OpenInterest,Internal
+2022-11-25T15:04:39.8316645Z TRACE:: Synchronizer.GetEnumerator(): Exited thread.
+2022-11-25T15:04:39.8360508Z TRACE:: AlgorithmManager.Run(): Firing On End Of Algorithm...
+2022-11-25T15:04:39.8386196Z TRACE:: Engine.Run(): Exiting Algorithm Manager
+2022-11-25T15:04:39.8444890Z TRACE:: StopSafely(): waiting for 'Isolator Thread' thread to stop...
+2022-11-25T15:04:39.8456755Z TRACE:: FileSystemDataFeed.Exit(): Start. Setting cancellation token...
+2022-11-25T15:04:39.8541874Z TRACE:: FileSystemDataFeed.Exit(): Exit Finished.
+2022-11-25T15:04:39.8552627Z TRACE:: DefaultAlphaHandler.Exit(): Exiting...
+2022-11-25T15:04:39.8707062Z TRACE:: DefaultAlphaHandler.Exit(): Ended
+2022-11-25T15:04:39.8739784Z TRACE:: BacktestingResultHandler.Exit(): starting...
+2022-11-25T15:04:39.8751163Z TRACE:: BacktestingResultHandler.Exit(): Saving logs...
+2022-11-25T15:04:39.8764845Z TRACE:: Debug: Algorithm Id:(1347518945) completed in 0.73 seconds at 2k data points per second. Processing total of 1,582 data points.
+2022-11-25T15:04:39.8918962Z TRACE:: Debug: Your log was successfully created and can be retrieved from: /Results/1347518945-log.txt
+2022-11-25T15:04:39.8920058Z TRACE:: StopSafely(): waiting for 'Result Thread' thread to stop...
+2022-11-25T15:04:39.8934249Z TRACE:: BacktestingResultHandler.Run(): Ending Thread...
+2022-11-25T15:04:40.3103850Z TRACE::
+STATISTICS:: Total Trades 0
+STATISTICS:: Average Win 0%
+STATISTICS:: Average Loss 0%
+STATISTICS:: Compounding Annual Return 0%
+STATISTICS:: Drawdown 0%
+STATISTICS:: Expectancy 0
+STATISTICS:: Net Profit 0%
+STATISTICS:: Sharpe Ratio 0
+STATISTICS:: Probabilistic Sharpe Ratio 0%
+STATISTICS:: Loss Rate 0%
+STATISTICS:: Win Rate 0%
+STATISTICS:: Profit-Loss Ratio 0
+STATISTICS:: Alpha 0
+STATISTICS:: Beta 0
+STATISTICS:: Annual Standard Deviation 0
+STATISTICS:: Annual Variance 0
+STATISTICS:: Information Ratio 0
+STATISTICS:: Tracking Error 0
+STATISTICS:: Treynor Ratio 0
+STATISTICS:: Total Fees $0.00
+STATISTICS:: Estimated Strategy Capacity $0
+STATISTICS:: Lowest Capacity Asset
+STATISTICS:: Fitness Score 0
+STATISTICS:: Kelly Criterion Estimate 0
+STATISTICS:: Kelly Criterion Probability Value 0
+STATISTICS:: Sortino Ratio 79228162514264337593543950335
+STATISTICS:: Return Over Maximum Drawdown 79228162514264337593543950335
+STATISTICS:: Portfolio Turnover 0
+STATISTICS:: Total Insights Generated 0
+STATISTICS:: Total Insights Closed 0
+STATISTICS:: Total Insights Analysis Completed 0
+STATISTICS:: Long Insight Count 0
+STATISTICS:: Short Insight Count 0
+STATISTICS:: Long/Short Ratio 100%
+STATISTICS:: Estimated Monthly Alpha Value $0
+STATISTICS:: Total Accumulated Estimated Alpha Value $0
+STATISTICS:: Mean Population Estimated Insight Value $0
+STATISTICS:: Mean Population Direction 0%
+STATISTICS:: Mean Population Magnitude 0%
+STATISTICS:: Rolling Averaged Population Direction 0%
+STATISTICS:: Rolling Averaged Population Magnitude 0%
+STATISTICS:: OrderListHash d41d8cd98f00b204e9800998ecf8427e
+2022-11-25T15:04:40.3190085Z TRACE:: BacktestingResultHandler.SendAnalysisResult(): Processed final packet
+2022-11-25T15:04:40.3239320Z TRACE:: Engine.Run(): Disconnecting from brokerage...
+2022-11-25T15:04:40.3270225Z TRACE:: Engine.Run(): Disposing of setup handler...
+2022-11-25T15:04:40.3402854Z TRACE:: Engine.Main(): Analysis Completed and Results Posted.
+2022-11-25T15:04:40.3532236Z TRACE:: StopSafely(): waiting for '' thread to stop...
+2022-11-25T15:04:40.3767707Z TRACE:: DataMonitor.GenerateReport():
+DATA USAGE:: Total data requests 5
+DATA USAGE:: Succeeded data requests 5
+DATA USAGE:: Failed data requests 0
+DATA USAGE:: Failed data requests percentage 0%
+DATA USAGE:: Total universe data requests 0
+DATA USAGE:: Succeeded universe data requests 0
+DATA USAGE:: Failed universe data requests 0
+DATA USAGE:: Failed universe data requests percentage 0%
+2022-11-25T15:04:40.4603793Z TRACE:: Engine.Main(): Packet removed from queue: 1347518945
+2022-11-25T15:04:40.4657487Z TRACE:: LeanEngineSystemHandlers.Dispose(): start...
+2022-11-25T15:04:40.4712196Z TRACE:: LeanEngineSystemHandlers.Dispose(): Disposed of system handlers.
+2022-11-25T15:04:40.4735564Z TRACE:: LeanEngineAlgorithmHandlers.Dispose(): start...
+2022-11-25T15:04:40.4784052Z TRACE:: LeanEngineAlgorithmHandlers.Dispose(): Disposed of algorithm handlers.
+        """)
+
+    Storage(str(Path.cwd() / "Python Project" / "config.json")).set("parameters", {"param1": "1"})
+
+    def run_image_for_estimate(image: DockerImage, **kwargs) -> bool:
+        results_path = next(key for key in kwargs["volumes"].keys() if kwargs["volumes"][key]["bind"] == "/Results")
+        log_file = Path(results_path) / "log.txt"
+        with log_file.open("w+", encoding="utf-8") as logs:
+            logs.write("""
+MSBuild version 17.3.2+561848881 for .NET
+  Determining projects to restore...
+  Restored /LeanCLI/ParametrizedAlgorithm.csproj (in 235 ms).
+  ParametrizedAlgorithm -> /Compile/bin/ParametrizedAlgorithm.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:04.15
+20221125 19:01:15.308 TRACE:: Config.GetValue(): debug-mode - Using default value: False
+20221125 19:01:15.310 TRACE:: Config.Get(): Configuration key not found. Key: plugin-directory - Using default value:
+20221125 19:01:15.315 TRACE:: Config.Get(): Configuration key not found. Key: composer-dll-directory - Using default value:
+20221125 19:01:15.319 TRACE:: Composer(): Loading Assemblies from /Lean/Optimizer.Launcher/bin/Debug/
+20221125 19:01:15.397 TRACE:: Config.Get(): Configuration key not found. Key: log-handler - Using default value: CompositeLogHandler
+20221125 19:01:15.538 TRACE:: Config.GetValue(): optimization-update-interval - Using default value: 10
+20221125 19:01:15.553 TRACE:: Config.Get(): Configuration key not found. Key: lean-binaries-location - Using default value: /Lean/Optimizer.Launcher/bin/Debug/../../../Launcher/bin/Debug/QuantConnect.Lean.Launcher.exe
+20221125 19:01:15.554 TRACE:: Config.Get(): Configuration key not found. Key: algorithm-type-name - Using default value:
+20221125 19:01:15.554 TRACE:: Config.Get(): Configuration key not found. Key: algorithm-language - Using default value:
+20221125 19:01:15.555 TRACE:: Config.Get(): Configuration key not found. Key: algorithm-location - Using default value:
+20221125 19:01:15.562 TRACE:: Optimization estimate: 50
+            """)
+        return True
+
+    docker_manager = mock.Mock()
+    docker_manager.run_image.side_effect = run_image_for_estimate
+    container.initialize(docker_manager=docker_manager)
+    container.optimizer_config_manager = _get_optimizer_config_manager_mock()
+
+    result = CliRunner().invoke(lean, ["optimize", "Python Project", "--estimate",
+                                       "--max-concurrent-backtests", max_concurrent_backtests])
+
+    assert result.exit_code == 0
+    assert "Total backtests: 50" in result.output
+    assert f"Estimated runtime: {expected_runtime}" in result.output
+
+    docker_manager.run_image.assert_called_once()
+    args, kwargs = docker_manager.run_image.call_args
+
+    assert any(command == 'dotnet QuantConnect.Optimizer.Launcher.dll --estimate' for command in kwargs["commands"])


### PR DESCRIPTION
- The new `--estimate` option allows for estimating optimization runtime
- Another option `--max-concurrent-backtests` allows the user to indicate the number of workers to use for the optimization

Closes #162 