### PR TITLE
Update Terminal Link Configurations Used In Tests 

### DIFF
--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -260,6 +260,8 @@ def test_live_aborts_when_lean_config_is_missing_properties(target: str, replace
 
 
 terminal_link_required_options = {
+    "terminal-link-connection-type": "SAPI",
+    "terminal-link-server-auth-id": "abc",
     "terminal-link-environment": "Beta",
     "terminal-link-server-host": "abc",
     "terminal-link-server-port": "123",


### PR DESCRIPTION
- Include new Terminal Link configuration `terminal-link-connection-type` and `terminal-link-server-auth-id` in tests 