### PR TITLE
Bulk download improvement

### DIFF
--- a/lean/components/cloud/data_downloader.py
+++ b/lean/components/cloud/data_downloader.py
@@ -111,6 +111,13 @@ class DataDownloader:
         tar.errorlevel = 0
         tar.extractall(destination)
         tar.close()
+        from os import remove
+        remove(file)
+
+    def remove_suffix(self,input_string, suffix):
+        if suffix and input_string.endswith(suffix):
+            return input_string[:-len(suffix)]
+        return input_string
 
     def _download_file(self,
                        relative_file: str,
@@ -129,23 +136,35 @@ class DataDownloader:
         :param organization_id: the id of the organization that should be billed
         :param callback: the lambda that is called just before the method returns
         """
-        local_path = data_directory / relative_file
 
-        if local_path.exists() and not overwrite:
+        local_path = canary_path = data_directory / relative_file
+
+        is_bulk = "setup/" in relative_file and relative_file.endswith(".tar")
+        if is_bulk:
+            # for bulk, we will download to a temporary folder and delete it at the end
+            import tempfile
+            local_path = tempfile.gettempdir() + "/" + relative_file
+            canary_path = Path(self.remove_suffix(str(data_directory / relative_file), ".tar") + ".log")
+
+        if canary_path.exists() and not overwrite:
             self._logger.warn("\n".join([
-                f"{local_path} already exists, use --overwrite to overwrite it",
+                f"{relative_file} already exists, use --overwrite to overwrite it",
                 "You have not been charged for this file"
             ]))
             progress_callback(1)
             return
 
+        if is_bulk:
+            with open(canary_path, 'a') as log_file:
+                log_file.write(f'Downloading: {relative_file}\n')
+
         try:
             self._api_client.data.download_file(relative_file, organization_id, local_path, progress_callback)
         except RequestFailedError as error:
-            self._logger.warn(f"{local_path}: {error}\nYou have not been charged for this file")
+            self._logger.warn(f"{relative_file}: {error}\nYou have not been charged for this file")
             progress_callback(1)
             return
 
         # Special case: bulk files need unpacked
-        if "setup/" in relative_file and relative_file.endswith(".tar"):
+        if is_bulk:
             self._process_bulk(local_path, data_directory)

--- a/lean/components/cloud/data_downloader.py
+++ b/lean/components/cloud/data_downloader.py
@@ -154,10 +154,6 @@ class DataDownloader:
             progress_callback(1)
             return
 
-        if is_bulk:
-            with open(canary_path, 'a') as log_file:
-                log_file.write(f'Downloading: {relative_file}\n')
-
         try:
             self._api_client.data.download_file(relative_file, organization_id, local_path, progress_callback)
         except RequestFailedError as error:
@@ -167,4 +163,7 @@ class DataDownloader:
 
         # Special case: bulk files need unpacked
         if is_bulk:
+            canary_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(canary_path, 'a') as log_file:
+                log_file.write(f'Downloaded: {relative_file}\n')
             self._process_bulk(local_path, data_directory)

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -13,15 +13,15 @@ test_files = Path(os.path.join(os.path.dirname(os.path.realpath(__file__)), "tes
 # Load in our test files into fake filesystem
 @pytest.fixture
 def setup(fs):
-    fs.add_real_directory(test_files)
+    fs.add_real_directory(test_files, read_only=False)
     yield fs
 
 def test_bulk_extraction(setup):
-    fakeTar = Path(os.path.join(test_files, "20220222_coinapi_crypto_ftx_price_aggregation.tar"))
+    fake_tar = Path(os.path.join(test_files, "20220222_coinapi_crypto_ftx_price_aggregation.tar"))
     out = Path("/tmp/out")
 
-    container.data_downloader._process_bulk(fakeTar, out)
-    assert os.path.exists(out)
+    container.data_downloader._process_bulk(fake_tar, out)
+    assert not os.path.exists(out / fake_tar)
 
     # Empty file in fake tar
     file = os.path.join(out, "crypto/ftx/daily/imxusd_trade.zip")


### PR DESCRIPTION
- Delete bulk file to avoid unnecessary storage usage

Tested downloading new, failing because existed & --overwrite behavior. Linux & windows