### PR TITLE
Minor Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1480,6 +1480,8 @@ Options:
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
+  --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the backtest when using
+                                  QuantConnect as historical data provider
   --release                       Compile C# projects in release configuration instead of debug
   --image TEXT                    The LEAN engine image to use (defaults to quantconnect/lean:latest)
   --update                        Pull the LEAN engine image before running the optimizer

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -105,6 +105,9 @@ def _get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
               is_flag=True,
               default=False,
               help="Update the Lean configuration file to download data from the QuantConnect API, alias for --data-provider-historical QuantConnect")
+@option("--data-purchase-limit",
+              type=int,
+              help="The maximum amount of QCC to spend on downloading data during the backtest when using QuantConnect as historical data provider")
 @option("--release",
               is_flag=True,
               default=False,
@@ -152,6 +155,7 @@ def optimize(project: Path,
              constraint: List[str],
              data_provider_historical: Optional[str],
              download_data: bool,
+             data_purchase_limit: Optional[int],
              release: bool,
              image: Optional[str],
              update: bool,
@@ -306,6 +310,8 @@ def optimize(project: Path,
                                                               cli_data_downloaders, kwargs, logger, environment_name)
         data_provider.ensure_module_installed(organization_id)
         container.lean_config_manager.set_properties(data_provider.get_settings())
+
+    lean_config_manager.configure_data_purchase_limit(lean_config, data_purchase_limit)
 
     if not output.exists():
         output.mkdir(parents=True)

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -318,8 +318,7 @@ brokerage_required_options = {
         "ib-user-name": "trader777",
         "ib-account": "DU1234567",
         "ib-password": "hunter2",
-        "ib-enable-delayed-streaming-data": "no",
-        "ib-weekly-restart-utc-time": "22:00:00",
+        "ib-enable-delayed-streaming-data": "no"
     },
     "Tradier": {
         "tradier-account-id": "123",


### PR DESCRIPTION
- Minor adjustment so that optional configurations are requested to the user if they have no value in interactive mode, in non interactive will use the default value if any
- Log configuration messages once
- Add data purchase limit for optimization. Closes https://github.com/QuantConnect/lean-cli/issues/425

Related https://github.com/QuantConnect/lean-cli/pull/428

Sanity tested running live deployments and optimizations