### PR TITLE
Implement Support For Project Encryption

### DIFF
--- a/lean/commands/__init__.py
+++ b/lean/commands/__init__.py
@@ -19,6 +19,8 @@ from lean.commands.config import config
 from lean.commands.create_project import create_project
 from lean.commands.delete_project import delete_project
 from lean.commands.data import data
+from lean.commands.decrypt import decrypt
+from lean.commands.encrypt import encrypt
 from lean.commands.init import init
 from lean.commands.library import library
 from lean.commands.live.live import live
@@ -35,6 +37,8 @@ from lean.commands.object_store import object_store
 lean.add_command(config)
 lean.add_command(cloud)
 lean.add_command(data)
+lean.add_command(decrypt)
+lean.add_command(encrypt)
 lean.add_command(library)
 lean.add_command(live)
 lean.add_command(login)

--- a/lean/commands/cloud/pull.py
+++ b/lean/commands/cloud/pull.py
@@ -12,23 +12,46 @@
 # limitations under the License.
 
 from typing import Optional
-
+from pathlib import Path
 from click import command, option
 
-from lean.click import LeanCommand
+from lean.click import LeanCommand, PathParameter
 from lean.container import container
-
+from lean.models.encryption import ActionType
 
 @command(cls=LeanCommand)
 @option("--project", type=str, help="Name or id of the project to pull (all cloud projects if not specified)")
 @option("--pull-bootcamp", is_flag=True, default=False, help="Pull Boot Camp projects (disabled by default)")
-def pull(project: Optional[str], pull_bootcamp: bool) -> None:
+@option("--encrypt",
+        is_flag=True, default=False,
+        help="Encrypt your cloud files with a key")
+@option("--decrypt",
+        is_flag=True, default=False,
+        help="Decrypt your cloud files with a key")
+@option("--key",
+              type=PathParameter(exists=True, file_okay=True, dir_okay=False),
+              help="Path to the encryption key to use")
+def pull(project: Optional[str], pull_bootcamp: bool, encrypt: Optional[bool], decrypt: Optional[bool], key: Optional[Path]) -> None:
     """Pull projects from QuantConnect to the local drive.
 
     This command overrides the content of local files with the content of their respective counterparts in the cloud.
 
     This command will not delete local files for which there is no counterpart in the cloud.
     """
+
+    encryption_key_id = None
+    encryption_action = None
+
+    if encrypt and decrypt:
+        raise RuntimeError(f"Cannot encrypt and decrypt at the same time.")
+    if key is None and (encrypt or decrypt):
+        raise RuntimeError(f"Encryption key is required when encrypting or decrypting.")
+
+    if encrypt:
+        encryption_action = ActionType.ENCRYPT
+    if decrypt:
+        encryption_action = ActionType.DECRYPT
+
     # Parse which projects need to be pulled
     project_id = None
     project_name = None
@@ -55,5 +78,8 @@ def pull(project: Optional[str], pull_bootcamp: bool) -> None:
     if project is None and not pull_bootcamp:
         projects_to_pull = [p for p in projects_to_pull if not p.name.startswith("Boot Camp/")]
 
+    if  len(projects_to_pull) > 1 and key is not None:
+        raise RuntimeError(f"Cannot encrypt or decrypt more than one project at a time.")
+
     pull_manager = container.pull_manager
-    pull_manager.pull_projects(projects_to_pull, all_projects)
+    pull_manager.pull_projects(projects_to_pull, encryption_action, key, all_projects)

--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -19,13 +19,23 @@ from click import command, option
 from lean.click import LeanCommand, PathParameter
 from lean.constants import PROJECT_CONFIG_FILE_NAME
 from lean.container import container
-
+from lean.components.util.encryption_helper import get_project_key_hash
+from lean.models.encryption import ActionType
 
 @command(cls=LeanCommand)
 @option("--project",
         type=PathParameter(exists=True, file_okay=False, dir_okay=True),
         help="Path to the local project to push (all local projects if not specified)")
-def push(project: Optional[Path]) -> None:
+@option("--encrypt",
+        is_flag=True, default=False,
+        help="Encrypt your cloud files with a key")
+@option("--decrypt",
+        is_flag=True, default=False,
+        help="Decrypt your cloud files with a key")
+@option("--key",
+              type=PathParameter(exists=True, file_okay=True, dir_okay=False),
+              help="Path to the encryption key to use")
+def push(project: Optional[Path], encrypt: Optional[bool], decrypt: Optional[bool], key: Optional[Path]) -> None:
     """Push local projects to QuantConnect.
 
     This command overrides the content of cloud files with the content of their respective local counterparts.
@@ -33,6 +43,18 @@ def push(project: Optional[Path]) -> None:
     This command will delete cloud files which don't have a local counterpart.
     """
     push_manager = container.push_manager
+    encryption_key_id = None
+    encryption_action = None
+
+    if encrypt and decrypt:
+        raise RuntimeError(f"Cannot encrypt and decrypt at the same time.")
+    if key is None and (encrypt or decrypt):
+        raise RuntimeError(f"Encryption key is required when encrypting or decrypting.")
+
+    if encrypt:
+        encryption_action = ActionType.ENCRYPT
+    if decrypt:
+        encryption_action = ActionType.DECRYPT
 
     # Parse which projects need to be pushed
     if project is not None:
@@ -41,7 +63,17 @@ def push(project: Optional[Path]) -> None:
         if not project_config.file.exists():
             raise RuntimeError(f"'{project}' is not a Lean project")
 
-        push_manager.push_project(project)
+        if encrypt and key is not None:
+            # lets check if the given key is registered with the cloud
+            organization_id = container.organization_manager.try_get_working_organization_id()
+            available_encryption_keys = container.api_client.encryption_keys.list(organization_id)['keys']
+            encryption_key_id = get_project_key_hash(key)
+            if (not any(found_key for found_key in available_encryption_keys if found_key['hash'] == encryption_key_id)):
+                raise RuntimeError(f"Given encryption key is not registered with the cloud.")
+        
+        push_manager.push_project(project, encryption_action, key)
     else:
+        if key is not None:
+            raise RuntimeError(f"Encryption key can only be specified when pushing a single project.")
         projects_to_push = [p.parent for p in Path.cwd().rglob(PROJECT_CONFIG_FILE_NAME)]
-        push_manager.push_projects(projects_to_push)
+        push_manager.push_projects(projects_to_push, encryption_action, key)

--- a/lean/commands/decrypt.py
+++ b/lean/commands/decrypt.py
@@ -1,0 +1,70 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional
+from click import command, option, argument
+
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.components.util.encryption_helper import get_decrypted_file_content_for_project
+
+@command(cls=LeanCommand)
+@argument("project", type=PathParameter(exists=True, file_okay=False, dir_okay=True))
+@option("--key",
+              type=PathParameter(exists=True, file_okay=True, dir_okay=False),
+              help="Path to the decryption key to use")
+def decrypt(project: Path,
+            key: Optional[Path]) -> None:
+    """Decrypt the project using the specified decryption key.
+
+    :param project: The project to decrypt
+    :param key: The path to the decryption key to use
+    """
+    logger = container.logger
+    project_manager = container.project_manager
+    project_config_manager = container.project_config_manager
+    project_config = project_config_manager.get_project_config(project)
+
+    # Check if the project is already decrypted
+    if not project_config.get("encrypted", False):
+        return
+
+    decryption_key: Path = project_config.get('encryption-key-path', None)
+    if decryption_key is not None and Path(decryption_key).exists():
+        decryption_key = Path(decryption_key)
+
+    if decryption_key is None and key is None:
+        raise RuntimeError("No decryption key was provided, please provide one using --key")
+    elif decryption_key is None:
+        decryption_key = key
+    elif key is not None and decryption_key != key:
+        raise RuntimeError(f"Provided decryption key ({key}) does not match the decryption key in the project ({decryption_key})")
+
+    organization_id = container.organization_manager.try_get_working_organization_id()
+
+    source_files = project_manager.get_source_files(project)
+    try:
+        decrypted_data = get_decrypted_file_content_for_project(project, 
+                                source_files, decryption_key, project_config_manager, organization_id)
+    except Exception as e:
+        raise RuntimeError(f"Could not decrypt project {project}: {e}")
+
+    for file, decrypted in zip(source_files, decrypted_data):
+        with open(file, 'w') as f:
+            f.write(decrypted)
+
+    # Mark the project as decrypted
+    project_config.set('encrypted', False)
+    project_config.delete('encryption-key-path')
+    logger.info(f"Successfully decrypted project {project}")

