### PR TITLE
Feature enable custom html file for reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,6 +1256,7 @@ Options:
   --live-results FILE          Path to the JSON file containing the live trading results
   --report-destination FILE    Path where the generated report is stored as HTML (defaults to ./report.html)
   --css FILE                   Path where the CSS override file is stored
+  --html FILE                  Path where the custom HTML template file is stored
   -d, --detach                 Run the report creator in a detached Docker container and return immediately
   --strategy-name TEXT         Name of the strategy, will appear at the top-right corner of each page
   --strategy-version TEXT      Version number of the strategy, will appear next to the project name

--- a/lean/commands/report.py
+++ b/lean/commands/report.py
@@ -55,6 +55,9 @@ def _find_project_directory(backtest_file: Path) -> Optional[Path]:
 @option("--css",
               type=PathParameter(exists=False, file_okay=True, dir_okay=False),
               help="Path where the CSS override file is stored")
+@option("--html",
+              type=PathParameter(exists=False, file_okay=True, dir_okay=False),
+              help="Path where the custom HTML template file is stored")
 @option("--detach", "-d",
               is_flag=True,
               default=False,
@@ -87,6 +90,7 @@ def report(backtest_results: Optional[Path],
            live_results: Optional[Path],
            report_destination: Path,
            css: Optional[Path],
+           html: Optional[Path],
            detach: bool,
            strategy_name: Optional[str],
            strategy_version: Optional[str],
@@ -162,6 +166,7 @@ def report(backtest_results: Optional[Path],
         "backtest-data-source-file": "backtest-data-source-file.json",
         "report-destination": "/tmp/report.html",
         "report-css-override-file": "report_override.css" if (css is not None) and (css.exists()) else "",
+        "report-html-custom-file": "template_custom.html" if (html is not None) and (html.exists()) else "",
         "report-format": "pdf" if pdf else "",
         "environment": "report",
 
@@ -235,6 +240,15 @@ def report(backtest_results: Optional[Path],
                                                read_only=True))
         else:
             logger.info(f"CSS override file '{css}' could not be found")
+
+    if html is not None:
+        if html.exists():
+            run_options["mounts"].append(Mount(target="/Lean/Report/bin/Debug/template_custom.html",
+                                               source=str(html),
+                                               type="bind",
+                                               read_only=True))
+        else:
+            logger.info(f"Custom HTML template file '{html}' could not be found")
 
     if pdf:
         run_options["commands"].append(f'cp /tmp/report.pdf "/Output/{report_destination.name.replace(".html", ".pdf")}"')


### PR DESCRIPTION
This PR is to complete the changes made in LEAN #7410. This changes allows the user to provide a custom HTML template to use for the report to be generated. The following changes were made:
- Modify `report.py` to receive a custom HTML file as an optional argument and mount it
- Add unit tests in `test_report.py` to assert lean-cli mounts the custom HTML template file when given
- Update README.md to brief the users on the new optional argument in `lean report` for a custom HTML template file