### PR TITLE
Fix cloud live deploy by project ID

### DIFF
--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -307,8 +307,12 @@ def deploy(project: str,
 
     else:
         environment_name = "lean-cli-cloud"
-        algorithm_file = container.project_manager.find_algorithm_file(Path(project))
-        lean_config = container.lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)
+        project_path = Path(cloud_project.name)
+        if project_path.exists():
+            algorithm_file = container.project_manager.find_algorithm_file(project_path)
+            lean_config = container.lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)
+        else:
+            lean_config = container.lean_config_manager.get_lean_config()
         brokerage_instance = _configure_brokerage(lean_config, logger, kwargs, show_secrets=show_secrets)
         live_node = _configure_live_node(logger, api_client, cloud_project)
         notify_order_events, notify_insights, notify_methods = _configure_notifications(logger)

--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -306,13 +306,7 @@ def deploy(project: str,
             raise RuntimeError(f"Custom portfolio holdings setting is not available for {brokerage_instance.get_name()}")
 
     else:
-        environment_name = "lean-cli-cloud"
-        project_path = Path(cloud_project.name)
-        if project_path.exists():
-            algorithm_file = container.project_manager.find_algorithm_file(project_path)
-            lean_config = container.lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)
-        else:
-            lean_config = container.lean_config_manager.get_lean_config()
+        lean_config = container.lean_config_manager.get_lean_config()
         brokerage_instance = _configure_brokerage(lean_config, logger, kwargs, show_secrets=show_secrets)
         live_node = _configure_live_node(logger, api_client, cloud_project)
         notify_order_events, notify_insights, notify_methods = _configure_notifications(logger)


### PR DESCRIPTION
It was trying to get local files from a project that only exists in the cloud. It was trying to get the algorithm file by using `Path(project)` but `project` is an int, not a path in this case.

Bug introduced with #340 

```
PS D:\someIbTest> lean cloud live 15315602
Started compiling project 'Hipster Blue Alligator'
Detected parameters: none
Build Request Successful for Project ID: 15315602, with CompileID: b3dec7f0f4a0d42fc8501ad0b8136312-fbd24dee313b7488fa99bd0586f3a138, Lean Version: 2.5.0.0.15734
Successfully compiled project 'Hipster Blue Alligator'
Error: The specified project does not contain a main.py or Main.cs file
```