--- a/lean/commands/encrypt.py
+++ b/lean/commands/encrypt.py
@@ -1,0 +1,74 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional
+from click import command, option, argument
+
+from lean.click import LeanCommand, PathParameter
+from lean.container import container
+from lean.components.util.encryption_helper import get_encrypted_file_content_for_project
+
+
+@command(cls=LeanCommand)
+@argument("project", type=PathParameter(exists=True, file_okay=False, dir_okay=True))
+@option("--key",
+              type=PathParameter(exists=True, file_okay=True, dir_okay=False),
+              help="Path to the encryption key to use")
+def encrypt(project: Path,
+            key: Optional[Path]) -> None:
+    """Encrypt the project using the specified encryption key.
+
+    :param project: The project to encrypt
+    :param key: The path to the encryption key to use
+    """
+
+    logger = container.logger
+    project_manager = container.project_manager
+    project_config_manager = container.project_config_manager
+    project_config = project_config_manager.get_project_config(project)
+
+    # Check if the project is already encrypted
+    if project_config.get('encrypted', False):
+        return
+    
+    encryption_key: Path = project_config.get('encryption-key-path', None)
+    if encryption_key is not None and Path(encryption_key).exists():
+        encryption_key = Path(encryption_key)
+
+    if encryption_key is None and key is None:
+        raise RuntimeError("No encryption key was provided, please provide one using --key")
+    elif encryption_key is None:
+        encryption_key = key
+    elif key is not None and encryption_key != key:
+        raise RuntimeError(f"Provided encryption key ({key}) does not match the encryption key in the project ({encryption_key})")
+
+    organization_id = container.organization_manager.try_get_working_organization_id()
+
+    source_files = project_manager.get_source_files(project)
+    try:
+        encrypted_data = get_encrypted_file_content_for_project(project, 
+                            source_files, encryption_key, project_config_manager, organization_id)
+    except Exception as e:
+        raise RuntimeError(f"Could not encrypt project {project}: {e}")
+    for file, encrypted in zip(source_files, encrypted_data):
+        with open(file, 'w') as f:
+            f.write(encrypted)
+    
+    # Mark the project as encrypted
+    project_config.set('encrypted', True)
+    project_config.set('encryption-key-path', str(encryption_key))
+    logger.info(f"Local files encrypted successfully with key {encryption_key}")
+
+
+

--- a/lean/components/api/api_client.py
+++ b/lean/components/api/api_client.py
@@ -17,6 +17,7 @@ from lean.components.api.account_client import AccountClient
 from lean.components.api.backtest_client import BacktestClient
 from lean.components.api.compile_client import CompileClient
 from lean.components.api.data_client import DataClient
+from lean.components.api.encryption_keys_client import EncryptionKeysClient
 from lean.components.api.file_client import FileClient
 from lean.components.api.lean_client import LeanClient
 from lean.components.api.live_client import LiveClient
@@ -55,6 +56,7 @@ class APIClient:
         self.backtests = BacktestClient(self)
         self.compiles = CompileClient(self)
         self.data = DataClient(self, http_client)
+        self.encryption_keys = EncryptionKeysClient(self)
         self.files = FileClient(self)
         self.live = LiveClient(self)
         self.market = MarketClient(self)

--- a/lean/components/api/encryption_keys_client.py
+++ b/lean/components/api/encryption_keys_client.py
@@ -1,0 +1,39 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lean.components.api.api_client import *
+
+
+class EncryptionKeysClient:
+    """The EncryptionKeysClient class contains methods to interact with organizations/encryption/keys/* API endpoints."""
+
+    def __init__(self, api_client: 'APIClient') -> None:
+        """Creates a new EncryptionKeysClient instance.
+
+        :param api_client: the APIClient instance to use when making requests
+        """
+        self._api = api_client
+
+    def list(self, organization_id: str) -> str:
+        """List all values for the given organization
+
+        :param organization_id: the id of the organization who's object store to retrieve from
+        :return: all objects for the given root key
+        """
+        payload = {
+            "organizationId": organization_id
+        }
+
+        data = self._api.post("organizations/encryption/keys/list/", payload)
+
+        return data

--- a/lean/components/api/project_client.py
+++ b/lean/components/api/project_client.py
@@ -82,7 +82,8 @@ class ProjectClient:
                lean_engine: Optional[int] = None,
                python_venv: Optional[int] = None,
                files: Optional[List[Dict[str, str]]] = None,
-               libraries: Optional[List[int]] = None) -> None:
+               libraries: Optional[List[int]] = None,
+               encryption_key: Optional[str] = None) -> None:
         """Updates an existing project.
 
         :param project_id: the id of the project to update
@@ -133,6 +134,9 @@ class ProjectClient:
             else:
                 request_parameters["libraries"] = []
 
+        if encryption_key is not None:
+            request_parameters["encryptionKey"] = encryption_key
+            
         self._api.post("projects/update", request_parameters, data_as_json=False)
 
     def delete(self, project_id: int) -> None:

--- a/lean/components/cloud/push_manager.py
+++ b/lean/components/cloud/push_manager.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from lean.components.api.api_client import APIClient
 from lean.components.config.project_config_manager import ProjectConfigManager
@@ -21,6 +21,9 @@ from lean.components.util.organization_manager import OrganizationManager
 from lean.components.util.project_manager import ProjectManager
 from lean.models.api import QCLanguage, QCProject
 from lean.models.utils import LeanLibraryReference
+from lean.components.util.encryption_helper import get_encrypted_file_content_for_project,\
+                                get_project_key_hash, get_decrypted_file_content_for_project
+from lean.models.encryption import ActionType
 
 class PushManager:
     """The PushManager class is responsible for synchronizing local projects to the cloud."""
@@ -45,7 +48,7 @@ class PushManager:
         self._organization_manager = organization_manager
         self._cloud_projects = []
 
-    def push_project(self, project: Path) -> None:
+    def push_project(self, project: Path, encryption_action: Optional[ActionType], encryption_key: Optional[Path]) -> None:
         """Pushes the given project from the local drive to the cloud.
 
         It will also push every library referenced by the project and add or remove references.
@@ -53,9 +56,9 @@ class PushManager:
         :param project: path to the directory containing the local project that needs to be pushed
         """
         libraries = self._project_manager.get_project_libraries(project)
-        self.push_projects(libraries + [project])
+        self.push_projects(libraries + [project], encryption_action, encryption_key)
 
-    def push_projects(self, projects_to_push: List[Path]) -> None:
+    def push_projects(self, projects_to_push: List[Path], encryption_action: Optional[ActionType], encryption_key: Optional[Path]) -> None:
         """Pushes the given projects from the local drive to the cloud.
 
         It will also push every library referenced by each project and add or remove references.
@@ -71,7 +74,7 @@ class PushManager:
             relative_path = path.relative_to(Path.cwd())
             try:
                 self._logger.info(f"[{index}/{len(projects_to_push)}] Pushing '{relative_path}'")
-                self._push_project(path, organization_id)
+                self._push_project(path, organization_id, encryption_action, encryption_key)
             except Exception as ex:
                 from traceback import format_exc
                 self._logger.debug(format_exc().strip())
@@ -88,7 +91,7 @@ class PushManager:
 
         return local_libraries_cloud_ids
 
-    def _push_project(self, project_path: Path, organization_id: str, suggested_rename_path: Path = None) -> None:
+    def _push_project(self, project_path: Path, organization_id: str, encryption_action: Optional[ActionType], encryption_key: Optional[Path], suggested_rename_path: Path = None) -> None:
         """Pushes a single local project to the cloud.
 
         Raises an error with a descriptive message if the project cannot be pushed.
@@ -107,6 +110,7 @@ class PushManager:
 
         project_config = self._project_config_manager.get_project_config(project_path)
         cloud_id = project_config.get("cloud-id")
+        local_encryption_state = project_config.get("encrypted", False)
 
         # check if project name is valid or if rename is required
         if cloud_id is not None:
@@ -138,33 +142,55 @@ class PushManager:
             if cloud_project.name != project_name:
                 # cloud project name was changed. Repeat steps to validate the new name locally.
                 self._logger.info(f"Received new name '{cloud_project.name}' for project '{project_name}' from QuantConnect.com")
-                self._push_project(project_path, organization_id, Path.cwd() / cloud_project.name)
+                self._push_project(project_path, organization_id, encryption_action, encryption_key, Path.cwd() / cloud_project.name)
                 return
 
             self._cloud_projects.append(cloud_project)
             organization_message_part = f" in organization '{organization_id}'" if organization_id is not None else ""
             self._logger.info(f"Successfully created cloud project '{cloud_project.name}'{organization_message_part}")
 
-        # Finalize pushing by updating locally modified metadata, files and libraries
-        self._push_metadata(project_path, cloud_project)
+        # Handle mismatch cases
+        if not encryption_key and bool(cloud_project.encrypted) != bool(local_encryption_state):
+            raise RuntimeError(f"Project encryption state mismatch. Please provide encryption key to push the project.")
+        if getattr(cloud_project.encryptionKey, 'id', None) and encryption_key and get_project_key_hash(encryption_key) != cloud_project.encryptionKey.id:
+            raise RuntimeError(f"Project encryption key mismatch. Please provide correct encryption key to push the project.")
 
-    def _get_files(self, project: Path) -> List[Dict[str, str]]:
+        # Finalize pushing by updating locally modified metadata, files and libraries
+        self._push_metadata(project_path, cloud_project, encryption_action, encryption_key)
+
+    def _get_files(self, project: Path, encryption_action: Optional[ActionType], encryption_key: Optional[Path]) -> List[Dict[str, str]]:
         """Pushes the files of a local project to the cloud.
 
         :param project: the local project to push the files of
         """
         paths = self._project_manager.get_source_files(project)
-        files = [
+        if (encryption_key):
+            organization_id = self._organization_manager.try_get_working_organization_id()
+            if encryption_action == ActionType.ENCRYPT:
+                data = get_encrypted_file_content_for_project(project, paths, 
+                        encryption_key, self._project_config_manager, organization_id)
+            else:
+                data = get_decrypted_file_content_for_project(project, 
+                        paths, encryption_key, self._project_config_manager, organization_id)
+            files = [
             {
                 'name': path.relative_to(project).as_posix(),
-                'content': path.read_text(encoding="utf-8")
+                'content': encrypted_content
             }
-            for path in paths
+            for path, encrypted_content in zip(paths, data)
         ]
+        else:
+            files = [
+                {
+                    'name': path.relative_to(project).as_posix(),
+                    'content': path.read_text(encoding="utf-8")
+                }
+                for path in paths
+            ]
 
         return files
 
-    def _push_metadata(self, project: Path, cloud_project: QCProject) -> None:
+    def _push_metadata(self, project: Path, cloud_project: QCProject, encryption_action: Optional[ActionType], encryption_key: Optional[Path]) -> None:
         """Pushes local project description and parameters to the cloud.
 
         Does nothing if the cloud is already up-to-date.
