### PR TITLE
Mount terminal link symbol map file from symbol properties folder

### DIFF
--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -259,7 +259,7 @@ class LeanRunner:
         cli_root_dir = self._lean_config_manager.get_cli_root_directory()
         files_to_mount = [
             ("transaction-log", cli_root_dir),
-            ("terminal-link-symbol-map-file", cli_root_dir / DEFAULT_DATA_DIRECTORY_NAME)
+            ("terminal-link-symbol-map-file", cli_root_dir / DEFAULT_DATA_DIRECTORY_NAME / "symbol-properties")
         ]
         for key, base_path in files_to_mount:
             if key not in lean_config or lean_config[key] == "":

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -265,7 +265,8 @@ class LeanRunner:
             if key not in lean_config or lean_config[key] == "":
                 continue
 
-            local_path = base_path / lean_config[key]
+            lean_config_entry = Path(lean_config[key])
+            local_path = lean_config_entry if lean_config_entry.is_absolute() else base_path / lean_config_entry
             if not local_path.exists():
                 local_path.parent.mkdir(parents=True, exist_ok=True)
                 local_path.touch()

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -469,7 +469,9 @@ def test_run_lean_mounts_terminal_link_symbol_map_file_from_data_folder(os: str,
 
     from lean.container import container
     cli_root_dir = container.lean_config_manager.get_cli_root_directory()
-    expected_source = local_path if local_path.is_absolute() else cli_root_dir / DEFAULT_DATA_DIRECTORY_NAME / local_path
+    expected_source = local_path \
+        if local_path.is_absolute() \
+        else cli_root_dir / DEFAULT_DATA_DIRECTORY_NAME / "symbol-properties" / local_path
 
     assert any([
         Path(mount["Source"]) == expected_source and


### PR DESCRIPTION
Mounting Terminal Link symbol map file either from:
- A relative path, which will read/create the file in the root CLI `data/symbol-properties` folder.
- An absolute path