### PR TITLE
Prompt user from modules configurations with default values

### DIFF
--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -13,9 +13,7 @@
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from click import option, argument, Choice, pass_context, Context
-from click.core import ParameterSource
-
+from click import option, argument, Choice
 from lean.click import LeanCommand, PathParameter, ensure_options
 from lean.constants import DEFAULT_ENGINE_IMAGE
 from lean.container import container
@@ -138,7 +136,6 @@ def _start_iqconnect_if_necessary(lean_config: Dict[str, Any], environment_name:
 def _configure_lean_config_interactively(lean_config: Dict[str, Any],
                                          environment_name: str,
                                          properties: Dict[str, Any],
-                                         default_values: Dict[str, Any],
                                          show_secrets: bool) -> None:
     """Interactively configures the Lean config to use.
 
@@ -147,7 +144,6 @@ def _configure_lean_config_interactively(lean_config: Dict[str, Any],
     :param lean_config: the base lean config to use
     :param environment_name: the name of the environment to configure
     :param properties: the properties to use to configure lean
-    :param default_values: the default values to use for each configuration
     :param show_secrets: whether to show secrets on input
     """
     logger = container.logger
@@ -160,9 +156,7 @@ def _configure_lean_config_interactively(lean_config: Dict[str, Any],
         Option(id=brokerage, label=brokerage.get_name()) for brokerage in all_local_brokerages
     ])
 
-    brokerage\
-        .build(lean_config, logger, properties, default_values, hide_input=not show_secrets)\
-        .configure(lean_config, environment_name)
+    brokerage.build(lean_config, logger, properties, hide_input=not show_secrets).configure(lean_config, environment_name)
 
     data_feeds = logger.prompt_list("Select a data feed", [
         Option(id=data_feed, label=data_feed.get_name()) for data_feed in local_brokerage_data_feeds[brokerage]
@@ -265,9 +259,7 @@ def _get_default_value(key: str) -> Optional[Any]:
               is_flag=True,
               default=False,
               help="Use the local LEAN engine image instead of pulling the latest version")
-@pass_context
-def deploy(context: Context,
-           project: Path,
+def deploy(project: Path,
            environment: Optional[str],
            output: Optional[Path],
            detach: bool,
@@ -347,15 +339,7 @@ def deploy(context: Context,
     else:
         environment_name = "lean-cli"
         lean_config = lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)
-
-        # filter configurations that were not passed as command line arguments,
-        # so that we prompt the user for them only when they don't have a value in the Lean config
-        configuration_values = {k: v for k, v in kwargs.items()
-                                if context.get_parameter_source(k) == ParameterSource.COMMANDLINE}
-        default_values = {k: v for k, v in kwargs.items() if k not in configuration_values}
-
-        _configure_lean_config_interactively(lean_config, environment_name, configuration_values, default_values,
-                                             show_secrets=show_secrets)
+        _configure_lean_config_interactively(lean_config, environment_name, kwargs, show_secrets=show_secrets)
 
     if data_provider is not None:
         [data_provider_configurer] = [get_and_build_module(data_provider, all_data_providers, kwargs, logger)]

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -189,10 +189,13 @@ class JsonModule(ABC):
             if property_name in user_provided_options and user_provided_options[property_name]:
                 user_choice = user_provided_options[property_name]
             else:
+                # Let's try to get the value from the lean config and use it as the user choice, without prompting
                 # TODO: use type(class) equality instead of class name (str)
                 if self.__class__.__name__ != 'CloudBrokerage':
-                    # Let's try to get the value from the lean config and use it as the user choice, without prompting
                     user_choice = self._get_default(lean_config, configuration._id)
+                # Try to get the values from lean config
+                elif lean_config is not None and configuration._id in lean_config:
+                    user_choice = lean_config[configuration._id]
 
                 # There's no value in the lean config, let's use the module default value instead and prompt the user
                 # NOTE: using "not" instead of "is None" because the default value can be false,


### PR DESCRIPTION
This makes sure the user is prompted for modules configuration properties when they don't have values in the Lean config file and have a "input-default" value in the modules json file.

Also, the default "input-default" value is shown in the prompt and automatically set on enter with no input.

Tested with `lean live deploy` and `live cloud live deploy`.

Closes #252 