### PR TITLE
Check and set container id if available in lean config

### DIFF
--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -323,7 +323,11 @@ class LeanRunner:
                                            read_only=True))
 
         # Assign the container a name and store it in the output directory's configuration
-        run_options["name"] = f"lean_cli_{str(uuid4()).replace('-', '')}"
+        if "container-name" in lean_config:
+            run_options["name"] = lean_config["container-name"]
+        else:
+            run_options["name"] = f"lean_cli_{str(uuid4()).replace('-', '')}"
+        
         output_config = self._output_config_manager.get_output_config(output_dir)
         output_config.set("container", run_options["name"])
         if "backtest-name" in lean_config:


### PR DESCRIPTION
Use container-id when docker from lean-config if available.

Tested by running backtest and validating the results.