### PR TITLE
Optional Downloader Data Provider

### DIFF
--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -395,7 +395,7 @@ def deploy(project: Path,
         [update_essential_properties_available(data_feed_configurers, kwargs)]
 
     elif brokerage is not None or len(data_provider_live) > 0:
-        ensure_options(["brokerage", "data_feed"])
+        ensure_options(["brokerage", "data_provider_live"])
 
         environment_name = "lean-cli"
         lean_config = lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -409,7 +409,7 @@ def deploy(project: Path,
         [update_essential_properties_available(data_feed_configurers, kwargs)]
 
     elif brokerage is not None or len(data_provider_live) > 0:
-        ensure_options(["brokerage", "data_provider_live"])
+        ensure_options(["brokerage", "data_feed"])
 
         environment_name = "lean-cli"
         lean_config = lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -409,7 +409,7 @@ def deploy(project: Path,
         [update_essential_properties_available(data_feed_configurers, kwargs)]
 
     elif brokerage is not None or len(data_provider_live) > 0:
-        ensure_options(["brokerage", "data_feed"])
+        ensure_options(["brokerage", "data_provider_live"])
 
         environment_name = "lean-cli"
         lean_config = lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -192,14 +192,14 @@ def _configure_lean_config_interactively(lean_config: Dict[str, Any],
 
 _cached_lean_config = None
 
-def _try_get_data_downloader_name(data_provider_historical_name: str, data_provider_live_name: str) -> str:
-    """ Get name for data downloader provider based on data provider live (if exist)
+def _try_get_data_historical_name(data_provider_historical_name: str, data_provider_live_name: str) -> str:
+    """ Get name for historical data provider based on data provider live (if exist)
 
     :param data_provider_historical_name: the current (default) data provider historical
     :param data_provider_live_name: the current data provider live name
     """
-    return next((live_data_downloader.get_name() for live_data_downloader in all_data_providers
-                                             if live_data_downloader.get_name() in data_provider_live_name), data_provider_historical_name)
+    return next((live_data_historical.get_name() for live_data_historical in all_data_providers
+                                             if live_data_historical.get_name() in data_provider_live_name), data_provider_historical_name)
 
 
 # being used by lean.models.click_options.get_the_correct_type_default_value()
@@ -417,7 +417,7 @@ def deploy(project: Path,
         _configure_lean_config_interactively(lean_config, environment_name, kwargs, show_secrets=show_secrets)
 
     if data_provider_historical is None:
-        data_provider_historical = _try_get_data_downloader_name("Local", data_provider_live)
+        data_provider_historical = _try_get_data_historical_name("Local", data_provider_live)
     [data_provider_configurer] = [get_and_build_module(data_provider_historical, all_data_providers, kwargs, logger)]
     data_provider_configurer.configure(lean_config, environment_name)
 

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -28,7 +28,7 @@ from lean.models.json_module import LiveInitialStateInput
 from lean.commands.live.live import live
 from lean.components.util.live_utils import get_last_portfolio_cash_holdings, configure_initial_cash_balance, configure_initial_holdings,\
                                             _configure_initial_cash_interactively, _configure_initial_holdings_interactively
-from lean.models.data_providers import all_data_providers
+from lean.models.data_providers import all_data_providers, installed_data_providers
 from lean.components.util.json_modules_handler import build_and_configure_modules, get_and_build_module, update_essential_properties_available
 
 _environment_skeleton = {
@@ -66,7 +66,7 @@ def _get_configurable_modules_from_environment(lean_config: Dict[str, Any], envi
     data_downloader_preference = None
     if "data-downloader" in lean_config:
         data_downloader_base_name = _get_brokerage_base_name(lean_config["data-downloader"])
-        data_downloader_preference = next((local_data_history for local_data_history in all_data_providers
+        data_downloader_preference = next((local_data_history for local_data_history in installed_data_providers
                                            if _get_brokerage_base_name(local_data_history.get_config_value_from_name('data-downloader')) in data_downloader_base_name), None)
 
     return brokerage_configurer, data_feed_configurers, data_downloader_preference

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -258,7 +258,6 @@ def _get_default_value(key: str) -> Optional[Any]:
               help="The live data provider to use")
 @option("--data-provider-historical",
               type=Choice([dp.get_name() for dp in all_data_providers if dp._id != "TerminalLinkBrokerage"], case_sensitive=False),
-              default="Local",
               help="Update the Lean configuration file to retrieve data from the given historical provider")
 @options_from_json(get_configs_for_options("live-local"))
 @option("--release",
@@ -431,12 +430,10 @@ def deploy(project: Path,
         lean_config = lean_config_manager.get_complete_lean_config(environment_name, algorithm_file, None)
         _configure_lean_config_interactively(lean_config, environment_name, kwargs, show_secrets=show_secrets)
 
-    if data_provider_historical is not None:
-        # if default historical provider try to find 
-        if data_provider_historical == "Local":
-            data_provider_historical = _try_get_data_downloader_name(data_provider_historical, data_provider_live)
-        [data_provider_configurer] = [get_and_build_module(data_provider_historical, all_data_providers, kwargs, logger)]
-        data_provider_configurer.configure(lean_config, environment_name)
+    if data_provider_historical is None:
+        data_provider_historical = _try_get_data_downloader_name("Local", data_provider_live)
+    [data_provider_configurer] = [get_and_build_module(data_provider_historical, all_data_providers, kwargs, logger)]
+    data_provider_configurer.configure(lean_config, environment_name)
 
     if "environments" not in lean_config or environment_name not in lean_config["environments"]:
         lean_config_path = lean_config_manager.get_lean_config_path()

--- a/lean/models/data_providers/__init__.py
+++ b/lean/models/data_providers/__init__.py
@@ -16,10 +16,15 @@ from lean.models.data_providers.data_provider import DataProvider
 from lean.models import json_modules
 
 all_data_providers: List[DataProvider] = []
+installed_data_providers: List[DataProvider] = []
 
 for json_module in json_modules:
     if "data-provider" in json_module["type"]:
         all_data_providers.append(DataProvider(json_module))
+
+for data_provider in all_data_providers:
+    if data_provider._installs:
+        installed_data_providers.append(data_provider)
 
 # QuantConnect DataProvider
 [QuantConnectDataProvider] = [

--- a/lean/models/data_providers/__init__.py
+++ b/lean/models/data_providers/__init__.py
@@ -16,15 +16,10 @@ from lean.models.data_providers.data_provider import DataProvider
 from lean.models import json_modules
 
 all_data_providers: List[DataProvider] = []
-installed_data_providers: List[DataProvider] = []
 
 for json_module in json_modules:
     if "data-provider" in json_module["type"]:
         all_data_providers.append(DataProvider(json_module))
-
-for data_provider in all_data_providers:
-    if data_provider._installs:
-        installed_data_providers.append(data_provider)
 
 # QuantConnect DataProvider
 [QuantConnectDataProvider] = [

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -415,6 +415,9 @@ data_feed_required_options = {
     "Kraken": brokerage_required_options["Kraken"],
     "TDAmeritrade": brokerage_required_options["TDAmeritrade"],
     "Bybit": brokerage_required_options["Bybit"],
+}
+
+data_provider_required_options = {
     "IEX": {
         "iex-cloud-api-key": "123",
         "iex-price-plan": "Launch",
@@ -1157,6 +1160,8 @@ def create_lean_option(brokerage_name: str, data_provider_live_name: str, data_p
     option = ["--brokerage", brokerage_name]
     for key, value in brokerage_required_options[brokerage_name].items():
         option.extend([f"--{key}", value])
+
+    data_feed_required_options.update(data_provider_required_options)
 
     option.extend(["--data-provider-live", data_provider_live_name])
     for key, value in data_feed_required_options[data_provider_live_name].items():

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -25,8 +25,9 @@ from lean.commands import lean
 from lean.constants import DEFAULT_ENGINE_IMAGE
 from lean.container import container
 from lean.models.docker import DockerImage
-from tests.test_helpers import create_fake_lean_cli_directory
+from tests.test_helpers import create_fake_lean_cli_directory, reset_state_installed_modules
 from tests.conftest import initialize_container
+from click.testing import Result
 
 ENGINE_IMAGE = DockerImage.parse(DEFAULT_ENGINE_IMAGE)
 
@@ -413,7 +414,18 @@ data_feed_required_options = {
     "Terminal Link": terminal_link_required_options,
     "Kraken": brokerage_required_options["Kraken"],
     "TDAmeritrade": brokerage_required_options["TDAmeritrade"],
-    "Bybit": brokerage_required_options["Bybit"]
+    "Bybit": brokerage_required_options["Bybit"],
+    "IEX": {
+        "iex-cloud-api-key": "123",
+        "iex-price-plan": "Launch",
+    },
+    "Polygon": {
+        "polygon-api-key": "123",
+    },
+    "AlphaVantage": {
+        "alpha-vantage-api-key": "111",
+        "alpha-vantage-price-plan": "Free"
+    }
 }
 
 
@@ -1108,28 +1120,6 @@ def test_live_non_interactive_deploy_with_live_and_historical_provider_missed_li
 
     assert result.exit_code == 1
 
-def test_live_non_interactive_deploy_with_live_and_without_historical_provider() -> None:
-    create_fake_lean_cli_directory()
-    create_fake_environment("live-paper", True)
-    
-    api_client = mock.MagicMock()
-    container.initialize(docker_manager=mock.Mock(), lean_runner=mock.Mock(), api_client=api_client)
-
-    provider_live_option = ["--data-provider-live", "IEX",
-                            "--iex-cloud-api-key", "123",
-                            "--iex-price-plan", "Launch"]
-
-    result = CliRunner().invoke(lean, ["live", "deploy" , "--brokerage", "Paper Trading",
-                                       *provider_live_option,
-                                       "Python Project",
-                                       ])
-    
-    # validate amount of request to download packages from api 
-    assert len(api_client.method_calls) == 2
-
-    assert "333" in api_client.method_calls[0].args[0]
-    assert result.exit_code == 0
-
 def test_live_non_interactive_deploy_with_real_brokerage_without_credentials() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -1148,38 +1138,93 @@ def test_live_non_interactive_deploy_with_real_brokerage_without_credentials() -
                                        *provider_live_option,
                                        "Python Project",
                                        ])
+    assert result.exit_code == 1
 
     error_msg = str(result.exc_info[1]).split()
 
     assert "--oanda-account-id" in error_msg
     assert "--oanda-access-token" in error_msg
     assert "--oanda-environment" in error_msg
-    assert "--iex-price-plan" not in error_msg
+    assert "--iex-price-plan" not in error_msg    
 
-    assert result.exit_code == 1
-
-def test_live_non_interactive_deploy_with_interactive_brokerage() -> None:
+def create_lean_option(brokerage_name: str, data_provider_live_name: str, data_provider_historical_name: str, api_client: any) -> Result:
+    reset_state_installed_modules()
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
 
-    api_client = mock.MagicMock()
-    container.initialize(docker_manager=mock.Mock(), lean_runner=mock.Mock(), api_client=api_client)
+    initialize_container(api_client_to_use=api_client)
 
-    # create fake environment has IB configs already
-    brokerage = ["--brokerage", "Interactive Brokers"]
+    option = ["--brokerage", brokerage_name]
+    for key, value in brokerage_required_options[brokerage_name].items():
+        option.extend([f"--{key}", value])
 
-    provider_live_option = ["--data-provider-live", "Interactive Brokers",
-                            "--iex-cloud-api-key", "123",
-                            "--iex-price-plan", "Launch"]
+    option.extend(["--data-provider-live", data_provider_live_name])
+    for key, value in data_feed_required_options[data_provider_live_name].items():
+        if f"--{key}" not in option:
+            option.extend([f"--{key}", value])
 
-    result = CliRunner().invoke(lean, ["live", "deploy" ,
-                                       *brokerage,
-                                       *provider_live_option,
+    if data_provider_historical_name is not None:
+        option.extend(["--data-provider-historical", data_provider_historical_name])
+        for key, value in data_feed_required_options[data_provider_historical_name].items():
+            if f"--{key}" not in option:
+                option.extend([f"--{key}", value])
+
+    result = CliRunner().invoke(lean, ["live", "deploy",
+                                       *option,
                                        "Python Project",
                                        ])
     assert result.exit_code == 0
-    
-    # validate amount of request to download packages from api 
-    assert len(api_client.method_calls) == 1
+    return result
 
-    assert "181" in api_client.method_calls[0].args[0]
+@pytest.mark.parametrize("brokerage_name,data_provider_live_name,data_provider_historical_name,brokerage_product_id,data_provider_live_product_id,data_provider_historical_id",
+                         [("Interactive Brokers", "IEX", "Polygon", "181", "333", "306"),
+                          ("Paper Trading", "IEX", "Polygon", None, "333", "306"),
+                          ("Tradier", "IEX", "AlphaVantage", "185", "333", "334")])
+def test_live_deploy_with_different_brokerage_and_different_live_data_provider_and_historical_data_provider(brokerage_name: str, data_provider_live_name: str, data_provider_historical_name: str, brokerage_product_id: str, data_provider_live_product_id: str, data_provider_historical_id: str) -> None:
+    api_client = mock.MagicMock()
+    create_lean_option(brokerage_name, data_provider_live_name, data_provider_historical_name, api_client)
+    
+    if brokerage_product_id is None:
+        assert len(api_client.method_calls) == 3
+        assert data_provider_live_product_id in api_client.method_calls[0].args[0]
+        assert data_provider_historical_id in api_client.method_calls[1].args[0]
+    else:
+        assert len(api_client.method_calls) == 3
+        assert brokerage_product_id in api_client.method_calls[0].args[0]
+        assert data_provider_live_product_id in api_client.method_calls[1].args[0]
+        assert data_provider_historical_id in f"{api_client.method_calls[2].args[0]}"
+
+@pytest.mark.parametrize("brokerage_name,data_provider_live_name,brokerage_product_id,data_provider_live_product_id",
+                         [("Interactive Brokers", "IEX", "181", "333"),
+                          ("Tradier", "IEX", "185", "333")])
+def test_live_non_interactive_deploy_with_different_brokerage_and_different_live_data_provider(brokerage_name: str, data_provider_live_name: str, brokerage_product_id: str, data_provider_live_product_id: str) -> None:
+    api_client = mock.MagicMock()
+    create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
+    
+    assert len(api_client.method_calls) == 2
+    assert brokerage_product_id in api_client.method_calls[0].args[0]
+    assert data_provider_live_product_id in api_client.method_calls[1].args[0]
+
+@pytest.mark.parametrize("brokerage_name,data_provider_live_name,brokerage_product_id",
+                         [("Bybit", "Bybit", "305"),
+                          ("Interactive Brokers", "Interactive Brokers", "181"),
+                          ("Tradier", "Tradier", "185")])
+def test_live_non_interactive_deploy_with_different_brokerage_with_the_same_live_data_provider(brokerage_name: str, data_provider_live_name: str, brokerage_product_id: str) -> None:
+    api_client = mock.MagicMock()
+    create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
+    
+    if brokerage_name == "Interactive Brokers":
+        assert len(api_client.method_calls) == 1
+    else:
+        assert len(api_client.method_calls) == 2
+    assert brokerage_product_id in api_client.method_calls[0].args[0]
+
+@pytest.mark.parametrize("brokerage_name,data_provider_live_name,data_provider_live_product_id",
+                         [("Paper Trading", "IEX", "333"),
+                          ("Paper Trading", "Polygon", "306")])
+def test_live_non_interactive_deploy_paper_brokerage_different_live_data_provider(brokerage_name: str, data_provider_live_name: str, data_provider_live_product_id: str) -> None:
+    api_client = mock.MagicMock()
+    create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
+
+    assert len(api_client.method_calls) == 2
+    assert data_provider_live_product_id in f"{api_client.method_calls[0].args[0]}"

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -1218,10 +1218,6 @@ def test_live_non_interactive_deploy_with_different_brokerage_with_the_same_live
     api_client = mock.MagicMock()
     create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
     
-    if brokerage_name == "Interactive Brokers":
-        assert len(api_client.method_calls) == 1
-    else:
-        assert len(api_client.method_calls) == 2
     assert brokerage_product_id in api_client.method_calls[0].args[0]
 
 @pytest.mark.parametrize("brokerage_name,data_provider_live_name,data_provider_live_product_id",

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -1200,6 +1200,7 @@ def test_live_non_interactive_deploy_with_different_brokerage_and_different_live
 
 @pytest.mark.parametrize("brokerage_name,data_provider_live_name,brokerage_product_id",
                          [("Bybit", "Bybit", "305"),
+                          ("Coinbase Advanced Trade", "Coinbase Advanced Trade", "183"),
                           ("Interactive Brokers", "Interactive Brokers", "181"),
                           ("Tradier", "Tradier", "185")])
 def test_live_non_interactive_deploy_with_different_brokerage_with_the_same_live_data_provider(brokerage_name: str, data_provider_live_name: str, brokerage_product_id: str) -> None:

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -1170,9 +1170,10 @@ def create_lean_option(brokerage_name: str, data_provider_live_name: str, data_p
 
     if data_provider_historical_name is not None:
         option.extend(["--data-provider-historical", data_provider_historical_name])
-        for key, value in data_feed_required_options[data_provider_historical_name].items():
-            if f"--{key}" not in option:
-                option.extend([f"--{key}", value])
+        if data_provider_historical_name is not "Local": 
+            for key, value in data_feed_required_options[data_provider_historical_name].items():
+                if f"--{key}" not in option:
+                    option.extend([f"--{key}", value])
 
     result = CliRunner().invoke(lean, ["live", "deploy",
                                        *option,
@@ -1184,15 +1185,19 @@ def create_lean_option(brokerage_name: str, data_provider_live_name: str, data_p
 @pytest.mark.parametrize("brokerage_name,data_provider_live_name,data_provider_historical_name,brokerage_product_id,data_provider_live_product_id,data_provider_historical_id",
                          [("Interactive Brokers", "IEX", "Polygon", "181", "333", "306"),
                           ("Paper Trading", "IEX", "Polygon", None, "333", "306"),
-                          ("Tradier", "IEX", "AlphaVantage", "185", "333", "334")])
+                          ("Tradier", "IEX", "AlphaVantage", "185", "333", "334"),
+                          ("Paper Trading", "IEX", "Local", None, "333", "222")])
 def test_live_deploy_with_different_brokerage_and_different_live_data_provider_and_historical_data_provider(brokerage_name: str, data_provider_live_name: str, data_provider_historical_name: str, brokerage_product_id: str, data_provider_live_product_id: str, data_provider_historical_id: str) -> None:
     api_client = mock.MagicMock()
     create_lean_option(brokerage_name, data_provider_live_name, data_provider_historical_name, api_client)
     
-    if brokerage_product_id is None:
+    if brokerage_product_id is None and data_provider_historical_name != "Local":
         assert len(api_client.method_calls) == 3
         assert data_provider_live_product_id in api_client.method_calls[0].args[0]
         assert data_provider_historical_id in api_client.method_calls[1].args[0]
+    elif brokerage_product_id is None and data_provider_historical_name == "Local":
+        assert len(api_client.method_calls) == 2
+        assert data_provider_live_product_id in api_client.method_calls[0].args[0]
     else:
         assert len(api_client.method_calls) == 3
         assert brokerage_product_id in api_client.method_calls[0].args[0]

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -545,7 +545,7 @@ def test_live_non_interactive_raise_error_when_missing_data_provider_live_option
 
     error_msg = str(result.exc_info[1]).split()
     
-    assert "data-provider-live" in error_msg
+    assert "--data-provider-live" in error_msg
     assert "data-queue-handler" not in error_msg 
 
     assert result.exit_code != 0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,6 +15,8 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import List
+from lean.models.data_providers import all_data_providers
+from lean.models.brokerages.local import all_local_brokerages, all_local_data_feeds
 
 from lean.commands.create_project import (DEFAULT_CSHARP_MAIN, DEFAULT_CSHARP_NOTEBOOK, DEFAULT_PYTHON_MAIN,
                                           DEFAULT_PYTHON_NOTEBOOK, LIBRARY_PYTHON_MAIN, LIBRARY_CSHARP_MAIN)
@@ -224,3 +226,11 @@ def create_lean_environments() -> List[QCLeanEnvironment]:
                           description="",
                           public=True)
     ]
+
+def reset_state_installed_modules() -> None:
+    for data_provider in all_data_providers:
+        data_provider.__setattr__("_is_module_installed", False)
+    for local_brokerage in all_local_brokerages:
+        local_brokerage.__setattr__("_is_module_installed", False)
+    for local_data_feed in all_local_data_feeds:
+        local_data_feed.__setattr__("_is_module_installed", False)


### PR DESCRIPTION
### Description
We stumbled upon impossible to subscribe on data provider _live_ and _historical_ in the same time. 
> The code is subscribed on `data-provider-live` well.

### Result 
Nowadays, we can use 2 command in the same time without exception. The fix is downloaded packages and create dependency references. Additionaly we have opportunity to combine our `live` and `historical` providers in different way, look at example bellow ⬇ we use `live` provider [iexcloud.io](https://iexcloud.io/) and `historical` [polygon.io](https://polygon.io/)
<pre>
 lean live deploy --brokerage "Paper Trading" --data-provider-<b>live IEX</b> --data-provider-<b>historical Polygon</b> ProjectAlgorithmName
</pre>
 - `--data-provider-live IEX` - [iexcloud.io](https://iexcloud.io/) data provider 
 - ` --data-provider-historical Polygon` - [polygon.io](https://polygon.io/) data provider
 
### If `--data-provider-live` doesn't have historical oportunity
For istance: 
<pre>
 lean live deploy --brokerage Bybit --data-provider-live Bybit ProjectAlgorithmName
</pre>
The Bybit doesn't have historical option like provider that's mean it will use `Local` provider by default:
<details>
<summary>Like this</summary>

<pre>
 lean live deploy --brokerage Bybit --data-provider-live Bybit --data-provider-historical Local ProjectAlgorithmName 
</pre>

</details>

### Feature (user friendly) 
If user subscribe on `--data-provider-live` **without** `--data-provider-historical` then the code is using the smae `data-provider-historical` like `live` **if it is exsist**.
#### For instance: 
<pre>
 lean live deploy --brokerage "Paper Trading" --data-provider-<b>live IEX</b> ProjectAlgorithmName
</pre>
> The `--data-provider-historical IEX` uses this part implicitly for users.
<pre>
 lean live deploy --brokerage "Paper Trading" --data-provider-<b>live IEX</b> --data-provider-<b>historical IEX</b> ProjectAlgorithmName
</pre>

### Testing
#### Test Algorithm:
```
public class IEXAlgo : QCAlgorithm
{
    public override void Initialize()
    {
        SetStartDate(2024, 1, 1); // Set Start Date
        SetEndDate(2024, 2, 1); // Set Start Date
        SetCash(100_000);             //Set Strategy Cash
        var plug = AddEquity("AAPL", Resolution.Daily, extendedMarketHours: false);
        Log("---------- BEFORE HISTORY ----------");
        var histories = History(plug.Symbol, 10, Resolution.Daily);
        foreach(var history in histories)
        {
            Log($"Time: {history.Time}, Data History: {history}");
        }
        Log("---------- AFTER HISTORY ----------");
    }
    
     public override void OnData(Slice slice)
    {
        if (slice == null) return;

        Log($"Time: {slice.Time}");
        Log($"data.Bars: {string.Join(",", slice.Bars)}");
        Log($"data.QuoteBars: {string.Join(",", slice.QuoteBars)}");
    }
}
```
#### First command:
- `lean live deploy --brokerage "Paper Trading" --data-provider-live IEX --data-provider-historical Polygon Project`
#### First Result img:
![111](https://github.com/QuantConnect/lean-cli/assets/45608740/d1a7c1e2-1b8a-474d-b708-5617bc704aae)
---
#### Second command:
- `lean live deploy --brokerage "Paper Trading" --data-provider-live IEX Project`
#### Second Result img:
![111](https://github.com/QuantConnect/lean-cli/assets/45608740/8e321c3b-4624-44bb-b108-a45cbef06d9a)
---
#### Third command:
- `lean live deploy --brokerage "Paper Trading" --data-provider-live IEX --data-provider-historical Local IEXAlgo`
#### Third Result img:
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/c5043920-ce4e-4b35-bf48-84c8493edc60)
---
#### Fourth command:
- `lean live deploy --brokerage "Coinbase Advanced Trade" --data-provider-live "Coinbase Advanced Trade" CoinApiAlgo`
#### Fourth img:
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/897612fd-5fef-4960-9822-de8f3df3e232)
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/1959939e-38ea-481e-9cbe-8303a9db534c)
---
#### Fifth command:
If don't have key in our `config.json`
- `lean live deploy --brokerage "Paper Trading" --data-provider-live IEX --data-provider-historical Polygon IEXAlgo`
#### Fifth img:
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/4a12419a-228f-4966-b77f-b5bb3b3ebbc0)

