### PR TITLE
Allow empty strings as default json module input values

### DIFF
--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -79,10 +79,10 @@ def _raise_for_missing_properties(lean_config: Dict[str, Any], environment_name:
     :param lean_config_path: the path to the LEAN configuration file
     """
     brokerage_configurer, data_feed_configurers = _get_configurable_modules_from_environment(lean_config, environment_name)
-    brokerage_properties = brokerage_configurer.get_required_properties()
+    brokerage_properties = brokerage_configurer.get_required_properties(include_optionals=False)
     data_queue_handler_properties = []
     for data_feed_configurer in data_feed_configurers:
-        data_queue_handler_properties.extend(data_feed_configurer.get_required_properties())
+        data_queue_handler_properties.extend(data_feed_configurer.get_required_properties(include_optionals=False))
     required_properties = list(set(brokerage_properties + data_queue_handler_properties))
     missing_properties = [p for p in required_properties if p not in lean_config or lean_config[p] == ""]
     missing_properties = set(missing_properties)

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -200,7 +200,7 @@ class UserInputConfiguration(Configuration, ABC):
             self._cloud_id = config_json_object["cloud-id"]
         if "save-persistently-in-lean" in config_json_object:
             self._save_persistently_in_lean = config_json_object["save-persistently-in-lean"]
-        if "optional" in config_json_object.keys():
+        if "optional" in config_json_object:
             self._optional = config_json_object["optional"]
 
     @abstractmethod

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -201,7 +201,7 @@ class UserInputConfiguration(Configuration, ABC):
         if "save-persistently-in-lean" in config_json_object:
             self._save_persistently_in_lean = config_json_object["save-persistently-in-lean"]
         if "optional" in config_json_object.keys():
-            self._optional = not config_json_object["optional"]
+            self._optional = config_json_object["optional"]
 
     @abstractmethod
     def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -187,18 +187,21 @@ class UserInputConfiguration(Configuration, ABC):
         self._save_persistently_in_lean = True
         self._input_method = self._prompt_info = self._help = ""
         self._input_default = self._cloud_id = None
-        if "input-method" in config_json_object.keys():
+        self._optional = False
+        if "input-method" in config_json_object:
             self._input_method = config_json_object["input-method"]
-        if "prompt-info" in config_json_object.keys():
+        if "prompt-info" in config_json_object:
             self._prompt_info = config_json_object["prompt-info"]
-        if "help" in config_json_object.keys():
+        if "help" in config_json_object:
             self._help = config_json_object["help"]
-        if "input-default" in config_json_object.keys():
+        if "input-default" in config_json_object:
             self._input_default = config_json_object["input-default"]
-        if "cloud-id" in config_json_object.keys():
+        if "cloud-id" in config_json_object:
             self._cloud_id = config_json_object["cloud-id"]
-        if "save-persistently-in-lean" in config_json_object.keys():
+        if "save-persistently-in-lean" in config_json_object:
             self._save_persistently_in_lean = config_json_object["save-persistently-in-lean"]
+        if "optional" in config_json_object.keys():
+            self._optional = not config_json_object["optional"]
 
     @abstractmethod
     def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -112,13 +112,18 @@ class JsonModule(ABC):
         return [config._id for config in self._lean_configs if not config._is_required_from_user and not
                 config._is_type_configurations_env and self.check_if_config_passes_filters(config)]
 
-    def get_required_properties(self, filters: List[Type[Configuration]] = []) -> List[str]:
-        return [config._id for config in self.get_required_configs(filters)]
+    def get_required_properties(self,
+                                filters: List[Type[Configuration]] = [],
+                                include_optionals: bool = True) -> List[str]:
+        return [config._id for config in self.get_required_configs(filters, include_optionals)]
 
-    def get_required_configs(self, filters: List[Type[Configuration]] = []) -> List[Configuration]:
+    def get_required_configs(self,
+                             filters: List[Type[Configuration]] = [],
+                             include_optionals: bool = True) -> List[Configuration]:
         required_configs = [copy(config) for config in self._lean_configs if config._is_required_from_user
                             and type(config) not in filters
-                            and self.check_if_config_passes_filters(config)]
+                            and self.check_if_config_passes_filters(config)
+                            and (include_optionals or not getattr(config, '_is_optional', True))]
         return required_configs
 
     def get_persistent_save_properties(self, filters: List[Type[Configuration]] = []) -> List[str]:

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -123,7 +123,7 @@ class JsonModule(ABC):
         required_configs = [copy(config) for config in self._lean_configs if config._is_required_from_user
                             and type(config) not in filters
                             and self.check_if_config_passes_filters(config)
-                            and (include_optionals or not getattr(config, '_is_optional', True))]
+                            and (include_optionals or not getattr(config, '_optional', False))]
         return required_configs
 
     def get_persistent_save_properties(self, filters: List[Type[Configuration]] = []) -> List[str]:


### PR DESCRIPTION
Allow empty strings as default json module input values when they are marked as optional.

- Empty values in the lean.json file will still be prompted each time the user tries to deploy a live algorithm locally in interactive mode.
- In non-interactive mode, skipped optional values will be populated with their default values -- even if they are empty -- and the user will not be pormpted for them.