@@ -212,8 +238,16 @@ class PushManager:
         if local_lean_venv is not None and local_lean_venv != cloud_lean_venv:
             update_args["python_venv"] = local_lean_venv
 
-        update_args["files"] = self._get_files(project)
+        update_args["files"] = self._get_files(project, encryption_action, encryption_key)
         update_args["libraries"] = self._get_local_libraries_cloud_ids(project)
+
+        if (encryption_action is not None and encryption_key is not None):
+            if encryption_action == ActionType.ENCRYPT:
+                encryption_key_id = get_project_key_hash(encryption_key)
+                update_args["encryption_key"] = encryption_key_id
+            else:
+                # decryption case: Lets reset the value in the Cloud.
+                update_args["encryption_key"] = ''
 
         if update_args != {}:
             self._api_client.projects.update(cloud_project.projectId, **update_args)

--- a/lean/components/util/encryption_helper.py
+++ b/lean/components/util/encryption_helper.py
@@ -1,0 +1,212 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import List
+from pathlib import Path
+from base64 import b64decode, b64encode
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+from lean.components.config.project_config_manager import ProjectConfigManager
+from lean.models.api import QCProject, QCFullFile
+
+def calculate_md5(input_string: str):
+    """Calculate the md5 hash of a string
+
+    :param input_string: The string to hash
+    :return: The md5 hash of the string
+    """
+    import hashlib
+    return hashlib.md5(input_string.encode()).hexdigest()
+
+def get_b64_encoded(key: str) -> bytes:
+    """Encode a string to base64
+
+    :param key: The string to encode
+    :return: The base64 encoded string
+    """
+    return b64encode(key.encode('utf-8'))
+
+def get_project_key(project_key_path: Path, organization_id: str) -> str:
+    """Get the project key from the project key file
+
+    :param project_key_path: The path to the project key file
+    :return: The project key
+    """
+    with open(project_key_path, 'r') as f:
+        content = f.read()
+        key_for_aes = _get_fixed_length_key_from_user_full_length_key(content, organization_id.encode('utf-8'))
+        return key_for_aes
+
+def get_project_key_hash(project_key_path: Path):
+    """Get the MD5 hash from the project key file
+
+    :param project_key_path: The path to the project key file
+    :return: The project iv
+    """
+    with open(project_key_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+        return calculate_md5(content)
+    
+def get_project_iv(project_key_path: Path):
+    """Get the project iv from the project key file
+
+    :param project_key_path: The path to the project key file
+    :return: The project iv
+    """
+    key_id = get_project_key_hash(project_key_path)
+    return key_id[:16]
+
+def get_decrypted_file_content_for_project(project: Path, source_files: List[Path], encryption_key: Path, project_config_manager: ProjectConfigManager, organization_id: str) -> List[str]:
+    project_config = project_config_manager.get_project_config(project)
+
+    # Check if the project is already encrypted
+    areProjectFilesAlreadyEncrypted = project_config.get('encrypted', False)
+
+    # Check if there is mismatch of keys
+    local_encryption_key_path = project_config.get('encryption-key-path', None)
+    if local_encryption_key_path and encryption_key and Path(local_encryption_key_path) != encryption_key:
+        raise RuntimeError(f"Registered encryption key {local_encryption_key_path} is different from the one provided {encryption_key}")
+    
+    project_key = get_project_key(encryption_key, organization_id)
+    project_iv = get_project_iv(encryption_key)
+    decrypted_data = []
+    for file in source_files:
+        try:
+            # lets read and decrypt the file
+            with open(file, 'r') as f:
+                encrypted = f.read()
+                if not areProjectFilesAlreadyEncrypted:
+                    decrypted = encrypted
+                else:
+                    decrypted = decrypt_file_content(get_b64_encoded(project_key), get_b64_encoded(project_iv), encrypted)
+                decrypted_data.append(decrypted)
+        except Exception as e:
+            raise RuntimeError(f"Failed to decrypt file {file} with error {e}")
+    return decrypted_data
+
+def decrypt_file_content(b64_encoded_key: bytes, b64_encoded_iv: bytes, b64_encoded_content: str) -> str:
+    # remove new line characters that we added during encryption
+    b64_encoded_content = b64_encoded_content.replace('\n', '')
+    b64_encoded_content = b64_encoded_content.strip()
+    content = b64decode(b64_encoded_content.encode('utf-8'))
+    key = b64decode(b64_encoded_key)
+    init_vector = b64decode(b64_encoded_iv)
+    # Setup module-specific classes
+    cipher = Cipher(algorithms.AES(key), modes.CBC(init_vector))
+    decryptor = cipher.decryptor()
+
+    plaintext = decryptor.update(content) + decryptor.finalize()
+    # Unpad the decrypted data
+    unpadder = padding.PKCS7(128).unpadder()
+    unpadded_data = unpadder.update(plaintext) + unpadder.finalize()
+    return unpadded_data.decode('utf-8').replace("\r\n", "\n")
+
+def get_encrypted_file_content_for_project(project: Path, source_files: List[Path], encryption_key: Path, project_config_manager: ProjectConfigManager, organization_id: str) -> List[str]:
+    project_config = project_config_manager.get_project_config(project)
+
+    # Check if the project is already encrypted
+    areProjectFilesAlreadyEncrypted = project_config.get('encrypted', False)
+
+    # Check if there is mismatch of keys
+    local_encryption_key_path = project_config.get('encryption-key-path', None)
+    if local_encryption_key_path and encryption_key and Path(local_encryption_key_path) != encryption_key:
+        raise RuntimeError(f"Registered encryption key {local_encryption_key_path} is different from the one provided {encryption_key}")
+
+    project_key = get_project_key(encryption_key, organization_id)
+    project_iv = get_project_iv(encryption_key)
+    encrypted_data: List[str] = []
+    for file in source_files:
+        try:
+            # lets read and decrypt the file
+            with open(file, 'rb') as f:
+                plain_text = f.read()
+                if areProjectFilesAlreadyEncrypted:
+                    encrypted = plain_text
+                else:
+                    encrypted = encrypt_file_content(get_b64_encoded(project_key), get_b64_encoded(project_iv), plain_text)
+                encrypted_data.append(encrypted)
+        except Exception as e:
+            raise RuntimeError(f"Failed to encrypt file {file} with error {e}")
+    return encrypted_data
+
+def encrypt_file_content(b64_encoded_key: bytes, b64_encoded_iv: bytes, content: bytes) -> str:
+    key = b64decode(b64_encoded_key)
+    init_vector = b64decode(b64_encoded_iv)
+    plain_text = _pad(content, 16)
+    # Setup module-specific classes
+    cipher = Cipher(algorithms.AES(key), modes.CBC(init_vector))
+    encryptor = cipher.encryptor()
+
+    # Encrypt and decrypt data
+    cipher_text = encryptor.update(plain_text) + encryptor.finalize()
+    encrypted_content = b64encode(cipher_text).decode('utf-8')
+    # let's make it user friendly and add new lines, same as local platform
+    regex = r".{1,80}"
+    chunks = re.findall(regex, encrypted_content)
+    return '\n'.join(chunks)
+
+def get_decrypted_content_from_cloud_project(project: QCProject, cloud_files: List[QCFullFile], encryption_key: Path, organization_id: str) -> List[QCFullFile]:
+    # Check if the project is already encrypted
+    if not project.encrypted or project.encryptionKey.id != get_project_key_hash(encryption_key):
+        return cloud_files
+    
+    project_key = get_project_key(encryption_key, organization_id)
+    project_iv = get_project_iv(encryption_key)
+    for cloud_file in cloud_files:
+        try:
+            decrypted = decrypt_file_content(get_b64_encoded(project_key), get_b64_encoded(project_iv), cloud_file.content)
+            cloud_file.content = decrypted
+        except Exception as e:
+            raise RuntimeError(f"Failed to decrypt file {cloud_file} with error {e}")
+    return cloud_files
+
+def get_encrypted_content_from_cloud_project(project: QCProject, cloud_files: List[QCFullFile], encryption_key: Path, organization_id: str) -> List[QCFullFile]:
+    # Check if the project is already encrypted
+    if project.encrypted or project.encryptionKey.id != get_project_key_hash(encryption_key):
+        return cloud_files
+
+    project_key = get_project_key(encryption_key, organization_id)
+    project_iv = get_project_iv(encryption_key)
+    for cloud_file in cloud_files:
+        try:
+            encrypted = encrypt_file_content(get_b64_encoded(project_key), get_b64_encoded(project_iv), cloud_file.content)
+            cloud_file.content = encrypted
+        except Exception as e:
+            raise RuntimeError(f"Failed to decrypt file {cloud_file} with error {e}")
+    return cloud_files
+
+def _pad(data, block_size):
+    """Padding function for AES encryption
+
+    :param data: data to pad
+    :param block_size: required block size
+    :return: padded data
+    """
+    padding_length = block_size - (len(data) % block_size)
+    return data + bytes([padding_length] * padding_length)
+
+def _get_fixed_length_key_from_user_full_length_key(password: str, salt: bytes):
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=16,
+        salt=salt,
+        iterations=100000,
+        backend=default_backend()
+    )
+    return kdf.derive(password.encode()).hex()
+

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -23,6 +23,10 @@ from lean.models.pydantic import WrappedBaseModel, validator
 # The keys of properties are not changed, so they don't obey the rest of the project's naming conventions
 
 
