### PR TITLE
Add `--show-secrets` option to commands with secrets inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Options:
                                   holdings
   --push                          Push local modifications to the cloud before starting live trading
   --open                          Automatically open the live results in the browser once the deployment starts
+  --show-secrets                  Show secrets as they are input
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
 ```
@@ -983,6 +984,7 @@ Options:
   --live-holdings TEXT            A comma-separated list of symbol:symbolId:quantity:averagePrice of initial portfolio
                                   holdings
   --update                        Pull the LEAN engine image before starting live trading
+  --show-secrets                  Show secrets as they are input
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
@@ -1090,6 +1092,7 @@ Usage: lean login [OPTIONS]
 Options:
   -u, --user-id TEXT    QuantConnect user id
   -t, --api-token TEXT  QuantConnect API token
+  --show-secrets        Show secrets as they are input
   --verbose             Enable debug logging
   --help                Show this message and exit.
 ```

--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -202,7 +202,7 @@ def _configure_auto_restart(logger: Logger) -> bool:
               is_flag=True,
               default=False,
               help="Automatically open the live results in the browser once the deployment starts")
-@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets")
+@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets as they are input")
 def deploy(project: str,
            brokerage: str,
            node: str,

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -265,7 +265,7 @@ def _get_default_value(key: str) -> Optional[Any]:
               is_flag=True,
               default=False,
               help="Pull the LEAN engine image before starting live trading")
-@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets")
+@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets as they are input")
 def deploy(project: Path,
            environment: Optional[str],
            output: Optional[Path],

--- a/lean/commands/login.py
+++ b/lean/commands/login.py
@@ -24,7 +24,8 @@ from lean.components.api.api_client import APIClient
 @command(cls=LeanCommand)
 @option("--user-id", "-u", type=str, help="QuantConnect user id")
 @option("--api-token", "-t", type=str, help="QuantConnect API token")
-def login(user_id: Optional[str], api_token: Optional[str]) -> None:
+@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets")
+def login(user_id: Optional[str], api_token: Optional[str], show_secrets: bool) -> None:
     """Log in with a QuantConnect account.
 
     If user id or API token is not provided an interactive prompt will show.
@@ -43,7 +44,7 @@ def login(user_id: Optional[str], api_token: Optional[str]) -> None:
         user_id = prompt("User id")
 
     if api_token is None:
-        api_token = logger.prompt_password("API token")
+        api_token = logger.prompt_password("API token", hide_input=not show_secrets)
 
     container.api_client.set_user_token(user_id=user_id, api_token=api_token)
     if not container.api_client.is_authenticated():

--- a/lean/commands/login.py
+++ b/lean/commands/login.py
@@ -24,7 +24,7 @@ from lean.components.api.api_client import APIClient
 @command(cls=LeanCommand)
 @option("--user-id", "-u", type=str, help="QuantConnect user id")
 @option("--api-token", "-t", type=str, help="QuantConnect API token")
-@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets")
+@option("--show-secrets", is_flag=True, show_default=True, default=False, help="Show secrets as they are input")
 def login(user_id: Optional[str], api_token: Optional[str], show_secrets: bool) -> None:
     """Log in with a QuantConnect account.
 

--- a/lean/components/util/logger.py
+++ b/lean/components/util/logger.py
@@ -116,11 +116,12 @@ class Logger:
                 if len(user_selected_values) == expected_outputs:
                     return user_selected_values
 
-    def prompt_password(self, text: str, default: Optional[str] = None) -> str:
+    def prompt_password(self, text: str, default: Optional[str] = None, hide_input: bool = True) -> str:
         """Asks the user for a string value while masking the given input.
 
         :param text: the text to display before prompting
         :param default: the default value if no input is given
+        :param hide_input: whether to hide the input
         :return: the given input
         """
         from platform import uname
@@ -131,8 +132,8 @@ class Logger:
             text = f"{text} [{'*' * len(default)}]"
 
         # Masking does not work properly in WSL2 and when the input is not coming from a keyboard
-        if "microsoft" in uname().release.lower() or not stdin.isatty():
-            return prompt(text, default=default, show_default=False)
+        if "microsoft" in uname().release.lower() or not stdin.isatty() or not hide_input:
+            return prompt(text, default=default, show_default=False, hide_input=hide_input)
 
         while True:
             user_input = askpass(f"{text}: ")

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -201,12 +201,13 @@ class UserInputConfiguration(Configuration, ABC):
             self._save_persistently_in_lean = config_json_object["save-persistently-in-lean"]
 
     @abstractmethod
-    def AskUserForInput(self, default_value: Any, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input
         :return: The value provided by the user.
         """
         return NotImplemented()
@@ -246,16 +247,16 @@ class InternalInputUserInput(UserInputConfiguration):
             self._is_conditional = True
         self._value_options = value_options
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
-        raise ValueError(
-            f'user input not allowed with {self.__class__.__name__}')
+        raise ValueError(f'user input not allowed with {self.__class__.__name__}')
 
 
 class PromptUserInput(UserInputConfiguration):
@@ -271,12 +272,13 @@ class PromptUserInput(UserInputConfiguration):
         if "input-type" in config_json_object.keys():
             self._input_type = config_json_object["input-type"]
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
         return prompt(self._prompt_info, default_value, type=self.get_input_type())
@@ -292,12 +294,13 @@ class ChoiceUserInput(UserInputConfiguration):
         if "input-choices" in config_json_object.keys():
             self._choices = config_json_object["input-choices"]
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
         return prompt(
@@ -311,12 +314,13 @@ class PathParameterUserInput(UserInputConfiguration):
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
 
@@ -339,12 +343,13 @@ class ConfirmUserInput(UserInputConfiguration):
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
         return prompt(self._prompt_info, default_value, type=bool)
@@ -354,15 +359,16 @@ class PromptPasswordUserInput(UserInputConfiguration):
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = True):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input
         :return: The value provided by the user.
         """
-        return logger.prompt_password(self._prompt_info, default_value)
+        return logger.prompt_password(self._prompt_info, default_value, hide_input=hide_input)
 
 
 class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput):
@@ -383,23 +389,23 @@ class BrokerageEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInp
             raise ValueError(
                 f'Undefined input method type {config_json_object["type"]}')
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
         if self._input_method == "confirm":
-            return ConfirmUserInput.AskUserForInput(self, default_value, logger)
+            return ConfirmUserInput.ask_user_for_input(self, default_value, logger)
         elif self._input_method == "choice":
-            return ChoiceUserInput.AskUserForInput(self, default_value, logger)
+            return ChoiceUserInput.ask_user_for_input(self, default_value, logger)
         elif self._input_method == "prompt":
-            return PromptUserInput.AskUserForInput(self, default_value, logger)
+            return PromptUserInput.ask_user_for_input(self, default_value, logger)
         else:
-            raise ValueError(
-                f"Undefined input method type {self._input_method}")
+            raise ValueError(f"Undefined input method type {self._input_method}")
 
 
 class TradingEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput):
