### PR TITLE
add attribute to save lean properties persistently

### DIFF
--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -95,6 +95,7 @@ class Configuration(ABC):
         self._value: str = config_json_object["value"]
         self._is_cloud_property: bool = "cloud-id" in config_json_object
         self._is_required_from_user = False
+        self._save_persistently_in_lean = False
         self._is_type_configurations_env: bool = type(
             self) is ConfigurationsEnvConfiguration
         self._is_type_trading_env: bool = type(self) is TradingEnvConfiguration
@@ -173,7 +174,7 @@ class ConfigurationsEnvConfiguration(InfoConfiguration):
 
 
 class UserInputConfiguration(Configuration, ABC):
-    """Base class extended to all confiugration class than store values in Lean config.
+    """Base class extended to all configuration class that requires input from user.
 
     Values are expected from the user via prompts.
     Values of this configuration is persistently saved in the Lean configuration,
@@ -183,6 +184,7 @@ class UserInputConfiguration(Configuration, ABC):
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
         self._is_required_from_user = True
+        self._save_persistently_in_lean = True
         self._input_method = self._prompt_info = self._help = ""
         self._input_default = self._cloud_id = None
         if "input-method" in config_json_object.keys():
@@ -195,6 +197,8 @@ class UserInputConfiguration(Configuration, ABC):
             self._input_default = config_json_object["input-default"]
         if "cloud-id" in config_json_object.keys():
             self._cloud_id = config_json_object["cloud-id"]
+        if "save-persistently-in-lean" in config_json_object.keys():
+            self._save_persistently_in_lean = config_json_object["save-persistently-in-lean"]
 
     @abstractmethod
     def AskUserForInput(self, default_value: Any, logger: Logger):

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -117,6 +117,9 @@ class JsonModule(ABC):
                             and self.check_if_config_passes_filters(config)]
         return required_configs
 
+    def get_persistent_save_properties(self, filters: List[Type[Configuration]] = []) -> List[str]:
+        return [config._id for config in self.get_required_configs(filters) if config._save_persistently_in_lean]
+
     def get_essential_properties(self) -> List[str]:
         return [config._id for config in self.get_essential_configs()]
 

--- a/lean/models/lean_config_configurer.py
+++ b/lean/models/lean_config_configurer.py
@@ -90,8 +90,8 @@ class LeanConfigConfigurer(JsonModule, ABC):
             if type(value) == WindowsPath or type(value) == PosixPath:
                 value = str(value).replace("\\", "/")
             lean_config[configuration._id] = value
-        container.logger.debug(f"LeanConfigConfigurer.ensure_module_installed(): _save_properties for module {self._id}: {self.get_required_properties()}")
-        self._save_properties(lean_config, self.get_required_properties())
+        container.logger.debug(f"LeanConfigConfigurer.ensure_module_installed(): _save_properties for module {self._id}: {self.get_persistent_save_properties()}")
+        self._save_properties(lean_config, self.get_persistent_save_properties())
 
     def ensure_module_installed(self, organization_id: str) -> None:
         if not self._is_module_installed and self._installs:


### PR DESCRIPTION
Adds `self._save_persistently_in_lean` attribute in configurations to control properties that need to be saved in lean config

Closes #258 

Red -> Green test
![image](https://user-images.githubusercontent.com/28739120/209810474-0ef12348-2375-4e4e-b4f3-f3cdee6a23a3.png)