+class ProjectEncryptionKey(WrappedBaseModel):
+    id: str
+    name: str
+
 class QCCollaborator(WrappedBaseModel):
     id: int
     uid: int
@@ -79,6 +83,8 @@ class QCProject(WrappedBaseModel):
     leanEnvironment: int
     parameters: List[QCParameter]
     libraries: List[QCProjectLibrary]
+    encrypted: Optional[bool] = False
+    encryptionKey: Optional[ProjectEncryptionKey] = None
 
     @validator("parameters", pre=True)
     def process_parameters_dict(cls, value: Any) -> Any:

--- a/lean/models/encryption.py
+++ b/lean/models/encryption.py
@@ -1,0 +1,18 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+class ActionType(Enum):
+    ENCRYPT = "encrypt"
+    DECRYPT = "decrypt"

--- a/tests/commands/cloud/test_push.py
+++ b/tests/commands/cloud/test_push.py
@@ -22,7 +22,8 @@ from lean.components.cloud.push_manager import PushManager
 from lean.models.api import QCFullFile
 from tests.test_helpers import create_fake_lean_cli_directory, create_api_project
 from tests.conftest import initialize_container
-
+from lean.container import container
+from lean.components.util.encryption_helper import get_project_key_hash
 
 def init_container(**kwargs) -> None:
     organization_manager = mock.Mock()
@@ -144,3 +145,286 @@ def test_cloud_push_updates_lean_config() -> None:
     assert result.exit_code == 0
 
     project_config.set.assert_called_with("organization-id", "123")
