### PR TITLE
Add Encryption Checks To `Library Add` Command

### DIFF
--- a/lean/commands/library/add.py
+++ b/lean/commands/library/add.py
@@ -303,6 +303,19 @@ def add(project: Path, name: str, version: Optional[str], no_local: bool) -> Non
     library_dir = Path(name).expanduser().resolve()
 
     if library_manager.is_lean_library(library_dir):
+        # check encryption conditions
+        if project_config.get('encrypted', False) and project_config.get('encryption-key-path', None):
+            library_project_config = container.project_config_manager.get_project_config(library_dir)
+            is_library_encrypted = library_project_config.get('encrypted', False)
+            library_encryption_key_path = library_project_config.get('encryption-key-path', None)
+            if library_encryption_key_path:
+                library_encryption_key_path = Path(library_encryption_key_path)
+            project_encryption_key_path = project_config.get('encryption-key-path', None)
+            if project_encryption_key_path:
+                project_encryption_key_path = Path(project_encryption_key_path)
+            if is_library_encrypted and library_encryption_key_path != project_encryption_key_path:
+                raise RuntimeError(f"Library is encrypted with a different key {library_encryption_key_path}. "
+                                   f"Please use the same key as project {project_encryption_key_path}.")
         logger.info(f"Adding Lean CLI library {library_dir} to project {project}")
         if project_language == "CSharp":
             library_manager.add_lean_library_to_csharp_project(project, library_dir, no_local)

--- a/lean/commands/library/add.py
+++ b/lean/commands/library/add.py
@@ -304,16 +304,14 @@ def add(project: Path, name: str, version: Optional[str], no_local: bool) -> Non
 
     if library_manager.is_lean_library(library_dir):
         # check encryption conditions
-        if project_config.get('encrypted', False) and project_config.get('encryption-key-path', None):
+        is_project_encrypted = project_config.get('encrypted', False)
+        project_encryption_key_path = project_config.get('encryption-key-path', None)
+        if is_project_encrypted and project_encryption_key_path:
+            from lean.components.util.encryption_helper import are_encryption_keys_equal
             library_project_config = container.project_config_manager.get_project_config(library_dir)
             is_library_encrypted = library_project_config.get('encrypted', False)
             library_encryption_key_path = library_project_config.get('encryption-key-path', None)
-            if library_encryption_key_path:
-                library_encryption_key_path = Path(library_encryption_key_path)
-            project_encryption_key_path = project_config.get('encryption-key-path', None)
-            if project_encryption_key_path:
-                project_encryption_key_path = Path(project_encryption_key_path)
-            if is_library_encrypted and library_encryption_key_path != project_encryption_key_path:
+            if is_library_encrypted and are_encryption_keys_equal(library_encryption_key_path, project_encryption_key_path) == False:
                 raise RuntimeError(f"Library is encrypted with a different key {library_encryption_key_path}. "
                                    f"Please use the same key as project {project_encryption_key_path}.")
         logger.info(f"Adding Lean CLI library {library_dir} to project {project}")

--- a/lean/components/util/encryption_helper.py
+++ b/lean/components/util/encryption_helper.py
@@ -73,6 +73,19 @@ def get_project_iv(project_key_path: Path):
     key_id = get_project_key_hash(project_key_path)
     return key_id[:16]
 
+def are_encryption_keys_equal(key1: Path, key2: Path) -> bool:
+    """Check if two encryption keys are equal
+
+    :param key1: The first key to compare
+    :param key2: The second key to compare
+    :return: True if the keys are equal, False otherwise
+    """
+    if key1 is None and key2 is None:
+        return True
+    if key1 is None or key2 is None:
+        return False
+    return get_project_key_hash(key1) == get_project_key_hash(key2)
+
 def get_decrypted_file_content_for_local_project(project: Path, source_files: List[Path], encryption_key: Path, project_config_manager: ProjectConfigManager, organization_id: str) -> List[str]:
     project_config = project_config_manager.get_project_config(project)
 


### PR DESCRIPTION
- Fail if the library is encrypted with a different key as project

![image](https://github.com/QuantConnect/lean-cli/assets/28739120/20156121-b5e0-446a-b02d-debf2c4569fc)

- Allow if the library is encrypted with the same key as project

![image](https://github.com/QuantConnect/lean-cli/assets/28739120/6324b348-3fd1-4b82-8fc1-805da5889f94)

- Allow if project not encrypted

- Closes https://github.com/QuantConnect/lean-cli/issues/380