### PR TITLE
Cloud API Normalization

### DIFF
--- a/lean/components/api/file_client.py
+++ b/lean/components/api/file_client.py
@@ -53,13 +53,12 @@ class FileClient:
 
         return [QCFullFile(**file) for file in data["files"]]
 
-    def create(self, project_id: int, file_name: str, content: str) -> QCMinimalFile:
+    def create(self, project_id: int, file_name: str, content: str) -> None:
         """Creates a new file.
 
         :param project_id: the id of the project to create a file for
         :param file_name: the name of the file to create
         :param content: the content of the file to create
-        :return: the created file
         """
         data = self._api.post("files/create", {
             "projectId": project_id,
@@ -67,9 +66,7 @@ class FileClient:
             "content": content
         })
 
-        return QCMinimalFile(**data["files"][0])
-
-    def update(self, project_id: int, file_name: str, content: str) -> QCMinimalFile:
+    def update(self, project_id: int, file_name: str, content: str) -> None:
         """Updates an existing file.
 
         :param project_id: the id of the project to update a file in
@@ -81,8 +78,6 @@ class FileClient:
             "name": file_name,
             "content": content
         })
-
-        return QCMinimalFile(**data["files"][0])
 
     def delete(self, project_id: int, file_name: str) -> None:
         """Deletes an existing file.

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -27,11 +27,10 @@ class ProjectEncryptionKey(WrappedBaseModel):
     name: str
 
 class QCCollaborator(WrappedBaseModel):
-    id: int
     uid: int
-    blivecontrol: bool
-    epermission: str
-    profileimage: str
+    liveControl: bool
+    permission: str
+    profileImage: str
     name: str
     owner: bool = False
 

--- a/tests/components/api/test_clients.py
+++ b/tests/components/api/test_clients.py
@@ -148,10 +148,7 @@ def test_files_crud() -> None:
 
     with create_project(api_client, "Test Project") as project:
         # Test a file can be created
-        created_file = file_client.create(project.projectId, "file.py", "# This is a comment")
-
-        assert created_file.name == "file.py"
-        assert created_file.content == "# This is a comment"
+        file_client.create(project.projectId, "file.py", "# This is a comment")
 
         # Test the file can be retrieved
         retrieved_file = file_client.get(project.projectId, "file.py")


### PR DESCRIPTION
- Remove old API response naming format
- File Create/Update/Delete will only return success with no payload

Related https://github.com/QuantConnect/Lean/pull/7877

Tested pushing and pulling cloud project updates