+
+
+def test_cloud_push_aborts_when_encrypting_without_key_given() -> None:
+    create_fake_lean_cli_directory()
+
+    push_manager = mock.Mock()
+    init_container(push_manager_to_use=push_manager)
+
+    (Path.cwd() / "Empty Project").mkdir()
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Empty Project", "--encrypt"])
+
+    assert result.exit_code != 0
+
+    push_manager.push_projects.assert_not_called()
+
+def test_cloud_push_aborts_when_decrypting_without_key_given() -> None:
+    create_fake_lean_cli_directory()
+
+    push_manager = mock.Mock()
+    init_container(push_manager_to_use=push_manager)
+
+    (Path.cwd() / "Empty Project").mkdir()
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", "Empty Project", "--decrypt"])
+
+    assert result.exit_code != 0
+
+    push_manager.push_projects.assert_not_called()
+
+
+def test_cloud_push_sends_encrypted_files_with_encrypted_flag_given() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+    # Keys API Data
+    key_hash = get_project_key_hash(encryption_file_path)
+    keys_api_data = {'keys': [{'name': 'test', 'hash': key_hash}]}
+
+    api_client = mock.Mock()
+    api_client.encryption_keys.list = mock.MagicMock(return_value=keys_api_data)
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", False)
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path, "--encrypt", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+    expected_arguments = {
+        "name": "Python Project",
+        "description": "",
+        "files": [{'name': 'main.py', 'content': 'ACt9qaSIRLLpdckQHMuT8U+kuh8RR+pK74GN9h4RhxS3P5rEDbyr8Wk82vJzK3Sfv3w8Iny9wmO7yjxD\noHXL2uiPa4nQ/WybaAgKOYkLY3SqHdXD1JvzHVDv3c4AiprHbocXzoiFoNlLjJEArCZ99cPVHObtV8O+\ntJOyJH8fTaOvfR2H3R2rJAf1PzIgx+sHNp/1T021kRQ+Mn/cKTLY+ijFou4TQLBOQEdwKY5pjnogWmK+\nLInQWHO4inBesrtU5Xl2btuGcbmoDC0xs0CRIQLx6w9h/2Dn4Df2Abz59T3p60Ng8/LsfVARYrIdG7EC\nshLjhOzyhhIx/F2NOEBLM1eXRbpq1bA2WgQea9ag1FlKUE/aJml/KRpQgD4i0bl4Kgc6/+HM9khQNxIQ\nzECYECCQv3TmX28FJVnpmmErGMTAvw/H1XowwQFU79VW17ewFGYaaMfiLwZREvc6sbmwcB9LU25Qqpz5\n5HjEpZL4hQd++nW7pusV9ACxFN8EssX4Va/K4LlBsW4O+dIFPFPKZQchvrAjo+6EX3azOgY89sHU2xLL\nyAlkSsBQBBoAqbLl02BMy6b728gXlhW/vY9zl5g7tF4HbG6nUc3XYzjICUitLKVZrCZDpX2EUDqjj8q/\nzuFrJEJOiKConZRn/kRh00l+AXkGEZ9x08/1sbGFGEbjxhobTS1WrrK2q+8NL8Thp+xqaRO9vKCEKtQc\nIDp3/sTD1DCaQOB0nudqy79V7i8TdnoKRMdE8i8ZeTpypQD4e6cv7JcDKZLAv12bmRPf5yn1Q/TZXI4f\n9zEPyBHApK6/9QKqh8QsgGgDRWma9na5BY7lnlkF0bKSGShmWQtHuNDw7lkHbsKPz/3mYBHJM5IWDdwk\nfHVr8j6+qQrj91uzIaAr/tVIP4IPT2RYRVOKJckrvaIvnpoKrhw2YxNkpcPMADmaCOa2RPAc1IovYPGK\n8FD79JNfpfF9uH+g6faIuoGEM5YG3mqx7//p+oLMF2IiaiuW8QN92SyOumgH3jYF3Hl/pSmoJox/waTY\ndDaHg4//NCb05yL+wN4YUqryHd9NJdOYUXcyxjiU8F2DJOrVsOcuhrZPPJbyXu1kxIxG+qszX6Z+evD4\nKvoYxv9/onbZKl7f4W5xjykBHos9QXn5IyMPIc/IOp0ZoGG8I5cDRQnK8n1WWw66dyDmJyV+yeY='}, {'name': 'research.ipynb', 'content': 'S3kdd/4WCyvdIl3tkd8WzuaKKg/vXagKpwlWgNILzHtWTL9LXYGqToEZIvaM9O9bruPSRu7lX6TqWdam\nWKTMwyeERZO/UnN1/Kja0w4jnMpWDZToG8LV1P5WnyGeJP7tyYEkzFn+aPoDrI4dOVaNa64SICb1Z9cE\n2wfdUjeE6eDM7JmrazJouZYS2aJ8/WoldWhslP2ogjfNUOcETgoHO96IWy5Yv/gYfhwWTkwI05VggczV\nw+yP6Oqb1nz4E+2zrMgQ5HyO2pATv93T4HQSUMvqAXltNznsVtcXQhZHHt+dfm8F4qCijnr0rgVYvYh4\nv7VyUW3VpPn1XXHPz9p6iVvDD1x682LeNSZfkbsMAbuBy68WV6hD0bAprImxOc4dq8LuLqIFbfx8aJI0\nvLvTixe5n9qJj7EaK16nPAuTWwiNU2neUGvbn8P3ktJAzX/GIpLgp0PhpsLrjTQeQ9GU4RYNA88Jd/ui\nhnxgLkiUkcqfuFAcQJOeLI0HZ7x75ngBJdiS6Yh2mOopx5U0nRPzrCnCTkt1fNBYbcGA4ONi4pbHcPen\nkEF7S3y3dOXHDY2YDQrlWKRVHLwEHQ05VqSA9M/RJmqG7pcD3e46z+37+5XTFb2IZa/tXscCEjiXDloX\n5MD5mlvtaU2gbNQ1Elh/x1GsXYKDFPnIWS5wFObVb79MxoP0jEP0vP/Y790X8baRVUJLOFrz1+h37cuJ\nY4jPWbWEB1O7JcjIwzASdJOciUIO+nuhEaaJrKHbmgxFGILNfe3/1smYxr0cNGunA/9L2S9Dqzp7iNzt\nfCwufgpdpmBwFMVB9UlbvpuDiFcEIVtGneId2ao+SSj1M8x/BebXrfA+4fEH/mwzTrcMYHQkSevt2EpL\n9XFEL1EleqYuNtdUlc9gzOz6xlVRIKsBCH7qAETIZTFB8ED5rx86jnyHpZ3+gV9qZjiWa+74ctR2Lzlp\nDpYszsnXVesRC0pgcNzDzQNbiWSW6U4IfMqXIPXWo3IWKOi8jQNtivhPQdfnQelfn0hAx7rZCG+j2KBC\nG8F3ejcjjZT6YQEpW9NQ2LkH7lVz15hpumyHw2y6zAN0uHdAO4xXWVD1uuYWo4/SUzvS6Erx300SENNu\nYx9Bsn07/wlOKD9iSl0VO8CkfxilVCnUz6HHa4nrffgMZ/w4MCSv2gCTJsR7b/Y+ShxysVbAXRSJGhV+\nv6Ia9zFayPjpL7i7bfg997CRkZ+ht6Yi5feSqLmj7KSrfeEOzBevZBXdMZsmzFSPcWm5dzpCeixY/63d\nBJRtvg10HZWwcFjkR66ThWBAXrkz+0xfkx2t5+7ZnhoK3JBNUMtvdoll6Y8XEtQeqr5Z24OQ0g2JtW4b\nSIJ2zIzpAOhbrk4lCtLq998Y1Pb0fdHqe3gafiKcGC3ywYi8oevLCjq1yKKSwKDFoNGrWiX6ooLxHBA+\nXZHJOTkicCYMZoeq0/9GnaW0enjZ8yTZl5ZVvg7YzRoiVm16co38zINOT2GUw0YOTES+FonUs4lOe/qe\n7/Do25uLTM4cLP1iAkLLA8vYLKmLxbXBP8IGqFHZDKtFmjpzA5SvYzhPcxuf91IhwIxKJ+bh4UtX8vYG\ntSfvytzEHRP4Z6Fly2UdoSEUdDar5VO2pEbY/KKZJBnSueXI+7xoH48v77NX+XQUP5ciaW1DyF7bvVNw\nkJh9VocbwELVpWU32rrf9QbjWU/PbNMZEdSWAvgJpRP/KFw5uFgCy5ESlG8pAj7W2K0drEFT+OKPg4qK\noqeKiTmt+yOX8o2u1KKarJmkLHAB3er0ijx7hX8q+hesS0jnj7dhG18nqM7mkSaIgMTyX9sg/xNJMPQ7\nXfU+kY+PxN3PbMT2ZkmWy5e9HFT+D7MM2U52dy1UJt3gGBVPagwKITRxXz3BKVxHgzmm8echfvH09VMV\nMFLAsyqp7AZXgyUp7QybH/WfO03N+lhYPFCRnmpKuFt00NhxM278xIOex/k4aTed'}],
+        "libraries": [],
+        "encryption_key": key_hash
+    }
+    api_client.projects.update.assert_called_once_with(1, **expected_arguments)
+
+def test_cloud_push_aborts_sending_encrypted_files_when_local_file_encrypted_with_key_x_and_given_key_y() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path_x = project_path / "encryption_x.txt"
+    encryption_file_path_x.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    encryption_file_path_y = project_path / "encryption_y.txt"
+    encryption_file_path_y.write_text("Jtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    # Keys API Data
+    key_hash = get_project_key_hash(encryption_file_path_y)
+    keys_api_data = {'keys': [{'name': 'test', 'hash': key_hash}]}
+
+    api_client = mock.Mock()
+    api_client.encryption_keys.list = mock.MagicMock(return_value=keys_api_data)
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", True)
+    project_config.set("encryption-key-path", str(encryption_file_path_x))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path, "--encrypt", "--key", encryption_file_path_y])
+
+    assert result.exit_code == 0
+    api_client.projects.update.assert_not_called()
+
+def test_cloud_push_turns_on_encryption_with_encrypted_flag_given() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+    # Keys API Data
+    key_hash = get_project_key_hash(encryption_file_path)
+    keys_api_data = {'keys': [{'name': 'test', 'hash': key_hash}]}
+
+    api_client = mock.Mock()
+    api_client.encryption_keys.list = mock.MagicMock(return_value=keys_api_data)
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", False)
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path, "--encrypt", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+    # verify that the 'encryption_key' is being set to turn on the encryption in the cloud.
+    expected_arguments = {
+        "name": "Python Project",
+        "description": "",
+        "files": [{'name': 'main.py', 'content': 'ACt9qaSIRLLpdckQHMuT8U+kuh8RR+pK74GN9h4RhxS3P5rEDbyr8Wk82vJzK3Sfv3w8Iny9wmO7yjxD\noHXL2uiPa4nQ/WybaAgKOYkLY3SqHdXD1JvzHVDv3c4AiprHbocXzoiFoNlLjJEArCZ99cPVHObtV8O+\ntJOyJH8fTaOvfR2H3R2rJAf1PzIgx+sHNp/1T021kRQ+Mn/cKTLY+ijFou4TQLBOQEdwKY5pjnogWmK+\nLInQWHO4inBesrtU5Xl2btuGcbmoDC0xs0CRIQLx6w9h/2Dn4Df2Abz59T3p60Ng8/LsfVARYrIdG7EC\nshLjhOzyhhIx/F2NOEBLM1eXRbpq1bA2WgQea9ag1FlKUE/aJml/KRpQgD4i0bl4Kgc6/+HM9khQNxIQ\nzECYECCQv3TmX28FJVnpmmErGMTAvw/H1XowwQFU79VW17ewFGYaaMfiLwZREvc6sbmwcB9LU25Qqpz5\n5HjEpZL4hQd++nW7pusV9ACxFN8EssX4Va/K4LlBsW4O+dIFPFPKZQchvrAjo+6EX3azOgY89sHU2xLL\nyAlkSsBQBBoAqbLl02BMy6b728gXlhW/vY9zl5g7tF4HbG6nUc3XYzjICUitLKVZrCZDpX2EUDqjj8q/\nzuFrJEJOiKConZRn/kRh00l+AXkGEZ9x08/1sbGFGEbjxhobTS1WrrK2q+8NL8Thp+xqaRO9vKCEKtQc\nIDp3/sTD1DCaQOB0nudqy79V7i8TdnoKRMdE8i8ZeTpypQD4e6cv7JcDKZLAv12bmRPf5yn1Q/TZXI4f\n9zEPyBHApK6/9QKqh8QsgGgDRWma9na5BY7lnlkF0bKSGShmWQtHuNDw7lkHbsKPz/3mYBHJM5IWDdwk\nfHVr8j6+qQrj91uzIaAr/tVIP4IPT2RYRVOKJckrvaIvnpoKrhw2YxNkpcPMADmaCOa2RPAc1IovYPGK\n8FD79JNfpfF9uH+g6faIuoGEM5YG3mqx7//p+oLMF2IiaiuW8QN92SyOumgH3jYF3Hl/pSmoJox/waTY\ndDaHg4//NCb05yL+wN4YUqryHd9NJdOYUXcyxjiU8F2DJOrVsOcuhrZPPJbyXu1kxIxG+qszX6Z+evD4\nKvoYxv9/onbZKl7f4W5xjykBHos9QXn5IyMPIc/IOp0ZoGG8I5cDRQnK8n1WWw66dyDmJyV+yeY='}, {'name': 'research.ipynb', 'content': 'S3kdd/4WCyvdIl3tkd8WzuaKKg/vXagKpwlWgNILzHtWTL9LXYGqToEZIvaM9O9bruPSRu7lX6TqWdam\nWKTMwyeERZO/UnN1/Kja0w4jnMpWDZToG8LV1P5WnyGeJP7tyYEkzFn+aPoDrI4dOVaNa64SICb1Z9cE\n2wfdUjeE6eDM7JmrazJouZYS2aJ8/WoldWhslP2ogjfNUOcETgoHO96IWy5Yv/gYfhwWTkwI05VggczV\nw+yP6Oqb1nz4E+2zrMgQ5HyO2pATv93T4HQSUMvqAXltNznsVtcXQhZHHt+dfm8F4qCijnr0rgVYvYh4\nv7VyUW3VpPn1XXHPz9p6iVvDD1x682LeNSZfkbsMAbuBy68WV6hD0bAprImxOc4dq8LuLqIFbfx8aJI0\nvLvTixe5n9qJj7EaK16nPAuTWwiNU2neUGvbn8P3ktJAzX/GIpLgp0PhpsLrjTQeQ9GU4RYNA88Jd/ui\nhnxgLkiUkcqfuFAcQJOeLI0HZ7x75ngBJdiS6Yh2mOopx5U0nRPzrCnCTkt1fNBYbcGA4ONi4pbHcPen\nkEF7S3y3dOXHDY2YDQrlWKRVHLwEHQ05VqSA9M/RJmqG7pcD3e46z+37+5XTFb2IZa/tXscCEjiXDloX\n5MD5mlvtaU2gbNQ1Elh/x1GsXYKDFPnIWS5wFObVb79MxoP0jEP0vP/Y790X8baRVUJLOFrz1+h37cuJ\nY4jPWbWEB1O7JcjIwzASdJOciUIO+nuhEaaJrKHbmgxFGILNfe3/1smYxr0cNGunA/9L2S9Dqzp7iNzt\nfCwufgpdpmBwFMVB9UlbvpuDiFcEIVtGneId2ao+SSj1M8x/BebXrfA+4fEH/mwzTrcMYHQkSevt2EpL\n9XFEL1EleqYuNtdUlc9gzOz6xlVRIKsBCH7qAETIZTFB8ED5rx86jnyHpZ3+gV9qZjiWa+74ctR2Lzlp\nDpYszsnXVesRC0pgcNzDzQNbiWSW6U4IfMqXIPXWo3IWKOi8jQNtivhPQdfnQelfn0hAx7rZCG+j2KBC\nG8F3ejcjjZT6YQEpW9NQ2LkH7lVz15hpumyHw2y6zAN0uHdAO4xXWVD1uuYWo4/SUzvS6Erx300SENNu\nYx9Bsn07/wlOKD9iSl0VO8CkfxilVCnUz6HHa4nrffgMZ/w4MCSv2gCTJsR7b/Y+ShxysVbAXRSJGhV+\nv6Ia9zFayPjpL7i7bfg997CRkZ+ht6Yi5feSqLmj7KSrfeEOzBevZBXdMZsmzFSPcWm5dzpCeixY/63d\nBJRtvg10HZWwcFjkR66ThWBAXrkz+0xfkx2t5+7ZnhoK3JBNUMtvdoll6Y8XEtQeqr5Z24OQ0g2JtW4b\nSIJ2zIzpAOhbrk4lCtLq998Y1Pb0fdHqe3gafiKcGC3ywYi8oevLCjq1yKKSwKDFoNGrWiX6ooLxHBA+\nXZHJOTkicCYMZoeq0/9GnaW0enjZ8yTZl5ZVvg7YzRoiVm16co38zINOT2GUw0YOTES+FonUs4lOe/qe\n7/Do25uLTM4cLP1iAkLLA8vYLKmLxbXBP8IGqFHZDKtFmjpzA5SvYzhPcxuf91IhwIxKJ+bh4UtX8vYG\ntSfvytzEHRP4Z6Fly2UdoSEUdDar5VO2pEbY/KKZJBnSueXI+7xoH48v77NX+XQUP5ciaW1DyF7bvVNw\nkJh9VocbwELVpWU32rrf9QbjWU/PbNMZEdSWAvgJpRP/KFw5uFgCy5ESlG8pAj7W2K0drEFT+OKPg4qK\noqeKiTmt+yOX8o2u1KKarJmkLHAB3er0ijx7hX8q+hesS0jnj7dhG18nqM7mkSaIgMTyX9sg/xNJMPQ7\nXfU+kY+PxN3PbMT2ZkmWy5e9HFT+D7MM2U52dy1UJt3gGBVPagwKITRxXz3BKVxHgzmm8echfvH09VMV\nMFLAsyqp7AZXgyUp7QybH/WfO03N+lhYPFCRnmpKuFt00NhxM278xIOex/k4aTed'}],
+        "libraries": [],
+        "encryption_key": key_hash
+    }
+    api_client.projects.update.assert_called_once_with(1, **expected_arguments)
+
+def test_cloud_push_sends_decrypted_files_with_decrypted_flag_given() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+    # Keys API Data
+    key_hash = get_project_key_hash(encryption_file_path)
+    keys_api_data = {'keys': [{'name': 'test', 'hash': key_hash}]}
+
+    api_client = mock.Mock()
+    api_client.encryption_keys.list = mock.MagicMock(return_value=keys_api_data)
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", False)
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path, "--decrypt", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+    expeceted_arguments = {
+        "name": "Python Project",
+        "description": "",
+        "files": [{'name': 'main.py', 'content': '# region imports\nfrom AlgorithmImports import *\n# endregion\n\nclass PythonProject(QCAlgorithm):\n\n    def Initialize(self):\n        # Locally Lean installs free sample data, to download more data please visit https://www.quantconnect.com/docs/v2/lean-cli/datasets/downloading-data\n        self.SetStartDate(2013, 10, 7)  # Set Start Date\n        self.SetEndDate(2013, 10, 11)  # Set End Date\n        self.SetCash(100000)  # Set Strategy Cash\n        self.AddEquity("SPY", Resolution.Minute)\n\n    def OnData(self, data: Slice):\n        """OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.\n            Arguments:\n                data: Slice object keyed by symbol containing the stock data\n        """\n        if not self.Portfolio.Invested:\n            self.SetHoldings("SPY", 1)\n            self.Debug("Purchased Stock")\n'}, {'name': 'research.ipynb', 'content': '{\n    "cells": [\n        {\n            "cell_type": "markdown",\n            "metadata": {},\n            "source": [\n                "![QuantConnect Logo](https://cdn.quantconnect.com/web/i/icon.png)\\n",\n                "<hr>"\n            ]\n        },\n        {\n            "cell_type": "code",\n            "execution_count": null,\n            "metadata": {},\n            "outputs": [],\n            "source": [\n                "# QuantBook Analysis Tool \\n",\n                "# For more information see [https://www.quantconnect.com/docs/v2/our-platform/research/getting-started]\\n",\n                "qb = QuantBook()\\n",\n                "spy = qb.AddEquity(\\"SPY\\")\\n",\n                "# Locally Lean installs free sample data, to download more data please visit https://www.quantconnect.com/docs/v2/lean-cli/datasets/downloading-data \\n",\n                "qb.SetStartDate(2013, 10, 11)\\n",\n                "history = qb.History(qb.Securities.Keys, 360, Resolution.Daily)\\n",\n                "\\n",\n                "# Indicator Analysis\\n",\n                "bbdf = qb.Indicator(BollingerBands(30, 2), spy.Symbol, 360, Resolution.Daily)\\n",\n                "bbdf.drop(\'standarddeviation\', axis=1).plot()"\n            ]\n        }\n    ],\n    "metadata": {\n        "kernelspec": {\n            "display_name": "Python 3",\n            "language": "python",\n            "name": "python3"\n        }\n    },\n    "nbformat": 4,\n    "nbformat_minor": 2\n}\n'}],
+        "libraries": [],
+        "encryption_key": ''
+    }
+    api_client.projects.update.assert_called_once_with(1, **expeceted_arguments)
+
+def test_cloud_push_turns_off_encryption_with_decrypted_flag_given() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+    # Keys API Data
+    key_hash = get_project_key_hash(encryption_file_path)
+    keys_api_data = {'keys': [{'name': 'test', 'hash': key_hash}]}
+
+    api_client = mock.Mock()
+    api_client.encryption_keys.list = mock.MagicMock(return_value=keys_api_data)
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", False)
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path, "--decrypt", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+    # verify that the encryption key is set to null to turn off the encryption.
+    expeceted_arguments = {
+        "name": "Python Project",
+        "description": "",
+        "files": [{'name': 'main.py', 'content': '# region imports\nfrom AlgorithmImports import *\n# endregion\n\nclass PythonProject(QCAlgorithm):\n\n    def Initialize(self):\n        # Locally Lean installs free sample data, to download more data please visit https://www.quantconnect.com/docs/v2/lean-cli/datasets/downloading-data\n        self.SetStartDate(2013, 10, 7)  # Set Start Date\n        self.SetEndDate(2013, 10, 11)  # Set End Date\n        self.SetCash(100000)  # Set Strategy Cash\n        self.AddEquity("SPY", Resolution.Minute)\n\n    def OnData(self, data: Slice):\n        """OnData event is the primary entry point for your algorithm. Each new data point will be pumped in here.\n            Arguments:\n                data: Slice object keyed by symbol containing the stock data\n        """\n        if not self.Portfolio.Invested:\n            self.SetHoldings("SPY", 1)\n            self.Debug("Purchased Stock")\n'}, {'name': 'research.ipynb', 'content': '{\n    "cells": [\n        {\n            "cell_type": "markdown",\n            "metadata": {},\n            "source": [\n                "![QuantConnect Logo](https://cdn.quantconnect.com/web/i/icon.png)\\n",\n                "<hr>"\n            ]\n        },\n        {\n            "cell_type": "code",\n            "execution_count": null,\n            "metadata": {},\n            "outputs": [],\n            "source": [\n                "# QuantBook Analysis Tool \\n",\n                "# For more information see [https://www.quantconnect.com/docs/v2/our-platform/research/getting-started]\\n",\n                "qb = QuantBook()\\n",\n                "spy = qb.AddEquity(\\"SPY\\")\\n",\n                "# Locally Lean installs free sample data, to download more data please visit https://www.quantconnect.com/docs/v2/lean-cli/datasets/downloading-data \\n",\n                "qb.SetStartDate(2013, 10, 11)\\n",\n                "history = qb.History(qb.Securities.Keys, 360, Resolution.Daily)\\n",\n                "\\n",\n                "# Indicator Analysis\\n",\n                "bbdf = qb.Indicator(BollingerBands(30, 2), spy.Symbol, 360, Resolution.Daily)\\n",\n                "bbdf.drop(\'standarddeviation\', axis=1).plot()"\n            ]\n        }\n    ],\n    "metadata": {\n        "kernelspec": {\n            "display_name": "Python 3",\n            "language": "python",\n            "name": "python3"\n        }\n    },\n    "nbformat": 4,\n    "nbformat_minor": 2\n}\n'}],
+        "libraries": [],
+        "encryption_key": ''
+    }
+    api_client.projects.update.assert_called_once_with(1, **expeceted_arguments)
+
+def test_cloud_push_aborts_when_local_files_in_encrypted_state_and_cloud_project_in_decrypted_state_without_key_given() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    api_client = mock.Mock()
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", True)
+    project_config.set("encryption-key-path", str(encryption_file_path))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path])
+
+    assert result.exit_code == 0
+    api_client.projects.update.assert_not_called()
+
+def test_cloud_push_aborts_when_local_files_in_decrypted_state_and_cloud_project_in_encrypted_state_without_key_given() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+    key_hash = get_project_key_hash(encryption_file_path)
+
+    api_client = mock.Mock()
+    cloud_project = create_api_project(1, "Python Project", encrypted=True, encryptionKey={"name":"test", "id": key_hash})
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project)
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path])
+
+    assert result.exit_code == 0
+    api_client.projects.update.assert_not_called()
+
+def test_cloud_push_aborts_when_local_files_in_encrypted_state_with_key_x_and_cloud_project_in_encrypted_state_with_key_y() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path_x = project_path / "encryption_x.txt"
+    encryption_file_path_x.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    encryption_file_path_y = project_path / "encryption_y.txt"
+    encryption_file_path_y.write_text("Jtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    # Keys API Data
+    key_hash_y = get_project_key_hash(encryption_file_path_y)
+
+    api_client = mock.Mock()
+    cloud_project = create_api_project(1, "Python Project")
+    api_client.projects.create = mock.MagicMock(return_value=cloud_project, encrypted=True, encryptionKey={"name":"test", "id": key_hash_y})
+    fake_cloud_files = [QCFullFile(name="file.py", content="testing", modified=datetime.now(), isLibrary=False)]
+    api_client.files.get_all = mock.MagicMock(return_value=fake_cloud_files)
+
+    init_container(api_client_to_use=api_client)
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", True)
+    project_config.set("encryption-key-path", str(encryption_file_path_x))
+
+    result = CliRunner().invoke(lean, ["cloud", "push", "--project", project_path])
+
+    assert result.exit_code == 0
+    api_client.projects.update.assert_not_called()

--- a/tests/commands/test_decrypt.py
+++ b/tests/commands/test_decrypt.py
@@ -1,0 +1,207 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from click.testing import CliRunner
+
+from lean.commands import lean
+from tests.test_helpers import create_fake_lean_cli_directory
+from lean.container import container
+
+
+def test_decrypt_decrypts_file_in_case_project_not_in_decrypt_state() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) != False
+    assert project_config.get("encryption-key-path", None) != None
+    for file in source_files:
+        assert file_contents_map[file.name] != file.read_text()
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == False
+    assert project_config.get("encryption-key-path", None) == None
+
+
+def test_decrypt_does_not_change_file_in_case_project_already_in_decrypt_state() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == False
+    assert project_config.get("encryption-key-path", None) == None
+
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == False
+    assert project_config.get("encryption-key-path", None) == None
+
+
+def test_decrypt_uses_key_from_config_file_when_not_provided() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) != False
+    assert project_config.get("encryption-key-path", None) != None
+    for file in source_files:
+            assert file_contents_map[file.name] != file.read_text()
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project"])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == False
+    assert project_config.get("encryption-key-path", None) == None
+
+def test_decrypt_updates_project_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) != False
+    assert project_config.get("encryption-key-path", None) != None
+    for file in source_files:
+            assert file_contents_map[file.name] != file.read_text()
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == False
+    assert project_config.get("encryption-key-path", None) == None
+
+def test_decrypt_does_not_update_project_config_file_if_not_all_files_successful() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) != False
+    assert project_config.get("encryption-key-path", None) != None
+
+    # let's corrupt one file
+    source_files = container.project_manager.get_source_files(project_path)
+    source_files[0].write_text("corrupted")
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code != 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) != False
+    assert project_config.get("encryption-key-path", None) != None
+
+def test_decrypt_aborts_when_key_is_not_provided_and_not_in_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+    assert project_config.get("encrypted", False) == False
+    project_config.set("encrypted", True)
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project"])
+
+    assert result.exit_code != 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+
+def test_decrypt_aborts_when_provided_key_different_from_key_in_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path_x = project_path / "encryption_x.txt"
+    encryption_file_path_x.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    encryption_file_path_y = project_path / "encryption_y.txt"
+    encryption_file_path_y.write_text("Jtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path_x])
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) != False
+    assert project_config.get("encryption-key-path", None) != None
+
+    result = CliRunner().invoke(lean, ["decrypt", "Python Project", "--key", encryption_file_path_y])
+
+    assert result.exit_code != 0