@@ -423,12 +429,13 @@ class TradingEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput
             raise ValueError(
                 f'Undefined input method type {config_json_object["type"]}')
 
-    def AskUserForInput(self, default_value, logger: Logger):
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
         """Prompts user to provide input while validating the type of input
         against the expected type
 
         :param default_value: The default to prompt to the user.
         :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
         # NOTE: trading envrionment config should not use old boolean value as default
@@ -438,7 +445,7 @@ class TradingEnvConfiguration(PromptUserInput, ChoiceUserInput, ConfirmUserInput
             raise ValueError(
                 f'input method -- {self._input_method} is not allowed with {self.__class__.__name__}')
         else:
-            return BrokerageEnvConfiguration.AskUserForInput(self, default_value, logger)
+            return BrokerageEnvConfiguration.ask_user_for_input(self, default_value, logger)
 
 
 class FilterEnvConfiguration(BrokerageEnvConfiguration):

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -145,12 +145,17 @@ class JsonModule(ABC):
         """
         return variable_key.replace('_', '-')
 
-    def build(self, lean_config: Dict[str, Any], logger: Logger, properties: Dict[str, Any] = {}) -> 'JsonModule':
+    def build(self,
+              lean_config: Dict[str, Any],
+              logger: Logger,
+              properties: Dict[str, Any] = {},
+              hide_input: bool = False) -> 'JsonModule':
         """Builds a new instance of this class, prompting the user for input when necessary.
 
         :param lean_config: the Lean configuration dict to read defaults from
         :param logger: the logger to use
         :param properties: the properties that passed as options
+        :param hide_input: whether to hide secrets inputs
         :return: a LeanConfigConfigurer instance containing all the details needed to configure the Lean config
         """
         logger.info(f'Configure credentials for {self._display_name}')
@@ -175,7 +180,7 @@ class JsonModule(ABC):
                 # TODO: use type(class) equality instead of class name (str)
                 if self.__class__.__name__ != 'CloudBrokerage':
                     default_value = self._get_default(lean_config, configuration._id)
-                user_choice = configuration.AskUserForInput(default_value, logger)
+                user_choice = configuration.ask_user_for_input(default_value, logger, hide_input=hide_input)
 
             self.update_value_for_given_config(configuration._id, user_choice)
 


### PR DESCRIPTION
Add `--show-secrets` option to commands with secrets inputs so users are able to disable secrets masking to see their secrets as they input them.

Closes #112 