### PR TITLE
Use Pydantic V1 even when V2 is installed for backwards compatibility

### DIFF
--- a/lean/main.py
+++ b/lean/main.py
@@ -101,7 +101,7 @@ def main() -> None:
         from click import UsageError, Abort
         from requests import exceptions
         from io import StringIO
-        from pydantic import ValidationError
+        from lean.models.pydantic import ValidationError
         from lean.models.errors import MoreInfoError
 
         logger = container.logger

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -15,10 +15,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import validator
-
 from lean.constants import EQUITY_SECURITY_MASTER_PRODUCT_ID
-from lean.models.pydantic import WrappedBaseModel
+from lean.models.pydantic import WrappedBaseModel, validator
 
 
 # The models in this module are all parts of responses from the QuantConnect API

--- a/lean/models/data.py
+++ b/lean/models/data.py
@@ -17,14 +17,12 @@ from enum import Enum
 from typing import List, Any, Optional, Dict, Set, Tuple, Pattern
 
 from click import prompt
-from pydantic import validator
 
 from lean.click import DateParameter
 from lean.container import container
 from lean.models.api import QCDataVendor
 from lean.models.logger import Option
-from lean.models.pydantic import WrappedBaseModel
-
+from lean.models.pydantic import WrappedBaseModel, validator
 
 class OptionResult(WrappedBaseModel):
     """The OptionResult class represents an option's result with an internal value and a display-friendly label."""

--- a/lean/models/market_hours_database.py
+++ b/lean/models/market_hours_database.py
@@ -14,10 +14,7 @@
 from datetime import datetime
 from typing import List, Dict, Any
 
-from pydantic import validator
-
-from lean.models.pydantic import WrappedBaseModel
-
+from lean.models.pydantic import WrappedBaseModel, validator
 
 class MarketHoursSegment(WrappedBaseModel):
     start: str

--- a/lean/models/optimizer.py
+++ b/lean/models/optimizer.py
@@ -13,9 +13,7 @@
 
 from enum import Enum
 
-from pydantic import Field
-
-from lean.models.pydantic import WrappedBaseModel
+from lean.models.pydantic import WrappedBaseModel, Field
 
 
 class OptimizationExtremum(str, Enum):

--- a/lean/models/pydantic.py
+++ b/lean/models/pydantic.py
@@ -11,8 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pydantic import BaseModel, ValidationError
-
+from pydantic import __version__ as pydantic_version
+if pydantic_version.startswith("1."):
+    # We keep all this imports here, even if not used like validator, so other files can import them through this file
+    # to avoid having to check the pydantic version in every file.
+    # All imports should be done through this file to avoid pydantic version related errors.
+    from pydantic import BaseModel, ValidationError, Field, validator
+else:
+    from pydantic.v1 import BaseModel, ValidationError, Field, validator
 
 class WrappedBaseModel(BaseModel):
     """A version of Pydantic's BaseModel which makes the input data accessible in case of a validation error."""


### PR DESCRIPTION
Ensure using Pydantic V1 without having to fix requirements major version.
Some actions started failing after Pydantic release V2. This ensures we use V1 (which comes [built in with V2](https://github.com/pydantic/pydantic#pydantic-v110-vs-v2)).

Closes #327 
Closes #329 