### PR TITLE
Add payment auto confirm option for data download

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Usage: lean data download [OPTIONS]
 Options:
   --dataset TEXT      The name of the dataset to download non-interactively
   --overwrite         Overwrite existing local data
+  -y, --yes           Automatically confirm all prompts
   --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose           Enable debug logging
   --help              Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ Usage: lean data download [OPTIONS]
 Options:
   --dataset TEXT      The name of the dataset to download non-interactively
   --overwrite         Overwrite existing local data
-  -y, --yes           Automatically confirm all prompts
+  -y, --yes           Automatically confirm payment confirmation prompts
   --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose           Enable debug logging
   --help              Show this message and exit.

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -410,7 +410,8 @@ def _get_available_datasets(organization: QCFullOrganization) -> List[Dataset]:
 @option("--dataset", type=str, help="The name of the dataset to download non-interactively")
 @option("--overwrite", is_flag=True, default=False, help="Overwrite existing local data")
 @option("--force", is_flag=True, default=False, hidden=True)
-@option("--yes", "-y", "auto_confirm", is_flag=True, default=False, hidden=True)
+@option("--yes", "-y", "auto_confirm", is_flag=True, default=False,
+        help="Automatically confirm payment confirmation prompts")
 @pass_context
 def download(ctx: Context, dataset: Optional[str], overwrite: bool, force: bool, auto_confirm: bool, **kwargs) -> None:
     """Purchase and download data from QuantConnect Datasets.

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -160,11 +160,14 @@ def _get_security_master_warn() -> str:
                       ])
 
 
-def _select_products_interactive(organization: QCFullOrganization, datasets: List[Dataset], force: bool) -> List[Product]:
+def _select_products_interactive(organization: QCFullOrganization, datasets: List[Dataset], force: bool,
+                                 ask_for_more_data: bool) -> List[Product]:
     """Asks the user for the products that should be purchased and downloaded.
 
     :param organization: the organization that will be charged
     :param datasets: the available datasets
+    :param force: whether to force when organization does not have an active Security Master subscription
+    :param ask_for_more_data: whether to ask the user if they want to select more products
     :return: the list of products selected by the user
     """
     from collections import OrderedDict
@@ -213,7 +216,7 @@ def _select_products_interactive(organization: QCFullOrganization, datasets: Lis
         logger.info("Selected data:")
         _display_products(organization, products)
 
-        if not confirm("Do you want to download more data?"):
+        if not ask_for_more_data or not confirm("Do you want to download more data?"):
             break
 
     return products
@@ -433,7 +436,7 @@ def download(ctx: Context, dataset: Optional[str], overwrite: bool, force: bool,
         products = _select_products_non_interactive(organization, datasets, ctx, force)
     else:
         datasets = _get_available_datasets(organization)
-        products = _select_products_interactive(organization, datasets, force)
+        products = _select_products_interactive(organization, datasets, force, ask_for_more_data=not auto_confirm)
 
     _confirm_organization_balance(organization, products)
     _verify_accept_agreement(organization, is_interactive)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -407,8 +407,9 @@ def _get_available_datasets(organization: QCFullOrganization) -> List[Dataset]:
 @option("--dataset", type=str, help="The name of the dataset to download non-interactively")
 @option("--overwrite", is_flag=True, default=False, help="Overwrite existing local data")
 @option("--force", is_flag=True, default=False, hidden=True)
+@option("--yes", "-y", "auto_confirm", is_flag=True, default=False, hidden=True)
 @pass_context
-def download(ctx: Context, dataset: Optional[str], overwrite: bool, force: bool, **kwargs) -> None:
+def download(ctx: Context, dataset: Optional[str], overwrite: bool, force: bool, auto_confirm: bool, **kwargs) -> None:
     """Purchase and download data from QuantConnect Datasets.
 
     An interactive wizard will show to walk you through the process of selecting data,
@@ -437,7 +438,7 @@ def download(ctx: Context, dataset: Optional[str], overwrite: bool, force: bool,
     _confirm_organization_balance(organization, products)
     _verify_accept_agreement(organization, is_interactive)
 
-    if is_interactive:
+    if is_interactive and not auto_confirm:
         _confirm_payment(organization, products)
 
     all_data_files = _get_data_files(organization, products)


### PR DESCRIPTION
Using this new `--yes/-y` in interactive mode will skip asking for more data and the final payment confirmation.

Closes #290 