### PR TITLE
Add `gui` command back to warn about deprecation

### DIFF
--- a/lean/commands/__init__.py
+++ b/lean/commands/__init__.py
@@ -29,6 +29,7 @@ from lean.commands.optimize import optimize
 from lean.commands.report import report
 from lean.commands.research import research
 from lean.commands.whoami import whoami
+from lean.commands.gui import gui
 
 lean.add_command(config)
 lean.add_command(cloud)
@@ -47,3 +48,4 @@ lean.add_command(research)
 lean.add_command(report)
 lean.add_command(build)
 lean.add_command(logs)
+lean.add_command(gui)

--- a/lean/commands/gui/__init__.py
+++ b/lean/commands/gui/__init__.py
@@ -1,0 +1,50 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click import command, Group
+
+from lean.models.errors import MoreInfoError
+
+
+class AnyCommandGroup(Group):
+    """A command group that can be used to have single action to perform on any command or sub-command in the group,
+    regardless of the sub-command name.
+
+    For instance, the following would raise an exception on any of these calls:
+    `mycommand`, `mycommand subcommand`, `mycommand anothersubcommand`, etc.
+
+    ```
+@command(cls=AnyCommandGroup, invoke_without_command=True)
+def mycommand() -> None:
+    raise MoreInfoError("Message")
+    ```
+    """
+
+    def get_command(self, ctx, cmd_name):
+        # always return the same command for any sub-command
+        return self
+
+    def resolve_command(self, ctx, args):
+        _, cmd, args = super().resolve_command(ctx, args)
+        return cmd.name, cmd, args
+
+
+@command(cls=AnyCommandGroup, invoke_without_command=True)
+def gui() -> None:
+    """Work with the local GUI."""
+    # This method is only used to warn users about GUI deprecation and point them to the new VSCode extension.
+    raise MoreInfoError(
+        "The LEAN GUI was deprecated in 2019 and has been replaced by a VSCode extension "
+        "which allows seamless local and cloud quantitative research. "
+        "See more information in the VSCode Marketplace.",
+        "https://marketplace.visualstudio.com/items?itemName=quantconnect.quantconnect")


### PR DESCRIPTION
Add `gui` command back to warn about its deprecation and pointing the users to the vscode extension.

This will show the warning on any of these commands:

- `lean gui`
- `lean gui start`
- `lean gui stop`
- etc. (any other subcommand).

Close #245 