### PR TITLE
Bug Fix Handle NoneType Error For `Cloud Push` Command

### DIFF
--- a/lean/commands/cloud/push.py
+++ b/lean/commands/cloud/push.py
@@ -68,4 +68,4 @@ def push(project: Optional[Path], encrypt: Optional[bool], decrypt: Optional[boo
         if key is not None:
             raise RuntimeError(f"Encryption key can only be specified when pushing a single project.")
         projects_to_push = [p.parent for p in Path.cwd().rglob(PROJECT_CONFIG_FILE_NAME)]
-        push_manager.push_projects(projects_to_push, encryption_action, key)
+        push_manager.push_projects(projects_to_push, [], encryption_action, key)


### PR DESCRIPTION
Fixes missing argument to call. 
Related To: https://github.com/QuantConnect/lean-cli/pull/385

User Report

```
Python version: 3.11.4 (main, Jul 5 2023, 14:15:25) [GCC 11.2.0]
OS: Linux-6.2.0-37-generic-x86_64-with-glibc2.35
Lean CLI version: 1.0.175
Traceback (most recent call last):
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/lean/main.py", line 94, in main
lean.main(standalone_mode=False)
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/click/core.py", line 1053, in main
rv = self.invoke(ctx)
^^^^^^^^^^^^^^^^
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/click/core.py", line 1659, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/click/core.py", line 1659, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/lean/click.py", line 159, in invoke
result = super().invoke(ctx)
^^^^^^^^^^^^^^^^^^^
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/click/core.py", line 1395, in invoke
return ctx.invoke(self.callback, **ctx.params)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/click/core.py", line 754, in invoke
return __callback(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/lean/commands/cloud/push.py", line 71, in push
push_manager.push_projects(projects_to_push, encryption_action, key)
File "/home/hindermj/anaconda3/lib/python3.11/site-packages/lean/components/cloud/push_manager.py", line 66, in push_projects
all_projects_to_push = associated_libraries_to_push + projects_to_push
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'
```