### PR TITLE
Normalize object storage path

### DIFF
--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -213,7 +213,7 @@ class LeanRunner:
             output_dir.mkdir(parents=True)
 
         # Create the storage directory if it doesn't exist yet
-        storage_dir = project_dir / "storage"
+        storage_dir = self._lean_config_manager.get_cli_root_directory() / "storage"
         if not storage_dir.exists():
             storage_dir.mkdir(parents=True)
 

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -260,7 +260,7 @@ def test_run_lean_mounts_storage_directory() -> None:
     assert any([volume["bind"] == "/Storage" for volume in kwargs["volumes"].values()])
 
     key = next(key for key in kwargs["volumes"].keys() if kwargs["volumes"][key]["bind"] == "/Storage")
-    assert key == str(Path.cwd() / "Python Project" / "storage")
+    assert key == str(Path.cwd() / "storage")
 
 
 def test_run_lean_creates_output_directory_when_not_existing_yet() -> None:


### PR DESCRIPTION
- Normalize object storage path to be in the root organization folder, following cloud behavior. See https://github.com/QuantConnect/Lean/pull/6594

Sanity tested backtesting/live/research/optimization accessing storage