--- a/tests/commands/test_encrypt.py
+++ b/tests/commands/test_encrypt.py
@@ -1,0 +1,227 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from click.testing import CliRunner
+
+from lean.commands import lean
+from tests.test_helpers import create_fake_lean_cli_directory
+from lean.container import container
+
+
+def test_encrypt_encrypts_file_in_case_project_not_in_encrypt_state() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == False
+    assert project_config.get("encryption-key-path", None) == None
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    expected_encrypted_files = _get_expected_encrypted_files_content()
+    for file in source_files:
+        assert expected_encrypted_files[file.name].strip() == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == True
+    assert project_config.get("encryption-key-path", None) == str(encryption_file_path)
+
+
+def test_encrypt_does_not_change_file_in_case_project_already_in_encrypt_state() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encrypted", True)
+    project_config.set("encryption-key-path", str(encryption_file_path))
+
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == True
+    assert project_config.get("encryption-key-path", None) == str(encryption_file_path)
+
+
+def test_encrypt_uses_key_from_config_file_when_not_provided() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encryption-key-path", str(encryption_file_path))
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project"])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    expected_encrypted_files = _get_expected_encrypted_files_content()
+    for file in source_files:
+        assert expected_encrypted_files[file.name].strip() == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == True
+    assert project_config.get("encryption-key-path", None) == str(encryption_file_path)
+
+def test_encrypt_updates_project_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path = project_path / "encryption_x.txt"
+    encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+    assert result.exit_code == 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    expected_encrypted_files = _get_expected_encrypted_files_content()
+    for file in source_files:
+        assert expected_encrypted_files[file.name].strip() == file.read_text()
+    project_config = container.project_config_manager.get_project_config(project_path)
+    assert project_config.get("encrypted", False) == True
+    assert project_config.get("encryption-key-path", None) == str(encryption_file_path)
+
+# def test_encrypt_does_not_update_project_config_file_if_not_all_files_successful() -> None:
+#     create_fake_lean_cli_directory()
+
+#     project_path = Path.cwd() / "Python Project"
+
+#     encryption_file_path = project_path / "encryption_x.txt"
+#     encryption_file_path.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+#     CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path])
+
+#     project_config = container.project_config_manager.get_project_config(project_path)
+#     assert project_config.get("encrypted", False) != False
+#     assert project_config.get("encryption-key-path", None) != None
+
+#     # let's corrupt one file
+#     source_files = container.project_manager.get_source_files(project_path)
+#     source_files[0].write_text("corrupted")
+#     file_contents_map = {file.name: file.read_text() for file in source_files}
+
+#     result = CliRunner().invoke(lean, ["decrypt", "Python Project", "--key", encryption_file_path])
+
+#     assert result.exit_code != 0
+
+#     source_files = container.project_manager.get_source_files(project_path)
+#     for file in source_files:
+#         assert file_contents_map[file.name] == file.read_text()
+#     project_config = container.project_config_manager.get_project_config(project_path)
+#     assert project_config.get("encrypted", False) != False
+#     assert project_config.get("encryption-key-path", None) != None
+
+def test_encrypt_aborts_when_key_is_not_provided_and_not_in_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    source_files = container.project_manager.get_source_files(project_path)
+    file_contents_map = {file.name: file.read_text() for file in source_files}
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project"])
+
+    assert result.exit_code != 0
+
+    source_files = container.project_manager.get_source_files(project_path)
+    for file in source_files:
+        assert file_contents_map[file.name] == file.read_text()
+
+def test_encrypt_aborts_when_provided_key_different_from_key_in_config_file() -> None:
+    create_fake_lean_cli_directory()
+
+    project_path = Path.cwd() / "Python Project"
+
+    encryption_file_path_x = project_path / "encryption_x.txt"
+    encryption_file_path_x.write_text("KtSwJtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    encryption_file_path_y = project_path / "encryption_y.txt"
+    encryption_file_path_y.write_text("Jtq5a4uuQmxbPqcCP3d8yMRz5TZxDBAKy7kGwPcvcvsNBdCprGYwSBN8ntJa5JNNYHTB2GrBpAbkA38kCdnceegffZH7")
+
+    project_config = container.project_config_manager.get_project_config(project_path)
+    project_config.set("encryption-key-path", str(encryption_file_path_x))
+
+    result = CliRunner().invoke(lean, ["encrypt", "Python Project", "--key", encryption_file_path_y])
+
+    assert result.exit_code != 0
+
+
+def _get_expected_encrypted_files_content() -> dict:
+    return {
+        "main.py":
+                        """UpMdqgoXS1tgqGgy6nKkmp65TT+GqReCQwA+FCyfwGPqW6phpj3l83KaX1Cz0uICPto9QlHVhhbsnRrd
+ydsvM2243MT0zUaPSpwD3FoNGPkjcdDCzj1pwJ9Xkgt7vwm9CMAL+NVUI9gd9e+/6zHprEOBwinzufX+
+XBlcwHCbePF2mP6d/TWtLVCChiFjipgW0Tpy9UUByQxo9K/j5/PUawTg3gV9xLszlG65aEe2x0upmP9Y
+OnZh9Uuyppe8dW4AaZMu64RRmxHWA0m9qH/N7QTJSBchlp/6Y/sWNLqoz6WvqCs8L5iAXVCQ5QYMKV1A
+bMmt536DlJ5+4c9vP6omi/wOkoWi30ojQBqGT/n7By5P3bOdCq5Yi7jGRWBRE/IMB26DnRbt9sLPQV2a
+TUnW/vjDbT6LUvg2Rgmsroq3fD2etI9GrQN6xp+0jGT7Drib9RwIJl+9dimyjuXwzpanmkdLJZ4d8w9g
+cyz/cTa+LaoXbLxDQgvgtDsJYifnDTm7IUJSUov3Uy9Anl5WeVk1XpbFk+9ZHhw2QR8jSJ93eyFDSGyG
+xyWltGdAmSBm814G2UJTeMGIBGBqwtel85mQw1sQkXluN86QjZQ7r9f8uBjyHwv7n3mu3ma+IHNfgB4q
+f2ZqK6WHGCaYSVUbXLgzD4If/kVPnrwWGrcfJuLis9F8kKFSK5/Hkf7xXNMWAta0WsN5EExga+iVycug
+8GAYTJoxaNsqFPssatdmo8OICQ4wIivPW5cCuJltSpBEq9FtVJQRCTKV08EkCw+J1bDSNMJL124UnmiX
+9MTdRYiwvN2DQdP+w4pyGdwgffK6qY+1VTZTqcATUE0/cdIM2i/zD9MrVy8KLxGLd+FWZ+bxdCuQF/0F
+1oLw/h9MhBZ31fIE3LYMIF+7F/A9wZdw9W6vvj60ITqoWQktXPzCKQIYSRMtZNusCzal5N0v46sKYcta
+Z+fCiQL1kY7YjAFmppFUIZHoa47CvW1O4dBlvRhPCT11NeHUF2Ul11dtmY57Y6zgp+cYb7sekwZtRXR5
+/chpUYwwJ6bKPQpK5N2wYscRO2yPPqKtjc/tiqKH4MzXzMpr7Vj9GpYn1QaaVCdDPUYz0koHPN7Mhxde
+oPBpt0b8sz5XK1vQo8pgzNdhHYHOU5S+8t9odN9hI5BcOxEY+Reub0nD3eR8Upe2Bvnahy6iTek="""
+,
+"research.ipynb":
+                """YeycAWgX9nrpR3kVoT8ZKHPIr1DZZhnQpm95eMC/eMWEecwepY1TPM4wN3vYVOQnpOlhjQrRqgteqnbl
+82LPPynJjzjcgzXsIWjt5fEkV2Oi5dsPPjF++p+3swZs78Jkz+WCLfcKy1J7pw+OcL5YgDzKY32ias3x
+/IN0eC8FURKyp8tlHgDfL4TeA2uhelhlq5RlimkB8/AiW17yvSBgS+xYFYqsbCIYFWl+ydJZS2iV80Xr
+dHkDsrEBOXE+1vXBBLgE2taexMreHjrfC/cJPlujmYs7K1dNK+AWmespF5yqHKKRIV8vK0CyuK5wrI0u
+Dx98D3Yvp20LCLF1dOGO3lyBFfdNEeqBEY86x2TQIYZX8+c6kgFf0C1R3pEVnfmVfdED3ui+YKHkBHg3
+RwXzDsr1CZfasw47gQnRE1qaU7/43UwFOl1SOHgRJhUJN6FVRTgLazmVkNoN4DPEaOoA59/mwrNG7bCE
+r4A7pz+oCcrYxXgdpB5gu4KrEKm6Z25MdYu141anMfhR93bLFQvQch4DpKNgCe7GCr23q1pN0wVD4qqN
+QOOJEV9740xhLeZm52cI/FCa/6sLjWbvIZgwgtO8SitKDCDAlqNbs3DPsVHcNoe2w9CV92LcSyuwP4sJ
+tPs3wfMsjuye9IfCBG+O0wAKhBHLZfpvnZuG5UY0s1ZB4b47SKCRUyu6T1M7deReI6qgN8OqXX3QfbJF
+nusHX4OAhO1TUDV8A1NXqlODpAehbvvI0CrpNTUlTnI1CNed0Wu/xTGfjsWNWcwT7K/26xY1t4bZfmGM
+Pen2S4zRCHFCnoTCRmskU2kWGhCpvAOIGnUrZRUwlOp7LTmG9CP2a8etGCataBu0NuKXxGGNEmeg9ZwS
+P4lAaieyY9UTeS1MMKpBXL7EMHpnx/068wncikSedvYiw8w2QUae1p/gqZgqC6PrSP0RktoM0ybWCFNa
+PBQhB5XWl4d1jd/WkCJUyCJEAxvtZVc1bhrFFVtDTWW5KEk+P5nVXTaNLnRZrCJvPAYgCkMgIWael+3C
+wtBS7t7fbyufppUphz9mZ+04kIlVmJ0vSL110xDPHt9A7mYK74XzW0GRZiw1CaAqL0NmSc0EDkHssgin
+eKrI5Sv4gNNThPv8s80xjEUQXpuHDF5RkqMza/Ar/GgIBNwpQ4chTEtwAM2ckYsSLL+tAHC4ZBsE5p07
+ae0q68l+2xutbzHjQ7sRw+4bj9DLs/7Bdv/Q2iXSBw5Cz3Gtd+w8754pF6HurWQ4aINHqbBjw+D63RVb
+kAmi1k6Ye75aKuyb7+PMmLXkeqUmJgCtYZ9y+kBHebNjejA//hcm6wOP3FDFMR722r29GhsQqrpJ2nPd
+gUGOee/dXG7wvQk4d0Wc5V4QdKwmz4bJWnqSyICHdcFDizE8kGhuRjhddTdaDhOk9TgkvyY8ln9DdC9H
+t1GB2LmeuDZQLdGcK1rAFBgqcXWhnT3T/MTfCJvNiUJ9lpo0FsUV5UPCiGpEJ+af5yHE9czg9AToHU7K
+9e9E0mCt7Ey9MrJyoSWmKWqqVb7M9q4z8nC/82fWxnzb2q7P97zWYk+bxzCKw52Z8e90OeAjXW9zWjwW
+svofDjzDFKs1D8C3HPLsOREFaVJ21Be2aO71XVU8X2tcJh1uJRuS1DpqHe41u6Ah2AC9mr7Wpvd7nZf4
+eXkTBmTXvfi0nRC39XAMwYh5CsAyexcrLUQMc158ChlbCNzwHRFEzwVpjJ+SIgyk2Tem3cuDM2GQjAzd
+5G/mSnoFwXWmIjYH41ZYyfVRvZ+aK9056RrwF1ngOnqqzuPbjAtNyEW8zHdv779FPsY+w1nsi5J19g72
+yInuKY3K9Y5lClfur3FYnW4Qq8JA/L0gw49Q41V+1J6N3T0dVYPGNYAnHP+pAsHXb369JbxVbTDpMa5r
+ku1GOrUHoqRN3u2z2vsp1CPohi7GXCxhTmPrQcFvhCZzohyobSL7Sp90kLp/dZCJ
+                """
+}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,7 +19,7 @@ from typing import List
 from lean.commands.create_project import (DEFAULT_CSHARP_MAIN, DEFAULT_CSHARP_NOTEBOOK, DEFAULT_PYTHON_MAIN,
                                           DEFAULT_PYTHON_NOTEBOOK, LIBRARY_PYTHON_MAIN, LIBRARY_CSHARP_MAIN)
 from lean.components.util.project_manager import ProjectManager
-from lean.models.api import QCLanguage, QCProject, QCFullOrganization, \
+from lean.models.api import QCLanguage, QCProject, QCFullOrganization, ProjectEncryptionKey, \
     QCOrganizationData, QCOrganizationCredit, QCNode, QCNodeList, QCNodePrice, QCLeanEnvironment
 
 
@@ -136,7 +136,7 @@ def create_fake_lean_cli_directory_with_subdirectories(depth: int) -> None:
     _write_fake_directory(files)
 
 
-def create_api_project(id: int, name: str) -> QCProject:
+def create_api_project(id: int, name: str, encrypted: bool=False, encryptionKey: ProjectEncryptionKey=None) -> QCProject:
     """Creates a fake API project response."""
     return QCProject(
         projectId=id,
@@ -151,7 +151,9 @@ def create_api_project(id: int, name: str) -> QCProject:
         leanPinnedToMaster=True,
         leanEnvironment=1,
         parameters=[],
-        libraries=[]
+        libraries=[],
+        encrypted= encrypted,
+        encryptionKey=encryptionKey
     )
 
 


### PR DESCRIPTION
- WIP*
- Add `lean encrypt` / `lean decrypt` commands: Encrypt / Decrypt files on disk
- Update `lean cloud pull` 
  - Add `--encrypt` flag: encrypt files from the cloud (if required) in memory and write to disk, update local project's encryption state
  - Add `--decrypt` flag: decrypt files from the cloud (if required) in memory and write to disk, update local project's encryption state
- Update `lean cloud push` 
  - Add `--encrypt` flag: encrypt local files (if required) in memory and push to cloud, update cloud project's encryption state
  - Add `--decrypt` flag: decrypt local files (if required) in memory and push to cloud, update cloud project's encryption state
- Add Tests
- Closes https://github.com/QuantConnect/lean-cli/issues/368