### PR TITLE
Fix support for grouping projects in dotnet solution in CLI root directory

### DIFF
--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -459,6 +459,14 @@ class LeanRunner:
         """
         compile_root = self._get_csharp_compile_root(project_dir)
 
+        if compile_root != project_dir:
+            # The /LeanCLI needs to be properly mounted to the compile root when the project is part of a solution
+            run_options["volumes"].pop(str(project_dir))
+            run_options["volumes"][str(compile_root)] = {
+                "bind": "/LeanCLI",
+                "mode": "rw"
+            }
+
         # Ensure all .csproj files refer to the version of LEAN in the Docker container
         csproj_temp_dir = self._temp_manager.create_temporary_directory()
         for path in compile_root.rglob("*.csproj"):


### PR DESCRIPTION
Having a solution file in the root directory is supported now.
This also fixes user's comment in #326: some organization workspace files were being copied to the project folder after backtesting failed.

Closes #260 (and the duplicate #326)