### PR TITLE
Improve Security Master Requirement

### DIFF
--- a/lean/constants.py
+++ b/lean/constants.py
@@ -91,9 +91,6 @@ UPDATE_CHECK_INTERVAL_DOCKER_IMAGE = 24 * 7
 # The interval in hours at which the CLI checks for new announcements
 UPDATE_CHECK_INTERVAL_ANNOUNCEMENTS = 24
 
-# The product id of the Equity Security Master subscription
-EQUITY_SECURITY_MASTER_PRODUCT_ID = 37
-
 # The product id of the Terminal Link module
 TERMINAL_LINK_PRODUCT_ID = 44
 

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from lean.constants import EQUITY_SECURITY_MASTER_PRODUCT_ID
 from lean.models.pydantic import WrappedBaseModel, validator
 
 
@@ -403,22 +402,18 @@ class QCFullOrganization(WrappedBaseModel):
     data: QCOrganizationData
     members: List[QCOrganizationMember]
 
-    def has_security_master_subscription(self) -> bool:
-        """Returns whether this organization has a Security Master subscription.
+    def has_security_master_subscription(self, id: int) -> bool:
+        """Returns whether this organization has the Security Master subscription of a given Id
 
+        :param id: the Id of the Security Master Subscription
         :return: True if the organization has a Security Master subscription, False if not
         """
-
-        # TODO: This sort of hardcoded product ID checking is not sufficient when we consider
-        # multiple 'Security Master' products. Especially since they will be specific to certain datasources.
-        # For now, simple checks for an equity "Security Master" subscription
-        # Issue created here: https://github.com/QuantConnect/lean-cli/issues/73
 
         data_products_product = next((x for x in self.products if x.name == "Data"), None)
         if data_products_product is None:
             return False
 
-        return any(x.productId in {EQUITY_SECURITY_MASTER_PRODUCT_ID} for x in data_products_product.items)
+        return any(x.productId == id for x in data_products_product.items)
 
 
 class QCMinimalOrganization(WrappedBaseModel):

--- a/lean/models/data.py
+++ b/lean/models/data.py
@@ -283,7 +283,7 @@ class Dataset(WrappedBaseModel):
     categories: List[str]
     options: List[DatasetOption]
     paths: List[DatasetPath]
-    requires_security_master: bool
+    requirements: Dict[int, str]
 
     @validator("options", pre=True)
     def parse_options(cls, values: List[Any]) -> List[Any]:

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -46,14 +46,30 @@ def test_interactive_bulk_select():
                         categories=["testData"],
                         options=datasource["options"],
                         paths=datasource["paths"],
-                        requires_security_master=datasource["requiresSecurityMaster"])]
+                        requirements=datasource.get("requirements", {}))]
 
     products = _select_products_interactive(organization, testSets)
     # No assertion, since interactive has multiple results
 
+def test_dataset_requirements():
+	organization = create_api_organization()
+	datasource = json.loads(bulk_datasource)
+	testSet = Dataset(name="testSet",
+                      vendor="testVendor",
+                      categories=["testData"],
+                      options=datasource["options"],
+                      paths=datasource["paths"],
+                      requirements=datasource.get("requirements", {}))
+    
+	for id, name in testSet.requirements.items():
+		assert not organization.has_security_master_subscription(id)
+	assert id==39
+
 bulk_datasource="""
 {
-	"requiresSecurityMaster": true,
+	"requirements": {
+        "39": "quantconnect-us-equity-security-master"
+    },
 	"options": [
 		{
 			"type": "select",
@@ -262,12 +278,12 @@ def test_filter_pending_datasets() -> None:
         str(test_datasets[0].id): {
             'options': [],
             'paths': [],
-            'requiresSecurityMaster': True,
+            'requirements': {},
         },
         str(test_datasets[1].id): {
             'options': [],
             'paths': [],
-            'requiresSecurityMaster': True,
+            'requirements': {},
         }
     }
     container.api_client.data.get_info = MagicMock(return_value=QCDataInformation(datasources=datasources, prices=[],


### PR DESCRIPTION
LEAN CLI will verify whether the Organization has a Security Master requirement set in the Dataset page. For example, US Futures requires US Futures Security Master. If the Org. doesn't have it, LEAN CLI directs the user to the US Futures Security Master pricing page.

Tested locally with Orgs. with and without Futures Security Master, and setting and not setting the requirements

```json
    "requirements": {
        "137": "quantconnect-us-futures-security-master"
    },
```
Closes #73 