### PR TITLE
Implement non-interactive input for data-providers in backtest command

### DIFF
--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -23,10 +23,10 @@ from lean.models.json_module import LiveInitialStateInput
 from lean.models.logger import Option
 from lean.models.brokerages.cloud.cloud_brokerage import CloudBrokerage
 from lean.models.configuration import InternalInputUserInput
-from lean.models.click_options import options_from_json
+from lean.models.click_options import options_from_json, get_configs_for_options
 from lean.models.brokerages.cloud import all_cloud_brokerages
 from lean.commands.cloud.live.live import live
-from lean.components.util.live_utils import _get_configs_for_options, get_last_portfolio_cash_holdings, configure_initial_cash_balance, configure_initial_holdings,\
+from lean.components.util.live_utils import get_last_portfolio_cash_holdings, configure_initial_cash_balance, configure_initial_holdings,\
                                             _configure_initial_cash_interactively, _configure_initial_holdings_interactively
 
 def _log_notification_methods(methods: List[QCNotificationMethod]) -> None:
@@ -173,7 +173,7 @@ def _configure_auto_restart(logger: Logger) -> bool:
 @option("--brokerage",
               type=Choice([b.get_name() for b in all_cloud_brokerages], case_sensitive=False),
               help="The brokerage to use")
-@options_from_json(_get_configs_for_options("cloud"))
+@options_from_json(get_configs_for_options("live-cloud"))
 @option("--node", type=str, help="The name or id of the live node to run on")
 @option("--auto-restart", type=bool, help="Whether automatic algorithm restarting must be enabled")
 @option("--notify-order-events", type=bool, help="Whether notifications must be sent for order events")

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -17,33 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from lean.components.api.api_client import APIClient
 from lean.components.util.logger import Logger
-from lean.models.brokerages.cloud import all_cloud_brokerages
-from lean.models.brokerages.local import all_local_brokerages, all_local_data_feeds
-from lean.models.data_providers import all_data_providers
 from lean.models.json_module import LiveInitialStateInput, JsonModule
-from lean.models.configuration import Configuration, InfoConfiguration, InternalInputUserInput
-
-def _get_configs_for_options(env: str) -> List[Configuration]:
-    if env == "cloud":
-        brokerage = all_cloud_brokerages
-    elif env == "local":
-        brokerage = all_local_brokerages + all_local_data_feeds + all_data_providers
-    else:
-        raise ValueError("Only 'cloud' and 'local' are accepted for the argument 'env'")
-
-    run_options: Dict[str, Configuration] = {}
-    config_with_module_id: Dict[str, str] = {}
-    for module in brokerage:
-        for config in module.get_all_input_configs([InternalInputUserInput, InfoConfiguration]):
-            if config._id in run_options:
-                if config._id in config_with_module_id and config_with_module_id[config._id] == module._id:
-                    continue
-                else:
-                    raise ValueError(f'Options names should be unique. Duplicate key present: {config._id}')
-            run_options[config._id] = config
-            config_with_module_id[config._id] = module._id
-    return list(run_options.values())
-
 
 def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Path) -> List[Dict[str, Any]]:
     from pytz import utc, UTC

--- a/lean/models/click_options.py
+++ b/lean/models/click_options.py
@@ -28,8 +28,10 @@ def get_configs_for_options(env: str) -> List[Configuration]:
         brokerage = all_local_brokerages + all_local_data_feeds + all_data_providers
     elif env == "backtest":
         brokerage = all_data_providers
+    elif env == "research":
+        brokerage = all_data_providers
     else:
-        raise ValueError("Only 'cloud' and 'local' are accepted for the argument 'env'")
+        raise ValueError("Acceptable values for 'env' are: 'live-cloud', 'live-local', 'backtest', 'research'")
 
     run_options: Dict[str, Configuration] = {}
     config_with_module_id: Dict[str, str] = {}


### PR DESCRIPTION
- Adds `@options_from_json()` decorator to add options from `moduels.json` 
- Updates `get_configs_for_options` to handle cases for `backtest` and `research` commands to provide data-provider related options.

Tested manually by running the following commands:
- live local
- live cloud
- backtest
- research

Research 
![image](https://user-images.githubusercontent.com/28739120/228679536-1965e526-6194-4b1d-842c-fb529afbba9e.png)

Backtest
![image](https://user-images.githubusercontent.com/28739120/228679701-d6a39529-3f56-4c21-b7f8-454cad7f40bd.png)

Closes #298 