### PR TITLE
Support extra docker configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ Options:
   --python-venv TEXT              The path of the python virtual environment to be used
   --update                        Pull the LEAN engine image before running the backtest
   --backtest-name TEXT            Backtest name
-  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
-                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
-                                  might be supported by the Lean CLI.
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. For more information https://docker-
+                                  py.readthedocs.io/en/stable/containers.html
   --no-update                     Use the local LEAN engine image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
@@ -1101,9 +1100,8 @@ Options:
                                   holdings
   --update                        Pull the LEAN engine image before starting live trading
   --show-secrets                  Show secrets as they are input
-  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
-                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
-                                  might be supported by the Lean CLI.
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. For more information https://docker-
+                                  py.readthedocs.io/en/stable/containers.html
   --no-update                     Use the local LEAN engine image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
@@ -1389,9 +1387,8 @@ Options:
   --estimate                      Estimate optimization runtime without running it
   --max-concurrent-backtests INTEGER RANGE
                                   Maximum number of concurrent backtests to run  [x>=1]
-  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
-                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
-                                  might be supported by the Lean CLI.
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. For more information https://docker-
+                                  py.readthedocs.io/en/stable/containers.html
   --no-update                     Use the local LEAN engine image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
@@ -1514,9 +1511,8 @@ Options:
   --no-open                       Don't open the Jupyter Lab environment in the browser after starting it
   --image TEXT                    The LEAN research image to use (defaults to quantconnect/research:latest)
   --update                        Pull the LEAN research image before starting the research environment
-  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
-                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
-                                  might be supported by the Lean CLI.
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. For more information https://docker-
+                                  py.readthedocs.io/en/stable/containers.html
   --no-update                     Use the local LEAN research image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Options:
   --python-venv TEXT              The path of the python virtual environment to be used
   --update                        Pull the LEAN engine image before running the backtest
   --backtest-name TEXT            Backtest name
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
+                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
+                                  might be supported by the Lean CLI.
   --no-update                     Use the local LEAN engine image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
@@ -1098,6 +1101,9 @@ Options:
                                   holdings
   --update                        Pull the LEAN engine image before starting live trading
   --show-secrets                  Show secrets as they are input
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
+                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
+                                  might be supported by the Lean CLI.
   --no-update                     Use the local LEAN engine image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
@@ -1383,6 +1389,9 @@ Options:
   --estimate                      Estimate optimization runtime without running it
   --max-concurrent-backtests INTEGER RANGE
                                   Maximum number of concurrent backtests to run  [x>=1]
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
+                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
+                                  might be supported by the Lean CLI.
   --no-update                     Use the local LEAN engine image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
@@ -1505,6 +1514,9 @@ Options:
   --no-open                       Don't open the Jupyter Lab environment in the browser after starting it
   --image TEXT                    The LEAN research image to use (defaults to quantconnect/research:latest)
   --update                        Pull the LEAN research image before starting the research environment
+  --extra-docker-config TEXT      Extra docker configuration as a JSON string. Supported configurations can be found at
+                                  https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them
+                                  might be supported by the Lean CLI.
   --no-update                     Use the local LEAN research image instead of pulling the latest version
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from pathlib import Path
 from typing import List, Optional, Tuple
 from click import command, option, argument, Choice
