### PR TITLE
Updates to support local backtesting in extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Usage: lean backtest [OPTIONS] PROJECT
 Options:
   --output DIRECTORY              Directory to store results in (defaults to PROJECT/backtests/TIMESTAMP)
   -d, --detach                    Run the backtest in a detached Docker container and return immediately
-  --debug [pycharm|ptvsd|vsdbg|rider|QC]
+  --debug [pycharm|ptvsd|vsdbg|rider|local-platform]
                                   Enable a certain debugging method (see --help for more information)
   --data-provider [Terminal Link|QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Usage: lean backtest [OPTIONS] PROJECT
 Options:
   --output DIRECTORY              Directory to store results in (defaults to PROJECT/backtests/TIMESTAMP)
   -d, --detach                    Run the backtest in a detached Docker container and return immediately
-  --debug [pycharm|ptvsd|vsdbg|rider]
+  --debug [pycharm|ptvsd|vsdbg|rider|QC]
                                   Enable a certain debugging method (see --help for more information)
   --data-provider [Terminal Link|QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -252,7 +252,7 @@ def _select_organization() -> QCMinimalOrganization:
               default=False,
               help="Run the backtest in a detached Docker container and return immediately")
 @option("--debug",
-              type=Choice(["pycharm", "ptvsd", "vsdbg", "rider", "QC"], case_sensitive=False),
+              type=Choice(["pycharm", "ptvsd", "vsdbg", "rider", "local-platform"], case_sensitive=False),
               help="Enable a certain debugging method (see --help for more information)")
 @option("--data-provider",
               type=Choice([dp.get_name() for dp in all_data_providers], case_sensitive=False),
@@ -339,10 +339,10 @@ def backtest(project: Path,
     elif debug == "rider":
         debugging_method = DebuggingMethod.Rider
         _migrate_csharp_rider(logger, algorithm_file.parent)
-    elif debug == "QC":
-        debugging_method = DebuggingMethod.QC
+    elif debug == "local-platform":
+        debugging_method = DebuggingMethod.LocalPlatform
 
-    if debugging_method is not None and detach and debugging_method != DebuggingMethod.QC:
+    if detach and debugging_method != None and debugging_method != DebuggingMethod.LocalPlatform:
         raise RuntimeError("Running a debugging session in a detached container is not supported")
 
     if algorithm_file.name.endswith(".cs"):

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -252,7 +252,7 @@ def _select_organization() -> QCMinimalOrganization:
               default=False,
               help="Run the backtest in a detached Docker container and return immediately")
 @option("--debug",
-              type=Choice(["pycharm", "ptvsd", "vsdbg", "rider"], case_sensitive=False),
+              type=Choice(["pycharm", "ptvsd", "vsdbg", "rider", "QC"], case_sensitive=False),
               help="Enable a certain debugging method (see --help for more information)")
 @option("--data-provider",
               type=Choice([dp.get_name() for dp in all_data_providers], case_sensitive=False),
@@ -339,8 +339,10 @@ def backtest(project: Path,
     elif debug == "rider":
         debugging_method = DebuggingMethod.Rider
         _migrate_csharp_rider(logger, algorithm_file.parent)
+    elif debug == "QC":
+        debugging_method = DebuggingMethod.QC
 
-    if debugging_method is not None and detach:
+    if debugging_method is not None and detach and debugging_method != DebuggingMethod.QC:
         raise RuntimeError("Running a debugging session in a detached container is not supported")
 
     if algorithm_file.name.endswith(".cs"):

--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -563,3 +563,24 @@ class DockerManager:
                 break
 
         return path
+    
+    def get_container_port(self, container_name: str, internal_port: str) -> Optional[int]:
+        """
+        Returns a containers external port for a mapped internal port
+        :param container_name: Name of the container
+        :param internal_port: The internal port of container. If protocol not included
+        we assume /tcp. ex. 5678/tcp 
+        :return: The external port that is linked to it, or None if it does not exist
+        """
+
+        # In case a port is supplied without a protocol assume tcp
+        if not internal_port.__contains__("/tcp") and not internal_port.__contains__("/udp"):
+            internal_port = str(internal_port) + "/tcp"
+
+        container = self.get_container_by_name(container_name)
+
+        # Grab the host port assigned
+        if container is not None and internal_port in container.ports:
+            return container.ports[internal_port][0]["HostPort"]
+
+        return None

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -122,7 +122,7 @@ class LeanRunner:
             }
 
         # Setup debugging with QC Extension
-        if debugging_method == DebuggingMethod.QC:
+        if debugging_method == DebuggingMethod.LocalPlatform:
             run_options["ports"]["5678"] = "0" # Using port 0 will assign a random port every time
 
         run_options["commands"].append("exec dotnet QuantConnect.Lean.Launcher.dll")
@@ -142,7 +142,7 @@ class LeanRunner:
         relative_project_dir = project_dir.relative_to(cli_root_dir)
         relative_output_dir = output_dir.relative_to(cli_root_dir)
 
-        if debugging_method == DebuggingMethod.QC:
+        if debugging_method == DebuggingMethod.LocalPlatform:
             # set the container port mapped with host in config for later retrieval
             port = self._docker_manager.get_container_port(run_options["name"], "5678/tcp")
             output_config = self._output_config_manager.get_output_config(output_dir)

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -13,7 +13,6 @@
 
 from pathlib import Path
 from typing import Any, Dict, Optional, List
-
 from lean.components.cloud.module_manager import ModuleManager
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.output_config_manager import OutputConfigManager
@@ -122,6 +121,10 @@ class LeanRunner:
                 "mode": "rw"
             }
 
+        # Setup debugging with QC Extension
+        if debugging_method == DebuggingMethod.QC:
+            run_options["ports"]["5678"] = "0" # Using port 0 will assign a random port every time
+
         run_options["commands"].append("exec dotnet QuantConnect.Lean.Launcher.dll")
 
         # Copy the project's code to the output directory
@@ -139,6 +142,12 @@ class LeanRunner:
         relative_project_dir = project_dir.relative_to(cli_root_dir)
         relative_output_dir = output_dir.relative_to(cli_root_dir)
 
+        if debugging_method == DebuggingMethod.QC:
+            # set the container port mapped with host in config for later retrieval
+            port = self._docker_manager.get_container_port(run_options["name"], "5678/tcp")
+            output_config = self._output_config_manager.get_output_config(output_dir)
+            output_config.set("debugport", port)
+            
         if detach:
             self._temp_manager.delete_temporary_directories_when_done = False
 

--- a/lean/models/utils.py
+++ b/lean/models/utils.py
@@ -22,6 +22,7 @@ class DebuggingMethod(Enum):
     PTVSD = 2
     VSDBG = 3
     Rider = 4
+    QC  = 5
 
     def get_internal_name(self) -> str:
         """Returns the LEAN debugging method that should be used for the current enum member.
@@ -30,7 +31,8 @@ class DebuggingMethod(Enum):
         """
         return {
             DebuggingMethod.PyCharm: "PyCharm",
-            DebuggingMethod.PTVSD: "PTVSD"
+            DebuggingMethod.PTVSD: "PTVSD",
+            DebuggingMethod.QC: "DebugPy" # QC -> DebugPy, If its Python it uses DebugPy, if its C# LEAN safely ignores DebugPy
         }.get(self, "LocalCmdline")
 
 

--- a/lean/models/utils.py
+++ b/lean/models/utils.py
@@ -22,7 +22,7 @@ class DebuggingMethod(Enum):
     PTVSD = 2
     VSDBG = 3
     Rider = 4
-    QC  = 5
+    LocalPlatform  = 5
 
     def get_internal_name(self) -> str:
         """Returns the LEAN debugging method that should be used for the current enum member.
@@ -32,7 +32,7 @@ class DebuggingMethod(Enum):
         return {
             DebuggingMethod.PyCharm: "PyCharm",
             DebuggingMethod.PTVSD: "PTVSD",
-            DebuggingMethod.QC: "DebugPy" # QC -> DebugPy, If its Python it uses DebugPy, if its C# LEAN safely ignores DebugPy
+            DebuggingMethod.LocalPlatform: "DebugPy" # QC -> DebugPy, If its Python it uses DebugPy, if its C# LEAN safely ignores DebugPy
         }.get(self, "LocalCmdline")
 
 


### PR DESCRIPTION
- Adds `local-platform` choice in `--debug` option in `backtest` command
- Updates Readme

Tested manually using the new added option as well as with integration from the extension