### PR TITLE
Implement addon modules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Options:
   --python-venv TEXT              The path of the python virtual environment to be used
   --update                        Pull the LEAN engine image before running the backtest
   --backtest-name TEXT            Backtest name
+  --vscode                        Setup vscode extension related configurations.
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.

--- a/lean/models/addon_modules/__init__.py
+++ b/lean/models/addon_modules/__init__.py
@@ -1,0 +1,22 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+from lean.models.addon_modules.addon_module import AddonModule
+from lean.models import json_modules
+
+all_addon_modules: List[AddonModule] = []
+
+for json_module in json_modules:
+    if "addon-module" in json_module["type"]:
+        all_addon_modules.append(AddonModule(json_module))

--- a/lean/models/addon_modules/addon_module.py
+++ b/lean/models/addon_modules/addon_module.py
@@ -1,0 +1,20 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lean.models.lean_config_configurer import LeanConfigConfigurer
+
+class AddonModule(LeanConfigConfigurer):
+    """A JsonModule implementation for add on modules."""
+
+
+

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -14,8 +14,6 @@
 from enum import Enum
 from typing import Any, Dict, List, Type
 from lean.components.util.logger import Logger
-from lean.container import container
-from lean.models.logger import Option
 from lean.models.configuration import BrokerageEnvConfiguration, Configuration, InternalInputUserInput
 from copy import copy
 from abc import ABC


### PR DESCRIPTION
- Add an `addon` module class to handle any additional packages that need to be used.
- Updates backtest to use addon modules
- Adds `--vscode` option in backtest to triggered `vscode extension` related settings
- Updates readme