@@ -292,7 +291,9 @@ def _select_organization() -> QCMinimalOrganization:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              hidden=True)
+              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
+                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
+                   "supported by the Lean CLI.")
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -329,6 +330,8 @@ def backtest(project: Path,
     Alternatively you can set the default engine image for all commands using `lean config set engine-image <image>`.
     """
     from datetime import datetime
+    from json import loads
+
     logger = container.logger
     project_manager = container.project_manager
     algorithm_file = project_manager.find_algorithm_file(Path(project))
@@ -413,4 +416,4 @@ def backtest(project: Path,
                          debugging_method,
                          release,
                          detach,
-                         json.loads(extra_docker_config))
+                         loads(extra_docker_config))

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -291,9 +291,8 @@ def _select_organization() -> QCMinimalOrganization:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
-                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
-                   "supported by the Lean CLI.")
+              help="Extra docker configuration as a JSON string. "
+                   "For more information https://docker-py.readthedocs.io/en/stable/containers.html")
 @option("--no-update",
               is_flag=True,
               default=False,

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import json
 from pathlib import Path
 from typing import List, Optional, Tuple
 from click import command, option, argument, Choice
@@ -289,6 +289,10 @@ def _select_organization() -> QCMinimalOrganization:
               type=(str, str),
               multiple=True,
               hidden=True)
+@option("--extra-docker-config",
+              type=str,
+              default="{}",
+              hidden=True)
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -307,6 +311,7 @@ def backtest(project: Path,
              backtest_name: str,
              addon_module: Optional[List[str]],
              extra_config: Optional[Tuple[str, str]],
+             extra_docker_config: Optional[str],
              no_update: bool,
              **kwargs) -> None:
     """Backtest a project locally using Docker.
@@ -407,4 +412,5 @@ def backtest(project: Path,
                          engine_image,
                          debugging_method,
                          release,
-                         detach)
+                         detach,
+                         json.loads(extra_docker_config))

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -258,9 +258,8 @@ def _get_default_value(key: str) -> Optional[Any]:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
-                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
-                   "supported by the Lean CLI.")
+              help="Extra docker configuration as a JSON string. "
+                   "For more information https://docker-py.readthedocs.io/en/stable/containers.html")
 @option("--no-update",
               is_flag=True,
               default=False,

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from click import option, argument, Choice
@@ -259,7 +258,9 @@ def _get_default_value(key: str) -> Optional[Any]:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              hidden=True)
+              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
+                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
+                   "supported by the Lean CLI.")
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -305,6 +306,7 @@ def deploy(project: Path,
     """
     from copy import copy
     from datetime import datetime
+    from json import loads
     # Reset globals so we reload everything in between tests
     global _cached_lean_config
     _cached_lean_config = None
@@ -436,4 +438,4 @@ def deploy(project: Path,
             raise RuntimeError(f"InteractiveBrokers is currently not supported for ARM hosts")
 
     lean_runner = container.lean_runner
-    lean_runner.run_lean(lean_config, environment_name, algorithm_file, output, engine_image, None, release, detach, json.loads(extra_docker_config))
+    lean_runner.run_lean(lean_config, environment_name, algorithm_file, output, engine_image, None, release, detach, loads(extra_docker_config))

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from click import option, argument, Choice
@@ -255,6 +256,10 @@ def _get_default_value(key: str) -> Optional[Any]:
               type=(str, str),
               multiple=True,
               hidden=True)
+@option("--extra-docker-config",
+              type=str,
+              default="{}",
+              hidden=True)
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -275,6 +280,7 @@ def deploy(project: Path,
            show_secrets: bool,
            addon_module: Optional[List[str]],
            extra_config: Optional[Tuple[str, str]],
+           extra_docker_config: Optional[str],
            no_update: bool,
            **kwargs) -> None:
     """Start live trading a project locally using Docker.
@@ -430,4 +436,4 @@ def deploy(project: Path,
             raise RuntimeError(f"InteractiveBrokers is currently not supported for ARM hosts")
 
     lean_runner = container.lean_runner
-    lean_runner.run_lean(lean_config, environment_name, algorithm_file, output, engine_image, None, release, detach)
+    lean_runner.run_lean(lean_config, environment_name, algorithm_file, output, engine_image, None, release, detach, json.loads(extra_docker_config))

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -123,9 +123,8 @@ def _get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
-                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
-                   "supported by the Lean CLI.")
+              help="Extra docker configuration as a JSON string. "
+                   "For more information https://docker-py.readthedocs.io/en/stable/containers.html")
 @option("--no-update",
               is_flag=True,
               default=False,

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from pathlib import Path
 from typing import Optional, List, Tuple
 from datetime import datetime, timedelta
@@ -124,7 +123,9 @@ def _get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              hidden=True)
+              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
+                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
+                   "supported by the Lean CLI.")
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -316,7 +317,7 @@ def optimize(project: Path,
     container.update_manager.pull_docker_image_if_necessary(engine_image, update, no_update)
 
     # Add known additional run options from the extra docker config
-    LeanRunner.parse_extra_docker_config(run_options, json.loads(extra_docker_config))
+    LeanRunner.parse_extra_docker_config(run_options, loads(extra_docker_config))
 
     project_manager.copy_code(algorithm_file.parent, output / "code")
 

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from pathlib import Path
 from typing import Optional, Tuple
 from click import command, argument, option, Choice
@@ -70,7 +69,9 @@ def _check_docker_output(chunk: str, port: int) -> None:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              hidden=True)
+              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
+                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
+                   "supported by the Lean CLI.")
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -96,6 +97,7 @@ def research(project: Path,
     """
     from docker.types import Mount
     from docker.errors import APIError
+    from json import loads
 
     logger = container.logger
 
@@ -168,7 +170,7 @@ def research(project: Path,
     run_options["commands"].append("./start.sh")
 
     # Add known additional run options from the extra docker config
-    LeanRunner.parse_extra_docker_config(run_options, json.loads(extra_docker_config))
+    LeanRunner.parse_extra_docker_config(run_options, loads(extra_docker_config))
 
     project_config_manager = container.project_config_manager
     cli_config_manager = container.cli_config_manager

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -69,9 +69,8 @@ def _check_docker_output(chunk: str, port: int) -> None:
 @option("--extra-docker-config",
               type=str,
               default="{}",
-              help="Extra docker configuration as a JSON string. Supported configurations can be found at "
-                   "https://docker-py.readthedocs.io/en/stable/containers.html, althaugh not all of them might be "
-                   "supported by the Lean CLI.")
+              help="Extra docker configuration as a JSON string. "
+                   "For more information https://docker-py.readthedocs.io/en/stable/containers.html")
 @option("--no-update",
               is_flag=True,
               default=False,

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -13,6 +13,8 @@
 
 from pathlib import Path
 from typing import Any, Dict, Optional, List
+import docker.types
+
 from lean.components.cloud.module_manager import ModuleManager
 from lean.components.config.lean_config_manager import LeanConfigManager
 from lean.components.config.output_config_manager import OutputConfigManager
@@ -70,7 +72,8 @@ class LeanRunner:
                  image: DockerImage,
                  debugging_method: Optional[DebuggingMethod],
                  release: bool,
-                 detach: bool) -> None:
+                 detach: bool,
+                 extra_docker_config: Optional[Dict[str, Any]] = None) -> None:
         """Runs the LEAN engine locally in Docker.
 
         Raises an error if something goes wrong.
@@ -83,6 +86,7 @@ class LeanRunner:
         :param debugging_method: the debugging method if debugging needs to be enabled, None if not
         :param release: whether C# projects should be compiled in release configuration instead of debug
         :param detach: whether LEAN should run in a detached container
+        :param extra_docker_config: additional docker configurations
         """
         project_dir = algorithm_file.parent
 
@@ -94,6 +98,9 @@ class LeanRunner:
                                                    debugging_method,
                                                    release,
                                                    detach)
+
+        # Add known additional run options from the extra docker config
+        self.parse_extra_docker_config(run_options, extra_docker_config)
 
         # Set up PTVSD debugging
         if debugging_method == DebuggingMethod.PTVSD:
@@ -762,3 +769,11 @@ for library_id, library_data in project_assets["targets"][project_target].items(
                 "bind": "/Library",
                 "mode": "rw"
             }
+
+    @staticmethod
+    def parse_extra_docker_config(run_options: Dict[str, Any], extra_docker_config: Optional[Dict[str, Any]]) -> None:
+        # Add known additional run options from the extra docker config.
+        # For now, only device_requests is supported
+        if extra_docker_config is not None and "device_requests" in extra_docker_config:
+            run_options["device_requests"] = [docker.types.DeviceRequest(**device_request)
+                                              for device_request in extra_docker_config["device_requests"]]

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -13,7 +13,6 @@
 
 from pathlib import Path
 from typing import Any, Dict, Optional, List
-import docker.types
 
 from lean.components.cloud.module_manager import ModuleManager
 from lean.components.config.lean_config_manager import LeanConfigManager
@@ -772,8 +771,9 @@ for library_id, library_data in project_assets["targets"][project_target].items(
 
     @staticmethod
     def parse_extra_docker_config(run_options: Dict[str, Any], extra_docker_config: Optional[Dict[str, Any]]) -> None:
+        from docker.types import DeviceRequest
         # Add known additional run options from the extra docker config.
         # For now, only device_requests is supported
         if extra_docker_config is not None and "device_requests" in extra_docker_config:
-            run_options["device_requests"] = [docker.types.DeviceRequest(**device_request)
+            run_options["device_requests"] = [DeviceRequest(**device_request)
                                               for device_request in extra_docker_config["device_requests"]]

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -774,6 +774,13 @@ for library_id, library_data in project_assets["targets"][project_target].items(
         from docker.types import DeviceRequest
         # Add known additional run options from the extra docker config.
         # For now, only device_requests is supported
-        if extra_docker_config is not None and "device_requests" in extra_docker_config:
-            run_options["device_requests"] = [DeviceRequest(**device_request)
-                                              for device_request in extra_docker_config["device_requests"]]
+        if extra_docker_config is not None:
+            if "device_requests" in extra_docker_config:
+                run_options["device_requests"] = [DeviceRequest(**device_request)
+                                                  for device_request in extra_docker_config["device_requests"]]
+
+            if "volumes" in extra_docker_config:
+                volumes = run_options.get("volumes")
+                if not volumes:
+                    volumes = run_options["volumes"] = {}
+                volumes.update(extra_docker_config["volumes"])

--- a/tests/commands/test_backtest.py
+++ b/tests/commands/test_backtest.py
@@ -57,7 +57,8 @@ def test_backtest_calls_lean_runner_with_correct_algorithm_file() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_backtest_calls_lean_runner_with_default_output_directory() -> None:
@@ -88,7 +89,8 @@ def test_backtest_calls_lean_runner_with_custom_output_directory() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_backtest_calls_lean_runner_with_release_mode() -> None:
@@ -105,7 +107,8 @@ def test_backtest_calls_lean_runner_with_release_mode() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  True,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_backtest_calls_lean_runner_with_detach() -> None:
@@ -122,7 +125,8 @@ def test_backtest_calls_lean_runner_with_detach() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 True)
+                                                 True,
+                                                 {})
 
 
 def test_backtest_aborts_when_project_does_not_exist() -> None:
@@ -163,7 +167,8 @@ def test_backtest_forces_update_when_update_option_given() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_backtest_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
@@ -182,7 +187,8 @@ def test_backtest_passes_custom_image_to_lean_runner_when_set_in_config() -> Non
                                                  DockerImage(name="custom/lean", tag="123"),
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_backtest_passes_custom_image_to_lean_runner_when_given_as_option() -> None:
@@ -201,7 +207,8 @@ def test_backtest_passes_custom_image_to_lean_runner_when_given_as_option() -> N
                                                  DockerImage(name="custom/lean", tag="456"),
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 @pytest.mark.parametrize("python_venv", ["Custom-venv",
@@ -289,7 +296,8 @@ def test_backtest_passes_correct_debugging_method_to_lean_runner(value: str, deb
                                                  ENGINE_IMAGE,
                                                  debugging_method,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_backtest_auto_updates_outdated_python_pycharm_debug_config() -> None:
@@ -649,3 +657,23 @@ def test_backtest_adds_python_libraries_path_to_lean_config() -> None:
     expected_library_path = (Path("/") / library_path.relative_to(lean_cli_root_dir)).as_posix()
 
     assert expected_library_path in lean_config.get('python-additional-paths')
+
+
+def test_backtest_calls_lean_runner_with_extra_docker_config() -> None:
+    create_fake_lean_cli_directory()
+
+    result = CliRunner().invoke(lean, ["backtest", "Python Project",
+                                       "--extra-docker-config",
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+
+    assert result.exit_code == 0
+
+    container.lean_runner.run_lean.assert_called_once_with(mock.ANY,
+                                                           "backtesting",
+                                                           Path("Python Project/main.py").resolve(),
+                                                           mock.ANY,
+                                                           ENGINE_IMAGE,
+                                                           None,
+                                                           False,
+                                                           False,
+                                                           {"device_requests": [{"count": -1, "capabilities": [["compute"]]}]})

--- a/tests/commands/test_backtest.py
+++ b/tests/commands/test_backtest.py
@@ -664,7 +664,8 @@ def test_backtest_calls_lean_runner_with_extra_docker_config() -> None:
 
     result = CliRunner().invoke(lean, ["backtest", "Python Project",
                                        "--extra-docker-config",
-                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}],'
+                                       '"volumes": {"extra/path": {"bind": "/extra/path", "mode": "rw"}}}'])
 
     assert result.exit_code == 0
 
@@ -676,4 +677,11 @@ def test_backtest_calls_lean_runner_with_extra_docker_config() -> None:
                                                            None,
                                                            False,
                                                            False,
-                                                           {"device_requests": [{"count": -1, "capabilities": [["compute"]]}]})
+                                                           {
+                                                               "device_requests": [
+                                                                   {"count": -1, "capabilities": [["compute"]]}
+                                                               ],
+                                                               "volumes": {
+                                                                   "extra/path": {"bind": "/extra/path", "mode": "rw"}
+                                                               }
+                                                           })

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -84,7 +84,34 @@ def test_live_calls_lean_runner_with_correct_algorithm_file() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
+
+
+def test_live_calls_lean_runner_with_extra_docker_config() -> None:
+    # TODO: currently it is not using the live-paper environment
+    create_fake_lean_cli_directory()
+    create_fake_environment("live-paper", True)
+
+    result = CliRunner().invoke(lean, ["live", "Python Project",
+                                       "--environment",
+                                       "live-paper",
+                                       "--extra-docker-config",
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+
+    traceback.print_exception(*result.exc_info)
+
+    assert result.exit_code == 0
+
+    container.lean_runner.run_lean.assert_called_once_with(mock.ANY,
+                                                           "live-paper",
+                                                           Path("Python Project/main.py").resolve(),
+                                                           mock.ANY,
+                                                           ENGINE_IMAGE,
+                                                           None,
+                                                           False,
+                                                           False,
+                                                           {"device_requests": [{"count": -1, "capabilities": [["compute"]]}]})
 
 
 def test_live_aborts_when_environment_does_not_exist() -> None:
@@ -159,7 +186,8 @@ def test_live_calls_lean_runner_with_release_mode() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  True,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_live_calls_lean_runner_with_detach() -> None:
@@ -178,7 +206,8 @@ def test_live_calls_lean_runner_with_detach() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 True)
+                                                 True,
+                                                 {})
 
 
 def test_live_aborts_when_project_does_not_exist() -> None:
@@ -366,7 +395,8 @@ def test_live_calls_lean_runner_with_data_provider(data_provider: str) -> None:
                                                      ENGINE_IMAGE,
                                                      None,
                                                      False,
-                                                     False)
+                                                     False,
+                                                     {})
 
 
 @pytest.mark.parametrize("brokerage", brokerage_required_options.keys() - ["Paper Trading"])
@@ -468,7 +498,8 @@ def test_live_non_interactive_do_not_store_non_persistent_properties_in_lean_con
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
     config = container.lean_config_manager.get_lean_config()
     if brokerage in brokerage_required_options_not_persistently_save_in_lean_config:
@@ -509,7 +540,8 @@ def test_live_non_interactive_calls_run_lean_when_all_options_given(brokerage: s
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 @pytest.mark.parametrize("brokerage,data_feed1,data_feed2",[(brokerage, *data_feeds) for brokerage, data_feeds in
                          itertools.product(brokerage_required_options.keys(), itertools.combinations(data_feed_required_options.keys(), 2))])
@@ -548,7 +580,8 @@ def test_live_non_interactive_calls_run_lean_when_all_options_given_with_multipl
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 @pytest.mark.parametrize("brokerage", brokerage_required_options.keys() - ["Paper Trading"])
@@ -606,7 +639,8 @@ def test_live_non_interactive_falls_back_to_lean_config_for_brokerage_settings(b
                                                          ENGINE_IMAGE,
                                                          None,
                                                          False,
-                                                         False)
+                                                         False,
+                                                         {})
 
 
 @pytest.mark.parametrize("data_feed", data_feed_required_options.keys())
@@ -653,7 +687,8 @@ def test_live_non_interactive_falls_back_to_lean_config_for_data_feed_settings(d
                                                          ENGINE_IMAGE,
                                                          None,
                                                          False,
-                                                         False)
+                                                         False,
+                                                         {})
 
 
 @pytest.mark.parametrize("data_feed1,data_feed2", itertools.combinations(data_feed_required_options.keys(), 2))
@@ -702,7 +737,8 @@ def test_live_non_interactive_falls_back_to_lean_config_for_multiple_data_feed_s
                                                          ENGINE_IMAGE,
                                                          None,
                                                          False,
-                                                         False)
+                                                         False,
+                                                         {})
 
 
 def test_live_forces_update_when_update_option_given() -> None:
@@ -721,7 +757,8 @@ def test_live_forces_update_when_update_option_given() -> None:
                                                  ENGINE_IMAGE,
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_live_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
@@ -741,7 +778,8 @@ def test_live_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
                                                  DockerImage(name="custom/lean", tag="123"),
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 def test_live_passes_custom_image_to_lean_runner_when_given_as_option() -> None:
@@ -762,7 +800,8 @@ def test_live_passes_custom_image_to_lean_runner_when_given_as_option() -> None:
                                                  DockerImage(name="custom/lean", tag="456"),
                                                  None,
                                                  False,
-                                                 False)
+                                                 False,
+                                                 {})
 
 
 @pytest.mark.parametrize("python_venv", ["Custom-venv",

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -97,7 +97,8 @@ def test_live_calls_lean_runner_with_extra_docker_config() -> None:
                                        "--environment",
                                        "live-paper",
                                        "--extra-docker-config",
-                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}],'
+                                       '"volumes": {"extra/path": {"bind": "/extra/path", "mode": "rw"}}}'])
 
     traceback.print_exception(*result.exc_info)
 
@@ -111,7 +112,14 @@ def test_live_calls_lean_runner_with_extra_docker_config() -> None:
                                                            None,
                                                            False,
                                                            False,
-                                                           {"device_requests": [{"count": -1, "capabilities": [["compute"]]}]})
+                                                           {
+                                                               "device_requests": [
+                                                                   {"count": -1, "capabilities": [["compute"]]}
+                                                               ],
+                                                               "volumes": {
+                                                                   "extra/path": {"bind": "/extra/path", "mode": "rw"}
+                                                               }
+                                                           })
 
 
 def test_live_aborts_when_environment_does_not_exist() -> None:

--- a/tests/commands/test_optimize.py
+++ b/tests/commands/test_optimize.py
@@ -753,3 +753,29 @@ Time Elapsed 00:00:04.15
     args, kwargs = docker_manager.run_image.call_args
 
     assert any(command == 'dotnet QuantConnect.Optimizer.Launcher.dll --estimate' for command in kwargs["commands"])
+
+
+def test_optimize_runs_lean_container_with_extra_docker_config() -> None:
+    import docker.types
+
+    create_fake_lean_cli_directory()
+
+    docker_manager = mock.MagicMock()
+    docker_manager.run_image.side_effect = run_image
+    container.initialize(docker_manager=docker_manager)
+    container.optimizer_config_manager = _get_optimizer_config_manager_mock()
+
+    Storage(str(Path.cwd() / "Python Project" / "config.json")).set("parameters", {"param1": "1"})
+
+    result = CliRunner().invoke(lean, ["optimize", "Python Project",
+                                       "--extra-docker-config",
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+
+    assert result.exit_code == 0
+
+    docker_manager.run_image.assert_called_once()
+    args, kwargs = docker_manager.run_image.call_args
+
+    assert args[0] == ENGINE_IMAGE
+    assert "device_requests" in kwargs
+    assert kwargs["device_requests"] == [docker.types.DeviceRequest(count=-1, capabilities=[["compute"]])]

--- a/tests/commands/test_optimize.py
+++ b/tests/commands/test_optimize.py
@@ -769,7 +769,8 @@ def test_optimize_runs_lean_container_with_extra_docker_config() -> None:
 
     result = CliRunner().invoke(lean, ["optimize", "Python Project",
                                        "--extra-docker-config",
-                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}],'
+                                       '"volumes": {"extra/path": {"bind": "/extra/path", "mode": "rw"}}}'])
 
     assert result.exit_code == 0
 
@@ -777,5 +778,11 @@ def test_optimize_runs_lean_container_with_extra_docker_config() -> None:
     args, kwargs = docker_manager.run_image.call_args
 
     assert args[0] == ENGINE_IMAGE
+
     assert "device_requests" in kwargs
     assert kwargs["device_requests"] == [docker.types.DeviceRequest(count=-1, capabilities=[["compute"]])]
+
+    assert "volumes" in kwargs
+    volumes = kwargs["volumes"]
+    assert "extra/path" in volumes
+    assert volumes["extra/path"] == {"bind": "/extra/path", "mode": "rw"}

--- a/tests/commands/test_research.py
+++ b/tests/commands/test_research.py
@@ -228,3 +228,25 @@ def test_research_runs_custom_image_when_given_as_option() -> None:
     args, kwargs = docker_manager.run_image.call_args
 
     assert args[0] == DockerImage(name="custom/research", tag="456")
+
+
+def test_optimize_runs_lean_container_with_extra_docker_config() -> None:
+    import docker.types
+
+    create_fake_lean_cli_directory()
+
+    docker_manager = mock.MagicMock()
+    container.initialize(docker_manager)
+
+    result = CliRunner().invoke(lean, ["research", "Python Project",
+                                       "--extra-docker-config",
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+
+    assert result.exit_code == 0
+
+    docker_manager.run_image.assert_called_once()
+    args, kwargs = docker_manager.run_image.call_args
+
+    assert args[0] == RESEARCH_IMAGE
+    assert "device_requests" in kwargs
+    assert kwargs["device_requests"] == [docker.types.DeviceRequest(count=-1, capabilities=[["compute"]])]

--- a/tests/commands/test_research.py
+++ b/tests/commands/test_research.py
@@ -240,7 +240,8 @@ def test_optimize_runs_lean_container_with_extra_docker_config() -> None:
 
     result = CliRunner().invoke(lean, ["research", "Python Project",
                                        "--extra-docker-config",
-                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}]}'])
+                                       '{"device_requests": [{"count": -1, "capabilities": [["compute"]]}],'
+                                       '"volumes": {"extra/path": {"bind": "/extra/path", "mode": "rw"}}}'])
 
     assert result.exit_code == 0
 
@@ -248,5 +249,11 @@ def test_optimize_runs_lean_container_with_extra_docker_config() -> None:
     args, kwargs = docker_manager.run_image.call_args
 
     assert args[0] == RESEARCH_IMAGE
+
     assert "device_requests" in kwargs
     assert kwargs["device_requests"] == [docker.types.DeviceRequest(count=-1, capabilities=[["compute"]])]
+
+    assert "volumes" in kwargs
+    volumes = kwargs["volumes"]
+    assert "extra/path" in volumes
+    assert volumes["extra/path"] == {"bind": "/extra/path", "mode": "rw"}


### PR DESCRIPTION
Support extra docker configs in backtest/live/optimize/research local commands.

Extra configs need to be supported individually. The static method `LeanRunner.parse_extra_docker_config` is meant for this, each new config that is going to be supported you be handled there.

For now, only `device_requests` and `volumes` (for mounting additional volumes) are supported.

Closes #190 