### PR TITLE
Lean cloud pull improvements

### DIFF
--- a/lean/components/cloud/pull_manager.py
+++ b/lean/components/cloud/pull_manager.py
@@ -153,7 +153,8 @@ class PullManager:
         :param project: the cloud project to pull
         :return the actual local path of the project
         """
-        local_project_path = self._project_manager.get_local_project_path(project.name, project.projectId)
+        local_project_path = self._project_manager.get_local_project_path(project.name, project.projectId,
+                                                                          allow_corrupted=True)
         local_project_name = local_project_path.relative_to(Path.cwd()).as_posix()
         # Check if cloud project has invalid name, if so update it and inform user.
         if local_project_name != project.name:

--- a/lean/components/config/storage.py
+++ b/lean/components/config/storage.py
@@ -75,6 +75,13 @@ class Storage:
         else:
             self._data = {}
 
+    def is_empty(self) -> bool:
+        """Determines if this storage file is empty
+
+        :return: True if this storage file is empty
+        """
+        return len(self._data) == 0
+
     def get(self, key: str, default: Any = None) -> Any:
         """Returns the value assigned to the given key.
 

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -241,7 +241,7 @@ class ProjectManager:
                     self._logger.error(f"'{current_path}' '{PROJECT_CONFIG_FILE_NAME}' file is corrupted!")
                     if allow_corrupted:
                         return current_path
-                if current_project_config.get("cloud-id") == cloud_id:
+                elif current_project_config.get("cloud-id") == cloud_id:
                     return current_path
 
             if local_id is not None:
@@ -250,7 +250,7 @@ class ProjectManager:
                     self._logger.error(f"'{current_path}' '{PROJECT_CONFIG_FILE_NAME}' file is corrupted!")
                     if allow_corrupted:
                         return current_path
-                if current_project_config.get("local-id") == local_id:
+                elif current_project_config.get("local-id") == local_id:
                     return current_path
 
             if current_index == 1:

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -203,16 +203,18 @@ class ProjectManager:
             raise RuntimeError(f"Failed to delete project. Could not find the specified path {project_dir}.")
 
 
-    def get_local_project_path(self, project_name: str, cloud_id: Optional[int] = None, local_id: Optional[int] = None) -> Path:
+    def get_local_project_path(self, project_name: str, cloud_id: Optional[int] = None, local_id: Optional[int] = None,
+                               allow_corrupted: Optional[bool] = False) -> Path:
         """Returns the local path where a certain cloud project should be stored.
 
         If two cloud projects are named "Project", they are pulled to ./Project and ./Project 2.
 
         If you push a project with unsupported cloud name, a supported project name would be assigned.
 
-        :param project_name: the cloud project to get the project path of
-        :param cloud_id: the cloud project to get the project path of
-        :param local_id: the cloud project to get the project path of
+        :param project_name: the cloud project name to get the project path of
+        :param cloud_id: the cloud project id to get the project path of
+        :param local_id: the cloud project local id to get the project path of
+        :param allow_corrupted: true if a corrupted path can be used
         :return: the path to the local project directory
         """
 
@@ -226,6 +228,7 @@ class ProjectManager:
 
         current_index = 1
         while True:
+            # we first check the current project name
             path_suffix = "" if current_index == 1 else f" {current_index}"
             current_path = Path.cwd() / (local_path + path_suffix)
 
@@ -234,14 +237,33 @@ class ProjectManager:
 
             if cloud_id is not None:
                 current_project_config = self._project_config_manager.get_project_config(current_path)
+                if current_project_config.is_empty():
+                    self._logger.error(f"'{current_path}' '{PROJECT_CONFIG_FILE_NAME}' file is corrupted!")
+                    if allow_corrupted:
+                        return current_path
                 if current_project_config.get("cloud-id") == cloud_id:
                     return current_path
 
             if local_id is not None:
                 current_project_config = self._project_config_manager.get_project_config(current_path)
+                if current_project_config.is_empty():
+                    self._logger.error(f"'{current_path}' '{PROJECT_CONFIG_FILE_NAME}' file is corrupted!")
+                    if allow_corrupted:
+                        return current_path
                 if current_project_config.get("local-id") == local_id:
                     return current_path
 
+            if current_index == 1:
+                from re import findall
+
+                ints_in_name = findall(r"(\s\d+)$", local_path)
+                if len(ints_in_name) != 0:
+                    # the current project name already exists, and it has a 'space + int' at the end of it
+                    # so, we take that int and increment it
+                    int_value = ints_in_name[0]
+                    # we remove the int from the name because we will re add it in the loop
+                    local_path = local_path[:-len(int_value)]
+                    current_index = int(int_value)
             current_index += 1
 
     def rename_project_and_contents(self, old_path: Path, new_path: Path,) -> None:

--- a/tests/components/cloud/test_cloud_project_manager.py
+++ b/tests/components/cloud/test_cloud_project_manager.py
@@ -36,6 +36,7 @@ def test_get_cloud_project_pushing_new_project():
 
     project_config = mock.Mock()
     project_config.get = mock.MagicMock(return_value=cloud_project.projectId)
+    project_config.is_empty = mock.MagicMock(return_value=False)
     project_config_manager = mock.Mock()
     project_config_manager.try_get_project_config = mock.MagicMock(return_value=None)
     project_config_manager.get_project_config = mock.MagicMock(return_value=project_config)


### PR DESCRIPTION
- When pulling a project if we detect it's corrupted we wont rename it [**1 case in image bellow**]
- Fix for project index adjustment which was always appending ' 2'. [**2 & 3 cases in image bellow**]
- Use safe save for project pull, `safe_save` will use lock and mv operations when storing to a file

Closes https://github.com/QuantConnect/lean-cli/issues/352

**Case 4 is just a normal/happy case pull**

<img width="580" alt="image" src="https://github.com/QuantConnect/lean-cli/assets/18473240/8149d6ef-f752-4c88-a165-51aa7e0e851b">
