### PR TITLE
Minor TerminalLink mmprovements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ cython_debug/
 
 # vscode
 .vscode
+
+# modules file
+lean/modules-*.json

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Options:
   -d, --detach                    Run the backtest in a detached Docker container and return immediately
   --debug [pycharm|ptvsd|vsdbg|rider|local-platform]
                                   Enable a certain debugging method (see --help for more information)
-  --data-provider [Terminal Link|QuantConnect|Local]
+  --data-provider [QuantConnect|Local|Terminal Link]
                                   Update the Lean configuration file to retrieve data from the given provider
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider QuantConnect
@@ -860,7 +860,7 @@ Options:
                                   The brokerage to use
   --data-feed [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Pro|Binance|Zerodha|Samco|Terminal Link|Kraken|TDAmeritrade|IQFeed|Polygon Data Feed|Custom data only]
                                   The data feed to use
-  --data-provider [Terminal Link|QuantConnect|Local]
+  --data-provider [QuantConnect|Local]
                                   Update the Lean configuration file to retrieve data from the given provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -917,22 +917,12 @@ Options:
                                   The host of the TerminalLink server
   --terminal-link-server-port INTEGER
                                   The port of the TerminalLink server
-  --terminal-link-symbol-map-file FILE
-                                  The path to the TerminalLink symbol map file
   --terminal-link-emsx-broker TEXT
                                   The EMSX broker to use
   --terminal-link-emsx-user-time-zone TEXT
                                   The EMSX user timezone to use
   --terminal-link-emsx-account TEXT
                                   The EMSX account to use
-  --terminal-link-emsx-strategy TEXT
-                                  The EMSX strategy to use
-  --terminal-link-emsx-notes TEXT
-                                  The EMSX notes to use
-  --terminal-link-emsx-handling TEXT
-                                  The EMSX handling to use
-  --terminal-link-allow-modification BOOLEAN
-                                  Whether order updates are allowed
   --atreyu-host TEXT              The host of the Atreyu server
   --atreyu-req-port INTEGER       The Atreyu request port
   --atreyu-sub-port INTEGER       The Atreyu subscribe port
@@ -1292,7 +1282,7 @@ Usage: lean research [OPTIONS] PROJECT
 
 Options:
   --port INTEGER                  The port to run Jupyter Lab on (defaults to 8888)
-  --data-provider [Terminal Link|QuantConnect|Local]
+  --data-provider [QuantConnect|Local|Terminal Link]
                                   Update the Lean configuration file to retrieve data from the given provider
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider QuantConnect

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -255,6 +255,7 @@ def _select_organization() -> QCMinimalOrganization:
               help="Enable a certain debugging method (see --help for more information)")
 @option("--data-provider",
               type=Choice([dp.get_name() for dp in all_data_providers], case_sensitive=False),
+              default="Local",
               help="Update the Lean configuration file to retrieve data from the given provider")
 @option("--download-data",
               is_flag=True,

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -241,7 +241,8 @@ def _get_default_value(key: str) -> Optional[Any]:
               multiple=True,
               help="The data feed to use")
 @option("--data-provider",
-              type=Choice([dp.get_name() for dp in all_data_providers], case_sensitive=False),
+              type=Choice([dp.get_name() for dp in all_data_providers if dp._id != "TerminalLinkBrokerage"], case_sensitive=False),
+              default="Local",
               help="Update the Lean configuration file to retrieve data from the given provider")
 @options_from_json(_get_configs_for_options("local"))
 @option("--release",

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -37,6 +37,7 @@ def _check_docker_output(chunk: str, port: int) -> None:
 @option("--port", type=int, default=8888, help="The port to run Jupyter Lab on (defaults to 8888)")
 @option("--data-provider",
               type=Choice([dp.get_name() for dp in all_data_providers], case_sensitive=False),
+              default="Local",
               help="Update the Lean configuration file to retrieve data from the given provider")
 @option("--download-data",
               is_flag=True,

--- a/lean/models/__init__.py
+++ b/lean/models/__init__.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from time import time
 
 json_modules = {}
-file_name = "modules-1.8.json"
+file_name = "modules-1.9.json"
 directory = Path(__file__).parent
 file_path = directory.parent / file_name
 

--- a/tests/commands/test_backtest.py
+++ b/tests/commands/test_backtest.py
@@ -504,7 +504,7 @@ def test_backtest_passes_data_purchase_limit_to_lean_runner() -> None:
 }
         """)
 
-    result = CliRunner().invoke(lean, ["backtest", "Python Project", "--data-purchase-limit", "1000"])
+    result = CliRunner().invoke(lean, ["backtest", "Python Project", "--data-provider", "QuantConnect", "--data-purchase-limit", "1000"])
 
     assert result.exit_code == 0
 

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -227,11 +227,7 @@ terminal_link_required_options = {
     "terminal-link-server-host": "abc",
     "terminal-link-server-port": "123",
     "terminal-link-emsx-broker": "abc",
-    "terminal-link-allow-modification": "no",
     "terminal-link-emsx-account": "abc",
-    "terminal-link-emsx-strategy": "abc",
-    "terminal-link-emsx-notes": "abc",
-    "terminal-link-emsx-handling": "abc",
     "terminal-link-emsx-user-time-zone": "abc",
 }
 
@@ -366,16 +362,21 @@ def test_live_calls_lean_runner_with_data_provider(data_provider: str) -> None:
                                 "--data-provider", data_provider,
                                 *options])
 
-    assert result.exit_code == 0
+    expected = 0
+    # not a valid option
+    if data_provider == 'Terminal Link':
+        expected = 2
+    assert result.exit_code == expected
 
-    lean_runner.run_lean.assert_called_once_with(mock.ANY,
-                                                 "live-paper",
-                                                 Path("CSharp Project/Main.cs").resolve(),
-                                                 mock.ANY,
-                                                 ENGINE_IMAGE,
-                                                 None,
-                                                 False,
-                                                 False)
+    if expected == 0:
+        lean_runner.run_lean.assert_called_once_with(mock.ANY,
+                                                     "live-paper",
+                                                     Path("CSharp Project/Main.cs").resolve(),
+                                                     mock.ANY,
+                                                     ENGINE_IMAGE,
+                                                     None,
+                                                     False,
+                                                     False)
 
 
 @pytest.mark.parametrize("brokerage", brokerage_required_options.keys() - ["Paper Trading"])


### PR DESCRIPTION
- Minor TerminalLink configuration improvements
- Default to 'Local' data-provider if none specified
- Disable 'Terminal Link' data provider for live trading