### PR TITLE
Add new `data download` command to lean-cli for data retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,12 +781,26 @@ _See code: [lean/commands/create_project.py](lean/commands/create_project.py)_
 
 ### `lean data download`
 
-Purchase and download data from QuantConnect Datasets.
+Purchase and download data directly from QuantConnect or download from Support Data Providers
 
 ```
 Usage: lean data download [OPTIONS]
 
-  Purchase and download data from QuantConnect Datasets.
+  Purchase and download data directly from QuantConnect or download from Support Data Providers
+
+  1. Acquire Data from QuantConnect Datasets: Purchase and seamlessly download data directly from QuantConnect.
+
+  2. Streamlined Access from Support Data Providers:
+
+      - Choose your preferred historical data provider.
+
+      - Initiate hassle-free downloads from our supported providers.
+
+  We have 2 options:
+
+      - interactive (follow instruction in lean-cli)
+
+      - no interactive (write arguments in command line)
 
   An interactive wizard will show to walk you through the process of selecting data, accepting the CLI API Access and
   Data Agreement and payment. After this wizard the selected data will be downloaded automatically.
@@ -799,12 +813,90 @@ Usage: lean data download [OPTIONS]
   https://www.quantconnect.com/datasets
 
 Options:
-  --dataset TEXT      The name of the dataset to download non-interactively
-  --overwrite         Overwrite existing local data
-  -y, --yes           Automatically confirm payment confirmation prompts
-  --lean-config FILE  The Lean configuration file that should be used (defaults to the nearest lean.json)
-  --verbose           Enable debug logging
-  --help              Show this message and exit.
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit]
+                                  The name of the downloader data provider.
+  --ib-user-name TEXT             Your Interactive Brokers username
+  --ib-account TEXT               Your Interactive Brokers account id
+  --ib-password TEXT              Your Interactive Brokers password
+  --ib-weekly-restart-utc-time TEXT
+                                  Weekly restart UTC time (hh:mm:ss). Each week on Sunday your algorithm is restarted at
+                                  this time, and will require 2FA verification. This is required by Interactive Brokers.
+                                  Use this option explicitly to override the default value.
+  --oanda-account-id TEXT         Your OANDA account id
+  --oanda-access-token TEXT       Your OANDA API token
+  --oanda-environment [Practice|Trade]
+                                  The environment to run in, Practice for fxTrade Practice, Trade for fxTrade
+  --bitfinex-api-key TEXT         Your Bitfinex API key
+  --bitfinex-api-secret TEXT      Your Bitfinex API secret
+  --coinbase-api-key TEXT         Your Coinbase Advanced Trade API key
+  --coinbase-api-secret TEXT      Your Coinbase Advanced Trade API secret
+  --binance-exchange-name [Binance|BinanceUS|Binance-USDM-Futures|Binance-COIN-Futures]
+                                  Binance exchange name [Binance, BinanceUS, Binance-USDM-Futures, Binance-COIN-Futures]
+  --binance-api-key TEXT          Your Binance API key
+  --binanceus-api-key TEXT        Your Binance API key
+  --binance-api-secret TEXT       Your Binance API secret
+  --binanceus-api-secret TEXT     Your Binance API secret
+  --kraken-api-key TEXT           Your Kraken API key
+  --kraken-api-secret TEXT        Your Kraken API secret
+  --kraken-verification-tier [Starter|Intermediate|Pro]
+                                  Your Kraken Verification Tier
+  --iqfeed-iqconnect TEXT         The path to the IQConnect binary
+  --iqfeed-username TEXT          Your IQFeed username
+  --iqfeed-password TEXT          Your IQFeed password
+  --iqfeed-version TEXT           The product version of your IQFeed developer account
+  --iqfeed-host TEXT              The IQFeed host address
+  --polygon-api-key TEXT          Your Polygon.io API Key
+  --factset-auth-config-file FILE
+                                  The path to the FactSet authentication configuration file
+  --iex-cloud-api-key TEXT        Your iexcloud.io API token publishable key
+  --iex-price-plan [Launch|Grow|Enterprise]
+                                  Your IEX Cloud Price plan
+  --alpha-vantage-api-key TEXT    Your Alpha Vantage Api Key
+  --alpha-vantage-price-plan [Free|Plan30|Plan75|Plan150|Plan300|Plan600|Plan1200]
+                                  Your Alpha Vantage Premium API Key plan
+  --coinapi-api-key TEXT          Your coinapi.io Api Key
+  --coinapi-product [Free|Startup|Streamer|Professional|Enterprise]
+                                  CoinApi pricing plan (https://www.coinapi.io/market-data-api/pricing)
+  --thetadata-ws-url TEXT         The ThetaData host address
+  --thetadata-rest-url TEXT       The ThetaData host address
+  --thetadata-subscription-plan [Free|Value|Standard|Pro]
+                                  Your ThetaData subscription price plan
+  --terminal-link-connection-type [DAPI|SAPI]
+                                  Terminal Link Connection Type [DAPI, SAPI]
+  --terminal-link-server-auth-id TEXT
+                                  The Auth ID of the TerminalLink server
+  --terminal-link-environment [Production|Beta]
+                                  The environment to run in
+  --terminal-link-server-host TEXT
+                                  The host of the TerminalLink server
+  --terminal-link-server-port INTEGER
+                                  The port of the TerminalLink server
+  --terminal-link-openfigi-api-key TEXT
+                                  The Open FIGI API key to use for mapping options
+  --bybit-api-key TEXT            Your Bybit API key
+  --bybit-api-secret TEXT         Your Bybit API secret
+  --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
+                                  Your Bybit VIP Level
+  --dataset TEXT                  The name of the dataset to download non-interactively
+  --overwrite                     Overwrite existing local data
+  -y, --yes                       Automatically confirm payment confirmation prompts
+  --data-type [Trade|Quote|OpenInterest]
+                                  Specify the type of historical data
+  --resolution [Tick|Second|Minute|Hour|Daily]
+                                  Specify the resolution of the historical data
+  --security-type [Equity|Index|Forex|Cfd|Future|Crypto|CryptoFuture|Option|IndexOption|Commodity|FutureOption]
+                                  Specify the security type of the historical data
+  --market TEXT                   Specify the market name for tickers (e.g., 'USA', 'NYMEX', 'Binance')
+  --tickers TEXT                  Specify comma separated list of tickers to use for historical data request.
+  --start-date TEXT               Specify the start date for the historical data request in the format yyyyMMdd.
+  --end-date TEXT                 Specify the end date for the historical data request in the format yyyyMMdd. (defaults
+                                  to today)
+  --image TEXT                    The LEAN engine image to use (defaults to quantconnect/lean:latest)
+  --update                        Pull the LEAN engine image before running the Downloader Data Provider
+  --no-update                     Use the local LEAN engine image instead of pulling the latest version
+  --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
+  --verbose                       Enable debug logging
+  --help                          Show this message and exit.
 ```
 
 _See code: [lean/commands/data/download.py](lean/commands/data/download.py)_

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -657,7 +657,7 @@ def download(ctx: Context,
 
         run_options["working_dir"] = downloader_data_provider_path_dll
 
-        dll_arguments = ["dotnet", "QuantConnect.Lean.DownloaderDataProvider.dll",
+        dll_arguments = ["dotnet", "QuantConnect.DownloaderDataProvider.Launcher.dll",
                          "--data-type", data_type,
                          "--start-date", start_date.value.strftime("%Y%m%d"),
                          "--end-date", end_date.value.strftime("%Y%m%d"),

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -19,6 +19,7 @@ from lean.components.util.json_modules_handler import config_build_for_name, non
 from lean.constants import DATA_FOLDER_PATH, DATA_TYPES, DEFAULT_ENGINE_IMAGE, MODULE_DATA_DOWNLOADER, RESOLUTIONS, SECURITY_TYPES
 from lean.container import container
 from lean.models.api import QCDataInformation, QCDataVendor, QCFullOrganization, QCDatasetDelivery
+from lean.models.click_options import get_configs_for_options, options_from_json
 from lean.models.data import Dataset, DataFile, DatasetDateOption, DatasetTextOption, DatasetTextOptionTransform, Product
 from lean.models.logger import Option
 from lean.models.cli import cli_data_downloaders
@@ -409,10 +410,11 @@ def _get_available_datasets(organization: QCFullOrganization) -> List[Dataset]:
 
     return available_datasets
 
-@command(cls=LeanCommand, requires_lean_config=True, allow_unknown_options=True)
+@command(cls=LeanCommand, requires_lean_config=True, allow_unknown_options=True, name="download")
 @option("--data-provider-historical",
         type=Choice([data_downloader.get_name() for data_downloader in cli_data_downloaders], case_sensitive=False),
         help="The name of the downloader data provider.")
+@options_from_json(get_configs_for_options("backtest"))
 @option("--dataset", type=str, help="The name of the dataset to download non-interactively")
 @option("--overwrite", is_flag=True, default=False, help="Overwrite existing local data")
 @option("--force", is_flag=True, default=False, hidden=True)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from datetime import datetime
 from json import dump
 
 from docker.types import Mount
@@ -464,6 +464,7 @@ def _get_user_input_or_prompt(user_input_data: str, available_input_data: List[s
 
     return user_input_data
 
+
 def _configure_date_option(date_value: str, option_id: str, option_label: str) -> OptionResult:
     """
     Configure the date based on the provided date value, option ID, and option label.
@@ -477,10 +478,15 @@ def _configure_date_option(date_value: str, option_id: str, option_label: str) -
     - str: Configured date.
     """
 
-    date_option = DatasetDateOption(id=option_id, label=option_label, description=f"Enter the {option_label} for the historical data request in the format YYYYMMDD.")
+    date_option = DatasetDateOption(id=option_id, label=option_label,
+                                    description=f"Enter the {option_label} "
+                                                f"for the historical data request in the format YYYYMMDD.")
 
     if not date_value:
-        return date_option.configure_interactive()
+        if option_id == "end":
+            return date_option.configure_interactive_with_default(datetime.today().strftime("%Y%m%d"))
+        else:
+            return date_option.configure_interactive()
 
     return date_option.configure_non_interactive(date_value)
 
@@ -620,8 +626,8 @@ def download(ctx: Context,
                                transform=DatasetTextOptionTransform.Lowercase,
                                multiple=True).configure_interactive().value)
 
-        start_date = _configure_date_option(start_date, "start", "Start date")
-        end_date = _configure_date_option(end_date, "end", "End date")
+        start_date = _configure_date_option(start_date, "start", "Please enter a Start Date in the format")
+        end_date = _configure_date_option(end_date, "end", "Please enter a End Date in the format")
 
         if start_date.value >= end_date.value:
             raise ValueError("Historical start date cannot be greater than or equal to historical end date.")

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -633,7 +633,7 @@ def download(ctx: Context,
         run_options["working_dir"] = downloader_data_provider_path_dll
         
         dll_arguments = ["dotnet", "QuantConnect.Lean.DownloaderDataProvider.dll",
-                         "--data-provider", data_provider.get_config_value_from_name(MODULE_DATA_DOWNLOADER),
+                         "--data-provider", data_provider.get_settings()[MODULE_DATA_DOWNLOADER],
                          "--destination-dir", DATA_FOLDER_PATH,
                          "--data-type", data_type,
                          "--start-date", start_date.value.strftime("%Y%m%d"),

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -539,7 +539,16 @@ def download(ctx: Context,
              update: bool,
              no_update: bool,
              **kwargs) -> None:
-    """Purchase and download data from QuantConnect Datasets.
+    """Purchase and download data directly from QuantConnect or download from Support Data Providers
+
+    1. Acquire Data from QuantConnect Datasets: Purchase and seamlessly download data directly from QuantConnect.\n
+    2. Streamlined Access from Support Data Providers:\n
+        - Choose your preferred historical data provider.\n
+        - Initiate hassle-free downloads from our supported providers.
+
+    We have 2 options:\n
+        - interactive (follow instruction in lean-cli)\n
+        - no interactive (write arguments in command line)
 
     An interactive wizard will show to walk you through the process of selecting data,
     accepting the CLI API Access and Data Agreement and payment.
@@ -623,7 +632,7 @@ def download(ctx: Context,
                                                          cli_data_downloaders, kwargs, logger, interactive=False)
         data_downloader_provider.ensure_module_installed(organization.id)
         container.lean_config_manager.set_properties(data_downloader_provider.get_settings())
-        # Info: I don't understand why it returns empty result
+        # mounting additional data_downloader config files
         paths_to_mount = data_downloader_provider.get_paths_to_mount()
 
         engine_image = container.cli_config_manager.get_engine_image(image)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -11,11 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Iterable, List, Optional
 from click import command, option, confirm, pass_context, Context, Choice
 from lean.click import LeanCommand, ensure_options
 from lean.components.util.json_modules_handler import config_build_for_name, non_interactive_config_build_for_name
-from lean.constants import DATA_FOLDER_PATH, DATA_PROVIDER_DOWNLOAD_CONFIG_KEY, DATA_TYPES, DEFAULT_ENGINE_IMAGE, RESOLUTIONS, SECURITY_TYPES
+from lean.constants import DATA_FOLDER_PATH, DATA_TYPES, DEFAULT_ENGINE_IMAGE, MODULE_DATA_DOWNLOADER, RESOLUTIONS, SECURITY_TYPES
 from lean.container import container
 from lean.models.api import QCDataInformation, QCDataVendor, QCFullOrganization, QCDatasetDelivery
 from lean.models.data import Dataset, DataFile, DatasetDateOption, DatasetTextOption, DatasetTextOptionTransform, Product
@@ -546,7 +547,7 @@ def download(ctx: Context,
         data_dir = lean_config_manager.get_data_directory()
         
         entrypoint = ["dotnet", "QuantConnect.Lean.DownloaderDataProvider.dll",
-                      "--data-provider", data_provider.get_config_value_from_name(DATA_PROVIDER_DOWNLOAD_CONFIG_KEY),
+                      "--data-provider", data_provider.get_config_value_from_name(MODULE_DATA_DOWNLOADER),
                       "--destination-dir", DATA_FOLDER_PATH,
                       "--data-type", historical_data_type,
                       "--start-date", historical_start_date.value.strftime("%Y%m%d"),

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -11,11 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 from click import command, option, confirm, pass_context, Context, Choice
 from lean.click import LeanCommand, ensure_options
-from lean.components.util.json_modules_handler import config_build_for_name, non_interactive_config_build_for_name
+from lean.components.util.json_modules_handler import config_build_for_name
 from lean.constants import DATA_FOLDER_PATH, DATA_TYPES, DEFAULT_ENGINE_IMAGE, MODULE_DATA_DOWNLOADER, RESOLUTIONS, SECURITY_TYPES
 from lean.container import container
 from lean.models.api import QCDataInformation, QCDataVendor, QCFullOrganization, QCDatasetDelivery
@@ -502,40 +501,23 @@ def download(ctx: Context,
         if data_provider._specifications_url is not None:
             data_provider_config_json = container.api_client.data.download_public_file_json(data_provider._specifications_url)
 
-        data_provider_support_security_types = SECURITY_TYPES
-        if data_provider_config_json is not None:
-            data_provider_support_security_types = data_provider_config_json["data-supported"]
-        
-        # validate data_type exists
-        if not data_type:
-            data_type = logger.prompt_list("Select a historical data type", [Option(id=data_type, label=data_type) for data_type in DATA_TYPES])
+        data_provider_support_security_types = _get_param_from_config(data_provider_config_json, SECURITY_TYPES, "data-supported")
+        data_provider_support_data_types = _get_param_from_config(data_provider_config_json, DATA_TYPES, "data-types")
+        data_provider_support_resolutions = _get_param_from_config(data_provider_config_json, RESOLUTIONS, "data-resolutions")
 
-        if not resolution:
-            resolution = logger.prompt_list("Select a historical resolution", [Option(id=data_type, label=data_type) for data_type in RESOLUTIONS])
-
-        if not ticker_security_type:
-            ticker_security_type = logger.prompt_list("Select a Ticker's security type", [Option(id=data_type, label=data_type) for data_type in data_provider_support_security_types])
-        elif ticker_security_type not in data_provider_support_security_types:
-                raise ValueError(f"The {data_provider_historical} data provider does not support {ticker_security_type}. Please choose a supported security type from: {data_provider_support_security_types}.")
+        ticker_security_type = get_user_input_or_prompt(ticker_security_type, data_provider_support_security_types, data_provider_historical)  
+        data_type = get_user_input_or_prompt(data_type, data_provider_support_data_types, data_provider_historical)
+        resolution = get_user_input_or_prompt(resolution, data_provider_support_resolutions, data_provider_historical)
 
         if not tickers:
-            tickers = DatasetTextOption(id="id",
+            tickers = ','.join(DatasetTextOption(id="id",
                                label="Enter comma separated list of tickers to use for historical data request.",
                                description="description",
                                transform=DatasetTextOptionTransform.Lowercase,
-                               multiple=True).configure_interactive()
-
-        start_data_option = DatasetDateOption(id="start", label="Start date", description="Enter the start date for the historical data request in the format YYYYMMDD.")
-        if not start_date:
-            start_date = start_data_option.configure_interactive()
-        else:
-            start_date = start_data_option.configure_non_interactive(start_date)
-
-        end_date_option = DatasetDateOption(id="end", label="End date",description="Enter the end date for the historical data request in the format YYYYMMDD.")
-        if not end_date:
-            end_date = end_date_option.configure_interactive()
-        else:
-            end_date = end_date_option.configure_non_interactive(end_date)
+                               multiple=True).configure_interactive().value)
+            
+        start_date = configure_date_option(start_date, "start", "Start date")
+        end_date = configure_date_option(end_date, "end", "End date")
 
         if start_date.value >= end_date.value:
             raise ValueError("Historical start date cannot be greater than or equal to historical end date.")
@@ -578,7 +560,7 @@ def download(ctx: Context,
                          "--resolution", resolution,
                          "--tickers", tickers]
         
-        run_options["commands"].append(' '.join(dll_arguments))
+        run_options["commands"].append(' '.join(dll_arguments))        
 
         success = container.docker_manager.run_image(engine_image, **run_options)
         
@@ -588,3 +570,84 @@ def download(ctx: Context,
 
 def _get_historical_data_provider() -> str:
     return container.logger.prompt_list("Select a downloading mode", [Option(id=data_downloader.get_name(), label=data_downloader.get_name()) for data_downloader in cli_data_downloaders])
+
+def _get_param_from_config(data_provider_config_json: Dict[str, Any], default_param: List[str], key_config_data: str) -> List[str]:
+    """
+    Get parameter from data provider config JSON or return default parameters.
+
+    Args:
+    - data_provider_config_json (Dict[str, Any]): Configuration JSON.
+    - default_param (List[str]): Default parameters.
+    - key_config_data (str): Key to look for in the config JSON.
+
+    Returns:
+    - List[str]: List of parameters.
+    """
+    container.logger.info(f'data_provider_config_json: {data_provider_config_json}')
+    if data_provider_config_json is None:
+        return default_param
+    
+    return data_provider_config_json.get(key_config_data, default_param)
+
+def get_user_input_or_prompt(user_input_data: str, data_types: List[str], data_provider_name: str) -> str:
+    """
+    Get user input or prompt for selection based on data types.
+
+    Args:
+    - user_input_data (str): User input data.
+    - data_types (List[str]): List of supported data types.
+    - data_provider_name (str): Name of the data provider.
+
+    Returns:
+    - str: Selected data type or prompted choice.
+    
+    Raises:
+    - ValueError: If user input data is not in supported data types.
+    """
+    
+    if not user_input_data:
+        # Prompt user to select a ticker's security type
+        return prompt_user_selection(data_types)
+    
+    elif user_input_data not in data_types:
+        # Raise ValueError for unsupported data type
+        raise ValueError(
+            f"The {data_provider_name} data provider does not support {user_input_data}. "
+            f"Please choose a supported data from: {data_types}."
+        )
+    
+    return user_input_data
+
+def prompt_user_selection(data_types: List[str]) -> str:
+    """
+    Prompt user to select a data type from a list.
+
+    Args:
+    - data_types (List[str]): List of supported data types.
+
+    Returns:
+    - str: Selected data type.
+    """
+
+    options = [Option(id=data_type, label=data_type) for data_type in data_types]
+    return container.logger.prompt_list("Select a Ticker's security type", options)
+
+def configure_date_option(date_value: str, option_id: str, option_label: str) -> str:
+    """
+    Configure the date based on the provided date value, option ID, and option label.
+
+    Args:
+    - date_value (str): Existing date value.
+    - option_id (str): Identifier for the date option.
+    - option_label (str): Label for the date option.
+
+    Returns:
+    - str: Configured date.
+    """
+    
+    date_option = DatasetDateOption(id=option_id, label=option_label, description=f"Enter the {option_label} for the historical data request in the format YYYYMMDD.")
+    
+    if not date_value:
+        return date_option.configure_interactive()
+    
+    return date_option.configure_non_interactive(date_value)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -607,15 +607,15 @@ def download(ctx: Context,
 
         data_provider_support_security_types = _get_download_specification_from_config(data_provider_config_json,
                                                                                        QCSecurityType.get_all_members(),
-                                                                                       "data-supported")
+                                                                                       "security-types")
         data_provider_support_data_types = _get_download_specification_from_config(data_provider_config_json,
                                                                                    QCDataType.get_all_members(),
                                                                                    "data-types")
         data_provider_support_resolutions = _get_download_specification_from_config(data_provider_config_json,
                                                                                     QCResolution.get_all_members(),
-                                                                                    "data-resolutions")
+                                                                                    "resolutions")
         data_provider_support_markets = _get_download_specification_from_config(data_provider_config_json,
-                                                                                [market], "data-markets")
+                                                                                [market], "markets")
 
         security_type = _get_user_input_or_prompt(security_type, data_provider_support_security_types,
                                                   data_provider_historical, "Select a Ticker's security type")

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from json import dump
+
 from docker.types import Mount
 from typing import Any, Dict, Iterable, List, Optional
 from click import command, option, confirm, pass_context, Context, Choice
@@ -653,16 +654,16 @@ def download(ctx: Context,
         }
         config.update(data_downloader_provider.get_settings())
 
-        config_path = container.temp_manager.create_temporary_directory() / "config.json"
-        with config_path.open("w+", encoding="utf-8") as file:
-            dump(config, file)
-
-        run_options = container.lean_runner.get_basic_docker_config_without_algo(lean_config,
+        run_options = container.lean_runner.get_basic_docker_config_without_algo(config,
                                                                                  debugging_method=None,
                                                                                  detach=False,
                                                                                  image=engine_image,
                                                                                  target_path=downloader_data_provider_path_dll,
                                                                                  paths_to_mount=paths_to_mount)
+
+        config_path = container.temp_manager.create_temporary_directory() / "config.json"
+        with config_path.open("w+", encoding="utf-8") as file:
+            dump(config, file)
 
         run_options["working_dir"] = downloader_data_provider_path_dll
 

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -606,7 +606,7 @@ def download(ctx: Context,
         logger = container.logger
         lean_config = container.lean_config_manager.get_lean_config()
 
-        data_downloader_provider = config_build_for_name(lean_config, data_downloader_provider.get_name(), cli_data_downloaders, kwargs, logger, interactive=True)
+        data_downloader_provider = config_build_for_name(lean_config, data_downloader_provider.get_name(), cli_data_downloaders, kwargs, logger, interactive=False)
         data_downloader_provider = config_build_for_name(lean_config, data_downloader_provider.get_name(),
                                                          cli_data_downloaders, kwargs, logger, interactive=False)
         data_downloader_provider.ensure_module_installed(organization.id)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -497,7 +497,7 @@ def _configure_date_option(date_value: str, option_id: str, option_label: str) -
 @option("--data-provider-historical",
         type=Choice([data_downloader.get_name() for data_downloader in cli_data_downloaders], case_sensitive=False),
         help="The name of the downloader data provider.")
-@options_from_json(get_configs_for_options("backtest"))
+@options_from_json(get_configs_for_options("download"))
 @option("--dataset", type=str, help="The name of the dataset to download non-interactively")
 @option("--overwrite", is_flag=True, default=False, help="Overwrite existing local data")
 @option("--force", is_flag=True, default=False, hidden=True)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -424,7 +424,6 @@ def _get_param_from_config(data_provider_config_json: Dict[str, Any], default_pa
     Returns:
     - List[str]: List of parameters.
     """
-    container.logger.info(f'data_provider_config_json: {data_provider_config_json}')
     if data_provider_config_json is None:
         return default_param
     
@@ -576,9 +575,7 @@ def download(ctx: Context,
 
         all_data_files = _get_data_files(organization, products)
         container.data_downloader.download_files(all_data_files, overwrite, organization.id)
-    else:
-        logger = container.logger
-        
+    else:        
         data_provider = next(data_downloader for data_downloader in cli_data_downloaders if data_downloader.get_name() == data_provider_historical)
 
         data_provider_config_json = None
@@ -605,7 +602,8 @@ def download(ctx: Context,
 
         if start_date.value >= end_date.value:
             raise ValueError("Historical start date cannot be greater than or equal to historical end date.")
-
+        
+        logger = container.logger
         lean_config = container.lean_config_manager.get_lean_config()
         data_provider = config_build_for_name(lean_config, data_provider.get_name(), cli_data_downloaders, kwargs, logger, interactive=False)
         data_provider.ensure_module_installed(organization.id)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -541,7 +541,7 @@ def download(ctx: Context,
             raise ValueError("Historical start date cannot be greater than or equal to historical end date.")
 
         lean_config = container.lean_config_manager.get_lean_config()
-        data_provider = config_build_for_name(lean_config, data_provider.get_name(), cli_data_downloaders, kwargs, logger, True)
+        data_provider = config_build_for_name(lean_config, data_provider.get_name(), cli_data_downloaders, kwargs, logger, interactive=False)
         data_provider.ensure_module_installed(organization.id)
         container.lean_config_manager.set_properties(data_provider.get_settings())
         # Info: I don't understand why it returns empty result 
@@ -559,7 +559,12 @@ def download(ctx: Context,
 
         downloader_data_provider_path_dll = "/Lean/DownloaderDataProvider/bin/Debug"
         
-        run_options = container.lean_runner.get_basic_docker_config_without_algo(lean_config, True, False, engine_image, downloader_data_provider_path_dll, paths_to_mount)
+        run_options = container.lean_runner.get_basic_docker_config_without_algo(lean_config,
+                                                                                 debugging_method=None,
+                                                                                 detach=False,
+                                                                                 image=engine_image,
+                                                                                 target_path=downloader_data_provider_path_dll,
+                                                                                 paths_to_mount=paths_to_mount)
         
         run_options["working_dir"] = downloader_data_provider_path_dll
         

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Iterable, List, Optional
 from click import command, option, confirm, pass_context, Context, Choice
 from lean.click import LeanCommand, ensure_options
 from lean.components.util.json_modules_handler import config_build_for_name
-from lean.constants import DEFAULT_ENGINE_IMAGE, MODULE_DATA_DOWNLOADER
+from lean.constants import DEFAULT_ENGINE_IMAGE
 from lean.container import container
 from lean.models.api import QCDataInformation, QCDataVendor, QCFullOrganization, QCDatasetDelivery, QCResolution, QCSecurityType, QCDataType
 from lean.models.click_options import get_configs_for_options, options_from_json
@@ -517,6 +517,10 @@ def _configure_date_option(date_value: str, option_id: str, option_label: str) -
         is_flag=True,
         default=False,
         help="Pull the LEAN engine image before running the Downloader Data Provider")
+@option("--no-update",
+        is_flag=True,
+        default=False,
+        help="Use the local LEAN engine image instead of pulling the latest version")
 @pass_context
 def download(ctx: Context,
              data_provider_historical: Optional[str],
@@ -533,6 +537,7 @@ def download(ctx: Context,
              end_date: Optional[str],
              image: Optional[str],
              update: bool,
+             no_update: bool,
              **kwargs) -> None:
     """Purchase and download data from QuantConnect Datasets.
 
@@ -623,10 +628,8 @@ def download(ctx: Context,
 
         engine_image = container.cli_config_manager.get_engine_image(image)
 
-        no_update = False
         if str(engine_image) != DEFAULT_ENGINE_IMAGE:
             # Custom engine image should not be updated.
-            no_update = True
             logger.warn(f'A custom engine image: "{engine_image}" is being used!')
 
         container.update_manager.pull_docker_image_if_necessary(engine_image, update, no_update)

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -655,7 +655,6 @@ def download(ctx: Context,
         run_options["working_dir"] = downloader_data_provider_path_dll
 
         dll_arguments = ["dotnet", "QuantConnect.Lean.DownloaderDataProvider.dll",
-                         "--data-downloader", data_downloader_provider.get_settings()[MODULE_DATA_DOWNLOADER],
                          "--data-type", data_type,
                          "--start-date", start_date.value.strftime("%Y%m%d"),
                          "--end-date", end_date.value.strftime("%Y%m%d"),

--- a/lean/components/api/data_client.py
+++ b/lean/components/api/data_client.py
@@ -92,6 +92,14 @@ class DataClient:
         :return: the content of the file
         """
         return self._http_client.get(data_endpoint).content
+    
+    def download_public_file_json(self, data_endpoint: str) -> Any:
+        """Downloads the content of a downloadable public file in json format.
+
+        :param data_endpoint: the url of the public file
+        :return: the content of the file in json format
+        """
+        return self._http_client.get(data_endpoint).json()
 
     def list_files(self, prefix: str) -> List[str]:
         """Lists all remote files with a given prefix.

--- a/lean/components/api/data_client.py
+++ b/lean/components/api/data_client.py
@@ -13,7 +13,7 @@
 
 from lean.components.api.api_client import *
 from lean.models.api import QCDataInformation
-from typing import List, Callable
+from typing import List, Callable, cast
 
 
 class DataClient:
@@ -93,13 +93,13 @@ class DataClient:
         """
         return self._http_client.get(data_endpoint).content
     
-    def download_public_file_json(self, data_endpoint: str) -> Any:
+    def download_public_file_json(self, data_endpoint: str) -> Dict[str, Any]:
         """Downloads the content of a downloadable public file in json format.
 
         :param data_endpoint: the url of the public file
         :return: the content of the file in json format
         """
-        return self._http_client.get(data_endpoint).json()
+        return cast(Dict[str, Any], self._http_client.get(data_endpoint).json())
 
     def list_files(self, prefix: str) -> List[str]:
         """Lists all remote files with a given prefix.

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -375,6 +375,174 @@ class LeanRunner:
 
         return run_options
 
+    def get_basic_docker_config_without_algo(self,
+                                             lean_config: Dict[str, Any],
+                                             debugging_method: Optional[DebuggingMethod],
+                                             detach: bool,
+                                             image: DockerImage,
+                                             target_path: str,
+                                             paths_to_mount: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        """Creates a basic Docker config to run the engine with.
+
+        This method constructs the parts of the Docker config that is the same for both the engine and the optimizer.
+
+        :param lean_config: the LEAN configuration to use
+        :param debugging_method: the debugging method if debugging needs to be enabled, None if not
+        :param detach: whether LEAN should run in a detached container
+        :param image: The docker image that will be used
+        :return: the Docker configuration containing basic configuration to run Lean
+        :param paths_to_mount: additional paths to mount to the container
+        """
+        from docker.types import Mount
+        from uuid import uuid4
+        from json import dumps
+
+        docker_project_config = {
+            "docker": {}
+        }
+        # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
+        data_dir = self._lean_config_manager.get_data_directory()
+        if lean_config.get("data-provider", None) != "QuantConnect.Lean.Engine.DataFeeds.ApiDataProvider":
+            self._force_disk_provider_if_necessary(lean_config,
+                                                   "map-file-provider",
+                                                   "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
+                                                   "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
+                                                   data_dir / "equity" / "usa" / "map_files")
+            self._force_disk_provider_if_necessary(lean_config,
+                                                   "factor-file-provider",
+                                                   "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
+                                                   "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
+                                                   data_dir / "equity" / "usa" / "factor_files")
+
+        # Create the storage directory if it doesn't exist yet
+        storage_dir = self._lean_config_manager.get_cli_root_directory() / "storage"
+        if not storage_dir.exists():
+            storage_dir.mkdir(parents=True)
+
+        lean_config["debug-mode"] = self._logger.debug_logging_enabled
+        lean_config["data-folder"] = "/Lean/Data"
+        lean_config["results-destination-folder"] = "/Results"
+        lean_config["object-store-root"] = "/Storage"
+
+        # The dict containing all options passed to `docker run`
+        # See all available options at https://docker-py.readthedocs.io/en/stable/containers.html
+        run_options: Dict[str, Any] = {
+            "detach": detach,
+            "commands": [],
+            "environment": docker_project_config.get("environment", {}),
+            "stop_signal": "SIGINT" if debugging_method is None else "SIGKILL",
+            "mounts": [],
+            "volumes": {},
+            "ports": docker_project_config.get("ports", {})
+        }
+
+        # mount the paths passed in
+        self.mount_paths(paths_to_mount, lean_config, run_options)
+
+        # mount the project and library directories
+        #self.mount_project_and_library_directories(project_dir, run_options)
+
+        # Mount the data directory
+        run_options["volumes"][str(data_dir)] = {
+            "bind": "/Lean/Data",
+            "mode": "rw"
+        }
+
+        # Mount the local object store directory
+        run_options["volumes"][str(storage_dir)] = {
+            "bind": "/Storage",
+            "mode": "rw"
+        }
+
+        # Mount all local files referenced in the Lean config
+        cli_root_dir = self._lean_config_manager.get_cli_root_directory()
+        files_to_mount = [
+            ("transaction-log", cli_root_dir),
+            ("terminal-link-symbol-map-file", cli_root_dir / DEFAULT_DATA_DIRECTORY_NAME / "symbol-properties")
+        ]
+        for key, base_path in files_to_mount:
+            if key not in lean_config or lean_config[key] == "":
+                continue
+
+            lean_config_entry = Path(lean_config[key])
+            local_path = lean_config_entry if lean_config_entry.is_absolute() else base_path / lean_config_entry
+            if not local_path.exists():
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                local_path.touch()
+
+            run_options["mounts"].append(Mount(target=f"/Files/{key}",
+                                               source=str(local_path),
+                                               type="bind",
+                                               read_only=False))
+
+            lean_config[key] = f"/Files/{key}"
+
+        # Update all hosts that need to point to the host's localhost to host.docker.internal so they resolve properly
+        for key in ["terminal-link-server-host"]:
+            if key not in lean_config:
+                continue
+
+            if lean_config[key] == "localhost" or lean_config[key] == "127.0.0.1":
+                lean_config[key] = "host.docker.internal"
+
+        # Set up modules
+        installed_packages = self._module_manager.get_installed_packages()
+        if len(installed_packages) > 0:
+            self._logger.debug(f"LeanRunner.run_lean(): installed packages {len(installed_packages)}")
+            self.set_up_common_csharp_options(run_options, target_path)
+
+            # Mount the modules directory
+            run_options["volumes"][MODULES_DIRECTORY] = {
+                "bind": "/Modules",
+                "mode": "ro"
+            }
+
+            # Add the modules directory as a NuGet source root
+            run_options["commands"].append("dotnet nuget add source /Modules")
+
+            # Create a C# project used to resolve the dependencies of the modules
+            run_options["commands"].append("mkdir /ModulesProject")
+            run_options["commands"].append("dotnet new sln -o /ModulesProject")
+
+            framework_ver = self._docker_manager.get_image_label(image, 'target_framework',
+                                                                 DEFAULT_LEAN_DOTNET_FRAMEWORK)
+            run_options["commands"].append(f"dotnet new classlib -o /ModulesProject -f {framework_ver} --no-restore")
+            run_options["commands"].append("rm /ModulesProject/Class1.cs")
+
+            # Add all modules to the project, automatically resolving all dependencies
+            for package in installed_packages:
+                self._logger.debug(f"LeanRunner.run_lean(): Adding module {package} to the project")
+                run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
+                run_options["commands"].append(
+                    f"dotnet add /ModulesProject package {package.name} --version {package.version}")
+
+            # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
+            run_options["commands"].append(
+                "python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
+        
+        # Save the final Lean config to a temporary file so we can mount it into the container
+        config_path = self._temp_manager.create_temporary_directory() / "config.json"
+        with config_path.open("w+", encoding="utf-8") as file:
+            file.write(dumps(lean_config, indent=4))
+
+        # Mount the Lean config
+        run_options["mounts"].append(Mount(target=f"{LEAN_ROOT_PATH}/config.json",
+                                           source=str(config_path),
+                                           type="bind",
+                                           read_only=True))
+
+        # Assign the container a name and store it in the output directory's configuration
+        if "container-name" in lean_config:
+            run_options["name"] = lean_config["container-name"]
+        else:
+            run_options["name"] = f"lean_cli_{str(uuid4()).replace('-', '')}"
+
+        # set the hostname
+        if "hostname" in lean_config:
+            run_options["hostname"] = lean_config["hostname"]
+
+        return run_options
+
     def set_up_python_options(self, project_dir: Path, run_options: Dict[str, Any], image: DockerImage) -> None:
         """Sets up Docker run options specific to Python projects.
 
@@ -547,12 +715,22 @@ class LeanRunner:
         run_options["commands"].append(
             f'python /copy_csharp_dependencies.py "/Compile/obj/{project_file.stem}/project.assets.json"')
 
-    def set_up_common_csharp_options(self, run_options: Dict[str, Any]) -> None:
-        """Sets up common Docker run options that is needed for all C# work.
+    def set_up_common_csharp_options(self, run_options: Dict[str, Any], target_path: str = "/Lean/Launcher/bin/Debug") -> None:
+        """
+        Sets up common Docker run options that is needed for all C# work.
 
-        This method is only called if the user has installed modules and/or if the project to run is written in C#.
+        This method prepares the Docker run options required to run C# projects inside a Docker container. It is called 
+        when the user has installed specific modules or when the project to run is written in C#.
 
-        :param run_options: the dictionary to append run options to
+        Parameters:
+        - run_options (Dict[str, Any]): A dictionary to which the Docker run options will be appended.
+        - target_path (str, optional): The target path inside the Docker container where the C# project should be located.
+                                   Default value is "/Lean/Launcher/bin/Debug".
+                                   A Python script is typically used to copy the right C# dependencies to this path.
+                                   This script ensures that the correct DLLs are copied, even if they are OS-specific.
+
+        Returns:
+        - None: This function does not return anything. It modifies the `run_options` dictionary in place.
         """
         from docker.types import Mount
         # Mount a volume to NuGet's cache directory so we only download packages once
@@ -623,7 +801,7 @@ def copy_file(library_id, partial_path, file_data):
 
     output_name = file_data.get("outputPath", full_path.name)
 
-    target_path = Path("/Lean/Launcher/bin/Debug") / output_name
+    target_path = Path("""+ f'"{target_path}"' +""") / output_name
     if not target_path.exists():
         target_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(full_path, target_path)

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -340,27 +340,27 @@ class LeanRunner:
             self._logger.debug(f"LeanRunner._setup_installed_packages(): installed packages {len(installed_packages)}")
             self.set_up_common_csharp_options(run_options, target_path)
 
-        # Mount the modules directory
-        run_options["volumes"][MODULES_DIRECTORY] = {"bind": "/Modules", "mode": "ro"}
+            # Mount the modules directory
+            run_options["volumes"][MODULES_DIRECTORY] = {"bind": "/Modules", "mode": "ro"}
 
-        # Add the modules directory as a NuGet source root
-        run_options["commands"].append("dotnet nuget add source /Modules")
-        # Create a C# project used to resolve the dependencies of the modules
-        run_options["commands"].append("mkdir /ModulesProject")
-        run_options["commands"].append("dotnet new sln -o /ModulesProject")
+            # Add the modules directory as a NuGet source root
+            run_options["commands"].append("dotnet nuget add source /Modules")
+            # Create a C# project used to resolve the dependencies of the modules
+            run_options["commands"].append("mkdir /ModulesProject")
+            run_options["commands"].append("dotnet new sln -o /ModulesProject")
         
-        framework_ver = self._docker_manager.get_image_label(image, 'target_framework', DEFAULT_LEAN_DOTNET_FRAMEWORK)
-        run_options["commands"].append(f"dotnet new classlib -o /ModulesProject -f {framework_ver} --no-restore")
-        run_options["commands"].append("rm /ModulesProject/Class1.cs")
+            framework_ver = self._docker_manager.get_image_label(image, 'target_framework', DEFAULT_LEAN_DOTNET_FRAMEWORK)
+            run_options["commands"].append(f"dotnet new classlib -o /ModulesProject -f {framework_ver} --no-restore")
+            run_options["commands"].append("rm /ModulesProject/Class1.cs")
 
-        # Add all modules to the project, automatically resolving all dependencies
-        for package in installed_packages:
-            self._logger.debug(f"LeanRunner._setup_installed_packages(): Adding module {package} to the project")
-            run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
-            run_options["commands"].append(f"dotnet add /ModulesProject package {package.name} --version {package.version}")
-
-        # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
-        run_options["commands"].append("python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
+            # Add all modules to the project, automatically resolving all dependencies
+            for package in installed_packages:
+                self._logger.debug(f"LeanRunner._setup_installed_packages(): Adding module {package} to the project")
+                run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
+                run_options["commands"].append(f"dotnet add /ModulesProject package {package.name} --version {package.version}")
+                
+            # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
+            run_options["commands"].append("python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
         
         return bool(installed_packages)
     

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -904,16 +904,13 @@ for library_id, library_data in project_assets["targets"][project_target].items(
             path = Path(pathStr).resolve()
             target = f"/Files/{Path(path).name}"
 
-            self._logger.info(f"Mounting {path} to {target}")
+            self._logger.debug(f"Mounting {path} to {target}")
 
             mounts.append(Mount(target=target,
                                 source=str(path),
                                 type="bind",
                                 read_only=True))
             environment[key] = target
-            # update target in config too (not only in environment above)
-            if key in lean_config:
-                lean_config[key] = target
 
     @staticmethod
     def parse_extra_docker_config(run_options: Dict[str, Any], extra_docker_config: Optional[Dict[str, Any]]) -> None:

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -259,11 +259,12 @@ class LeanRunner:
         :param debugging_method: the debugging method if debugging needs to be enabled, None if not
         :param detach: whether LEAN should run in a detached container
         :param image: The docker image that will be used
-        :return: the Docker configuration containing basic configuration to run Lean
+        :param target_path: The target path inside the Docker container where the C# project should be located.
         :param paths_to_mount: additional paths to mount to the container
+        :return: the Docker configuration containing basic configuration to run Lean
         """
 
-        docker_project_config = { "docker": {} }
+        docker_project_config = {"docker": {}}
         # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
         data_dir = self._lean_config_manager.get_data_directory()
         self._handle_data_providers(lean_config, data_dir)

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -197,9 +197,6 @@ class LeanRunner:
         :return: the Docker configuration containing basic configuration to run Lean
         :param paths_to_mount: additional paths to mount to the container
         """
-        from docker.types import Mount
-        from uuid import uuid4
-        from json import dumps
 
         project_dir = algorithm_file.parent
         project_config = self._project_config_manager.get_project_config(project_dir)
@@ -207,92 +204,27 @@ class LeanRunner:
 
         # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
         data_dir = self._lean_config_manager.get_data_directory()
-        if lean_config.get("data-provider", None) != "QuantConnect.Lean.Engine.DataFeeds.ApiDataProvider":
-            self._force_disk_provider_if_necessary(lean_config,
-                                                   "map-file-provider",
-                                                   "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
-                                                   "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
-                                                   data_dir / "equity" / "usa" / "map_files")
-            self._force_disk_provider_if_necessary(lean_config,
-                                                   "factor-file-provider",
-                                                   "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
-                                                   "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
-                                                   data_dir / "equity" / "usa" / "factor_files")
+        self._handle_data_providers(lean_config, data_dir)
+
+        storage_dir = self._lean_config_manager.get_cli_root_directory() / "storage"
 
         # Create the output directory if it doesn't exist yet
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True)
-
         # Create the storage directory if it doesn't exist yet
-        storage_dir = self._lean_config_manager.get_cli_root_directory() / "storage"
-        if not storage_dir.exists():
-            storage_dir.mkdir(parents=True)
+        self._ensure_directories_exist([output_dir, storage_dir])
+        
+        lean_config.update({
+            "debug-mode": self._logger.debug_logging_enabled,
+            "data-folder": "/Lean/Data",
+            "results-destination-folder": "/Results",
+            "object-store-root": "/Storage"
+        })
 
-        lean_config["debug-mode"] = self._logger.debug_logging_enabled
-        lean_config["data-folder"] = "/Lean/Data"
-        lean_config["results-destination-folder"] = "/Results"
-        lean_config["object-store-root"] = "/Storage"
+        run_options = self._initialize_run_options(detach, docker_project_config, debugging_method)
 
-        # The dict containing all options passed to `docker run`
-        # See all available options at https://docker-py.readthedocs.io/en/stable/containers.html
-        run_options: Dict[str, Any] = {
-            "detach": detach,
-            "commands": [],
-            "environment": docker_project_config.get("environment", {}),
-            "stop_signal": "SIGINT" if debugging_method is None else "SIGKILL",
-            "mounts": [],
-            "volumes": {},
-            "ports": docker_project_config.get("ports", {})
-        }
-
-        # mount the paths passed in
-        self.mount_paths(paths_to_mount, lean_config, run_options)
-
-        # mount the project and library directories
-        self.mount_project_and_library_directories(project_dir, run_options)
-
-        # Mount the data directory
-        run_options["volumes"][str(data_dir)] = {
-            "bind": "/Lean/Data",
-            "mode": "rw"
-        }
-
-        # Mount the output directory
-        run_options["volumes"][str(output_dir)] = {
-            "bind": "/Results",
-            "mode": "rw"
-        }
-
-        # Mount the local object store directory
-        run_options["volumes"][str(storage_dir)] = {
-            "bind": "/Storage",
-            "mode": "rw"
-        }
-
-        # Mount all local files referenced in the Lean config
-        cli_root_dir = self._lean_config_manager.get_cli_root_directory()
-        files_to_mount = [
-            ("transaction-log", cli_root_dir),
-            ("terminal-link-symbol-map-file", cli_root_dir / DEFAULT_DATA_DIRECTORY_NAME / "symbol-properties")
-        ]
-        for key, base_path in files_to_mount:
-            if key not in lean_config or lean_config[key] == "":
-                continue
-
-            lean_config_entry = Path(lean_config[key])
-            local_path = lean_config_entry if lean_config_entry.is_absolute() else base_path / lean_config_entry
-            if not local_path.exists():
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                local_path.touch()
-
-            run_options["mounts"].append(Mount(target=f"/Files/{key}",
-                                               source=str(local_path),
-                                               type="bind",
-                                               read_only=False))
-
-            lean_config[key] = f"/Files/{key}"
+        self._mount_common_directories(run_options, paths_to_mount, lean_config, data_dir, storage_dir, project_dir, output_dir)
 
         # Update all hosts that need to point to the host's localhost to host.docker.internal so they resolve properly
+        # TODO: we should remove it or add to config json 
         for key in ["terminal-link-server-host"]:
             if key not in lean_config:
                 continue
@@ -300,78 +232,15 @@ class LeanRunner:
             if lean_config[key] == "localhost" or lean_config[key] == "127.0.0.1":
                 lean_config[key] = "host.docker.internal"
 
-        set_up_common_csharp_options_called = False
-
         # Set up modules
-        installed_packages = self._module_manager.get_installed_packages()
-        if len(installed_packages) > 0:
-            self._logger.debug(f"LeanRunner.run_lean(): installed packages {len(installed_packages)}")
-            self.set_up_common_csharp_options(run_options)
-            set_up_common_csharp_options_called = True
-
-            # Mount the modules directory
-            run_options["volumes"][MODULES_DIRECTORY] = {
-                "bind": "/Modules",
-                "mode": "ro"
-            }
-
-            # Add the modules directory as a NuGet source root
-            run_options["commands"].append("dotnet nuget add source /Modules")
-
-            # Create a C# project used to resolve the dependencies of the modules
-            run_options["commands"].append("mkdir /ModulesProject")
-            run_options["commands"].append("dotnet new sln -o /ModulesProject")
-
-            framework_ver = self._docker_manager.get_image_label(image, 'target_framework',
-                                                                 DEFAULT_LEAN_DOTNET_FRAMEWORK)
-            run_options["commands"].append(f"dotnet new classlib -o /ModulesProject -f {framework_ver} --no-restore")
-            run_options["commands"].append("rm /ModulesProject/Class1.cs")
-
-            # Add all modules to the project, automatically resolving all dependencies
-            for package in installed_packages:
-                self._logger.debug(f"LeanRunner.run_lean(): Adding module {package} to the project")
-                run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
-                run_options["commands"].append(
-                    f"dotnet add /ModulesProject package {package.name} --version {package.version}")
-
-            # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
-            run_options["commands"].append(
-                "python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
+        set_up_common_csharp_options_called = self._setup_installed_packages(run_options, image)
 
         # Set up language-specific run options
         self.setup_language_specific_run_options(run_options, project_dir, algorithm_file,
                                                  set_up_common_csharp_options_called, release,
                                                  image)
 
-        # Save the final Lean config to a temporary file so we can mount it into the container
-        config_path = self._temp_manager.create_temporary_directory() / "config.json"
-        with config_path.open("w+", encoding="utf-8") as file:
-            file.write(dumps(lean_config, indent=4))
-
-        # Mount the Lean config
-        run_options["mounts"].append(Mount(target=f"{LEAN_ROOT_PATH}/config.json",
-                                           source=str(config_path),
-                                           type="bind",
-                                           read_only=True))
-
-        # Assign the container a name and store it in the output directory's configuration
-        if "container-name" in lean_config:
-            run_options["name"] = lean_config["container-name"]
-        else:
-            run_options["name"] = f"lean_cli_{str(uuid4()).replace('-', '')}"
-
-        # set the hostname
-        if "hostname" in lean_config:
-            run_options["hostname"] = lean_config["hostname"]
-
-        output_config = self._output_config_manager.get_output_config(output_dir)
-        output_config.set("container", run_options["name"])
-        if "backtest-name" in lean_config:
-            output_config.set("backtest-name", lean_config["backtest-name"])
-        if "environment" in lean_config and "environments" in lean_config:
-            environment = lean_config["environments"][lean_config["environment"]]
-            if "live-mode-brokerage" in environment:
-                output_config.set("brokerage", environment["live-mode-brokerage"].split(".")[-1])
+        self._mount_lean_config_and_finalize(run_options, lean_config, output_dir)
 
         return run_options
 
@@ -393,68 +262,145 @@ class LeanRunner:
         :return: the Docker configuration containing basic configuration to run Lean
         :param paths_to_mount: additional paths to mount to the container
         """
+
+        docker_project_config = { "docker": {} }
+        # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
+        data_dir = self._lean_config_manager.get_data_directory()
+        self._handle_data_providers(lean_config, data_dir)
+
+        # Create the storage directory if it doesn't exist yet
+        storage_dir = self._lean_config_manager.get_cli_root_directory() / "storage"
+        self._ensure_directories_exist([storage_dir])
+
+        lean_config.update({
+            "debug-mode": self._logger.debug_logging_enabled,
+            "data-folder": "/Lean/Data",
+            "results-destination-folder": "/Results",
+            "object-store-root": "/Storage"
+        })
+
+        run_options = self._initialize_run_options(detach, docker_project_config, debugging_method)
+
+        self._mount_common_directories(run_options, paths_to_mount, lean_config, data_dir, storage_dir, None, None)
+
+        # Update all hosts that need to point to the host's localhost to host.docker.internal so they resolve properly
+        # TODO: we should remove it or add to config json 
+        for key in ["terminal-link-server-host"]:
+            if key not in lean_config:
+                continue
+
+            if lean_config[key] == "localhost" or lean_config[key] == "127.0.0.1":
+                lean_config[key] = "host.docker.internal"
+
+        # Set up modules
+        self._setup_installed_packages(run_options, image, target_path)
+
+        self._mount_lean_config_and_finalize(run_options, lean_config, None)
+
+        return run_options
+    
+    def _mount_lean_config_and_finalize(self, run_options: Dict[str, Any], lean_config: Dict[str, Any], output_dir: Optional[Path]):
+        """Mounts Lean config and finalizes."""
         from docker.types import Mount
         from uuid import uuid4
         from json import dumps
 
-        docker_project_config = {
-            "docker": {}
-        }
-        # Force the use of the LocalDisk map/factor providers if no recent zip present and not using ApiDataProvider
-        data_dir = self._lean_config_manager.get_data_directory()
-        if lean_config.get("data-provider", None) != "QuantConnect.Lean.Engine.DataFeeds.ApiDataProvider":
-            self._force_disk_provider_if_necessary(lean_config,
-                                                   "map-file-provider",
-                                                   "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
-                                                   "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
-                                                   data_dir / "equity" / "usa" / "map_files")
-            self._force_disk_provider_if_necessary(lean_config,
-                                                   "factor-file-provider",
-                                                   "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
-                                                   "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
-                                                   data_dir / "equity" / "usa" / "factor_files")
+        # Save the final Lean config to a temporary file so we can mount it into the container
+        config_path = self._temp_manager.create_temporary_directory() / "config.json"
+        with config_path.open("w+", encoding="utf-8") as file:
+            file.write(dumps(lean_config, indent=4))
+            
+        # Mount the Lean config
+        run_options["mounts"].append(Mount(target=f"{LEAN_ROOT_PATH}/config.json",
+                                           source=str(config_path),
+                                           type="bind",
+                                           read_only=True))
+        
+        # Assign the container a name and store it in the output directory's configuration
+        run_options["name"] = lean_config.get("container-name", f"lean_cli_{str(uuid4()).replace('-', '')}")
+        
+        # set the hostname
+        if "hostname" in lean_config:
+            run_options["hostname"] = lean_config["hostname"]
 
-        # Create the storage directory if it doesn't exist yet
-        storage_dir = self._lean_config_manager.get_cli_root_directory() / "storage"
-        if not storage_dir.exists():
-            storage_dir.mkdir(parents=True)
+        if output_dir:
+            output_config = self._output_config_manager.get_output_config(output_dir)
+            output_config.set("container", run_options["name"])
+            if "backtest-name" in lean_config:
+                output_config.set("backtest-name", lean_config["backtest-name"])
+            if "environment" in lean_config and "environments" in lean_config:
+                environment = lean_config["environments"][lean_config["environment"]]
+                if "live-mode-brokerage" in environment:
+                    output_config.set("brokerage", environment["live-mode-brokerage"].split(".")[-1])
+    
+    def _setup_installed_packages(self, run_options: Dict[str, Any], image: DockerImage, target_path: str = "/Lean/Launcher/bin/Debug"):
+        """Sets up installed packages."""
+        installed_packages = self._module_manager.get_installed_packages()
+        if installed_packages:
+            self._logger.debug(f"LeanRunner._setup_installed_packages(): installed packages {len(installed_packages)}")
+            self.set_up_common_csharp_options(run_options, target_path)
 
-        lean_config["debug-mode"] = self._logger.debug_logging_enabled
-        lean_config["data-folder"] = "/Lean/Data"
-        lean_config["results-destination-folder"] = "/Results"
-        lean_config["object-store-root"] = "/Storage"
+        # Mount the modules directory
+        run_options["volumes"][MODULES_DIRECTORY] = {"bind": "/Modules", "mode": "ro"}
 
-        # The dict containing all options passed to `docker run`
-        # See all available options at https://docker-py.readthedocs.io/en/stable/containers.html
-        run_options: Dict[str, Any] = {
-            "detach": detach,
-            "commands": [],
-            "environment": docker_project_config.get("environment", {}),
-            "stop_signal": "SIGINT" if debugging_method is None else "SIGKILL",
-            "mounts": [],
-            "volumes": {},
-            "ports": docker_project_config.get("ports", {})
-        }
+        # Add the modules directory as a NuGet source root
+        run_options["commands"].append("dotnet nuget add source /Modules")
+        # Create a C# project used to resolve the dependencies of the modules
+        run_options["commands"].append("mkdir /ModulesProject")
+        run_options["commands"].append("dotnet new sln -o /ModulesProject")
+        
+        framework_ver = self._docker_manager.get_image_label(image, 'target_framework', DEFAULT_LEAN_DOTNET_FRAMEWORK)
+        run_options["commands"].append(f"dotnet new classlib -o /ModulesProject -f {framework_ver} --no-restore")
+        run_options["commands"].append("rm /ModulesProject/Class1.cs")
 
-        # mount the paths passed in
+        # Add all modules to the project, automatically resolving all dependencies
+        for package in installed_packages:
+            self._logger.debug(f"LeanRunner._setup_installed_packages(): Adding module {package} to the project")
+            run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
+            run_options["commands"].append(f"dotnet add /ModulesProject package {package.name} --version {package.version}")
+
+        # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
+        run_options["commands"].append("python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
+        
+        return bool(installed_packages)
+    
+    def _mount_common_directories(self, 
+                                  run_options: Dict[str, Any], 
+                                  paths_to_mount: Optional[Dict[str, str]], 
+                                  lean_config: Dict[str, Any], 
+                                  data_dir: Path,
+                                  storage_dir: Path,
+                                  project_dir: Optional[Path], 
+                                  output_dir: Optional[Path]):
+        """
+        Mounts common directories.
+
+        1. mount the paths passed in
+        2. mount the project and library directories (param: `project_dir` is not None)
+        3. mount the data directory
+        4. mount the output directory (param: `output_dir` is not None)
+        5. mount the local object store directory
+        6. mount all local files referenced in the Lean config
+        """
+        from docker.types import Mount
+
+        # 1
         self.mount_paths(paths_to_mount, lean_config, run_options)
-
-        # mount the project and library directories
-        #self.mount_project_and_library_directories(project_dir, run_options)
-
-        # Mount the data directory
-        run_options["volumes"][str(data_dir)] = {
-            "bind": "/Lean/Data",
-            "mode": "rw"
-        }
-
-        # Mount the local object store directory
-        run_options["volumes"][str(storage_dir)] = {
-            "bind": "/Storage",
-            "mode": "rw"
-        }
-
-        # Mount all local files referenced in the Lean config
+        
+        # 2
+        if project_dir:
+            self.mount_project_and_library_directories(project_dir, run_options)
+        
+        # 3
+        run_options["volumes"][str(data_dir)] = {"bind": "/Lean/Data", "mode": "rw"}
+        
+        # 4
+        if output_dir:
+            run_options["volumes"][str(output_dir)] = {"bind": "/Results", "mode": "rw"}
+        # 5
+        run_options["volumes"][str(storage_dir)] = { "bind": "/Storage", "mode": "rw"}
+        
+        # 6
         cli_root_dir = self._lean_config_manager.get_cli_root_directory()
         files_to_mount = [
             ("transaction-log", cli_root_dir),
@@ -476,72 +422,43 @@ class LeanRunner:
                                                read_only=False))
 
             lean_config[key] = f"/Files/{key}"
-
-        # Update all hosts that need to point to the host's localhost to host.docker.internal so they resolve properly
-        for key in ["terminal-link-server-host"]:
-            if key not in lean_config:
-                continue
-
-            if lean_config[key] == "localhost" or lean_config[key] == "127.0.0.1":
-                lean_config[key] = "host.docker.internal"
-
-        # Set up modules
-        installed_packages = self._module_manager.get_installed_packages()
-        if len(installed_packages) > 0:
-            self._logger.debug(f"LeanRunner.run_lean(): installed packages {len(installed_packages)}")
-            self.set_up_common_csharp_options(run_options, target_path)
-
-            # Mount the modules directory
-            run_options["volumes"][MODULES_DIRECTORY] = {
-                "bind": "/Modules",
-                "mode": "ro"
-            }
-
-            # Add the modules directory as a NuGet source root
-            run_options["commands"].append("dotnet nuget add source /Modules")
-
-            # Create a C# project used to resolve the dependencies of the modules
-            run_options["commands"].append("mkdir /ModulesProject")
-            run_options["commands"].append("dotnet new sln -o /ModulesProject")
-
-            framework_ver = self._docker_manager.get_image_label(image, 'target_framework',
-                                                                 DEFAULT_LEAN_DOTNET_FRAMEWORK)
-            run_options["commands"].append(f"dotnet new classlib -o /ModulesProject -f {framework_ver} --no-restore")
-            run_options["commands"].append("rm /ModulesProject/Class1.cs")
-
-            # Add all modules to the project, automatically resolving all dependencies
-            for package in installed_packages:
-                self._logger.debug(f"LeanRunner.run_lean(): Adding module {package} to the project")
-                run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
-                run_options["commands"].append(
-                    f"dotnet add /ModulesProject package {package.name} --version {package.version}")
-
-            # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
-            run_options["commands"].append(
-                "python /copy_csharp_dependencies.py /Compile/obj/ModulesProject/project.assets.json")
+    
+    def _initialize_run_options(self, detach: bool, docker_project_config: Dict[str, Any], debugging_method: Optional[DebuggingMethod]):
+        """
+        Initializes run options.
         
-        # Save the final Lean config to a temporary file so we can mount it into the container
-        config_path = self._temp_manager.create_temporary_directory() / "config.json"
-        with config_path.open("w+", encoding="utf-8") as file:
-            file.write(dumps(lean_config, indent=4))
-
-        # Mount the Lean config
-        run_options["mounts"].append(Mount(target=f"{LEAN_ROOT_PATH}/config.json",
-                                           source=str(config_path),
-                                           type="bind",
-                                           read_only=True))
-
-        # Assign the container a name and store it in the output directory's configuration
-        if "container-name" in lean_config:
-            run_options["name"] = lean_config["container-name"]
-        else:
-            run_options["name"] = f"lean_cli_{str(uuid4()).replace('-', '')}"
-
-        # set the hostname
-        if "hostname" in lean_config:
-            run_options["hostname"] = lean_config["hostname"]
-
-        return run_options
+        The dict containing all options passed to `docker run`
+        See all available options at https://docker-py.readthedocs.io/en/stable/containers.html
+        """
+        return {
+            "detach": detach,
+            "commands": [],
+            "environment": docker_project_config.get("environment", {}),
+            "stop_signal": "SIGINT" if debugging_method is None else "SIGKILL",
+            "mounts": [],
+            "volumes": {},
+            "ports": docker_project_config.get("ports", {})
+        }
+    
+    def _ensure_directories_exist(self, dirs: List[Path]):
+        """Ensures directories exist."""
+        for dir_path in dirs:
+            if not dir_path.exists():
+                dir_path.mkdir(parents=True)
+    
+    def _handle_data_providers(self, lean_config: Dict[str, Any], data_dir: Path):
+        """Handles data provider logic."""
+        if lean_config.get("data-provider", None) != "QuantConnect.Lean.Engine.DataFeeds.ApiDataProvider":
+            self._force_disk_provider_if_necessary(lean_config,
+                                                   "map-file-provider",
+                                                   "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
+                                                   "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
+                                                   data_dir / "equity" / "usa" / "map_files")
+            self._force_disk_provider_if_necessary(lean_config,
+                                                   "factor-file-provider",
+                                                   "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
+                                                   "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
+                                                   data_dir / "equity" / "usa" / "factor_files")
 
     def set_up_python_options(self, project_dir: Path, run_options: Dict[str, Any], image: DockerImage) -> None:
         """Sets up Docker run options specific to Python projects.

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -896,6 +896,8 @@ for library_id, library_data in project_assets["targets"][project_target].items(
         environment = {}
         if "environment" in lean_config and "environments" in lean_config:
             environment = lean_config["environments"][lean_config["environment"]]
+        else:
+            environment = lean_config
         mounts = run_options["mounts"]
 
         for key, pathStr in paths_to_mount.items():

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -122,6 +122,3 @@ SECURITY_TYPES = [ "Equity", "Index", "Option", "IndexOption", "Commodity", "For
 
 # Lean Data folder path, where keeps tickers data
 DATA_FOLDER_PATH = "/Lean/Data"
-
-# Key in JSON configuration for data downloader settings.
-DATA_PROVIDER_DOWNLOAD_CONFIG_KEY = "data-downloader"

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -107,15 +107,3 @@ MODULE_DATA_QUEUE_HANDLER = "data-queue-handler"
 # platforms
 MODULE_CLI_PLATFORM = "cli"
 MODULE_CLOUD_PLATFORM = "cloud"
-
-# Lean Resolution
-RESOLUTIONS = ["Tick", "Second", "Minute", "Hour", "Daily"]
-
-# Lean Data Types
-DATA_TYPES = ["Trade", "Quote", "OpenInterest"]
-
-# Lean Security Types
-SECURITY_TYPES = [ "Equity", "Index", "Option", "IndexOption", "Commodity", "Forex", "Future", "Cfd", "Crypto", "FutureOption", "CryptoFuture" ]
-
-# Lean Data folder path, where keeps tickers data
-DATA_FOLDER_PATH = "/Lean/Data"

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -111,9 +111,6 @@ MODULE_CLOUD_PLATFORM = "cloud"
 # Lean Resolution
 RESOLUTIONS = ["Tick", "Second", "Minute", "Hour", "Daily"]
 
-# Lean Resolution
-RESOLUTIONS = ["Tick", "Second", "Minute", "Hour", "Daily"]
-
 # Lean Data Types
 DATA_TYPES = ["Trade", "Quote", "OpenInterest"]
 

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -119,3 +119,6 @@ DATA_TYPES = ["Trade", "Quote", "OpenInterest"]
 
 # Lean Security Types
 SECURITY_TYPES = [ "Equity", "Index", "Option", "IndexOption", "Commodity", "Forex", "Future", "Cfd", "Crypto", "FutureOption", "CryptoFuture" ]
+
+# Lean Data folder path, where keeps tickers data
+DATA_FOLDER_PATH = "/Lean/Data"

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -107,3 +107,15 @@ MODULE_DATA_QUEUE_HANDLER = "data-queue-handler"
 # platforms
 MODULE_CLI_PLATFORM = "cli"
 MODULE_CLOUD_PLATFORM = "cloud"
+
+# Lean Resolution
+RESOLUTIONS = ["Tick", "Second", "Minute", "Hour", "Daily"]
+
+# Lean Resolution
+RESOLUTIONS = ["Tick", "Second", "Minute", "Hour", "Daily"]
+
+# Lean Data Types
+DATA_TYPES = ["Trade", "Quote", "OpenInterest"]
+
+# Lean Security Types
+SECURITY_TYPES = [ "Equity", "Index", "Option", "IndexOption", "Commodity", "Forex", "Future", "Cfd", "Crypto", "FutureOption", "CryptoFuture" ]

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -122,3 +122,6 @@ SECURITY_TYPES = [ "Equity", "Index", "Option", "IndexOption", "Commodity", "For
 
 # Lean Data folder path, where keeps tickers data
 DATA_FOLDER_PATH = "/Lean/Data"
+
+# Key in JSON configuration for data downloader settings.
+DATA_PROVIDER_DOWNLOAD_CONFIG_KEY = "data-downloader"

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -407,14 +407,53 @@ class QCMinimalOrganization(WrappedBaseModel):
     preferred: bool
 
 
+class QCDataType(str, Enum):
+    Trade = "Trade"
+    Quote = "Quote"
+    OpenInterest = "OpenInterest"
+
+    @classmethod
+    def get_all_members(cls):
+        """
+        Retrieve all members (values) of the QCDataType enumeration.
+
+        Returns:
+        list: A list containing all the values of the QCDataType enumeration.
+
+        Example:
+        >>> all_data_types = QCDataType.get_all_members()
+        >>> print(all_data_types)
+        ['Trade', 'Quote', 'OpenInterest']
+        """
+        return list(cls.__members__.values())
+
 class QCSecurityType(str, Enum):
     Equity = "Equity"
+    Index = "Index"
     Forex = "Forex"
     CFD = "Cfd"
     Future = "Future"
     Crypto = "Crypto"
+    CryptoFuture = "CryptoFuture"
     Option = "Option"
+    IndexOption = "IndexOption"
+    Commodity = "Commodity"
     FutureOption = "FutureOption"
+
+    @classmethod
+    def get_all_members(cls):
+        """
+        Retrieve all members (values) of the QCSecurityType enumeration.
+
+        Returns:
+        list: A list containing all the values of the QCSecurityType enumeration.
+
+        Example:
+        >>> all_security_types = QCSecurityType.get_all_members()
+        >>> print(all_security_types)
+        ['Equity', 'Index', 'Forex', 'Cfd', 'Future', 'Crypto', 'CryptoFuture', 'Option', 'IndexOption', 'Commodity', 'FutureOption']
+        """
+        return list(cls.__members__.values())
 
 
 class QCResolution(str, Enum):
@@ -435,6 +474,21 @@ class QCResolution(str, Enum):
             if k.lower() == name.lower():
                 return v
         raise ValueError(f"QCResolution has no member named '{name}'")
+
+    @classmethod
+    def get_all_members(cls):
+        """
+        Retrieve all members (values) of the QCResolution enumeration.
+
+        Returns:
+        list: A list containing all the values of the QCResolution enumeration.
+
+        Example:
+        >>> all_resolutions = QCResolution.get_all_members()
+        >>> print(all_resolutions)
+        ['Tick', 'Second', 'Minute', 'Hour', 'Daily']
+        """
+        return list(cls.__members__.values())
 
 
 class QCLink(WrappedBaseModel):

--- a/lean/models/click_options.py
+++ b/lean/models/click_options.py
@@ -29,6 +29,8 @@ def get_configs_for_options(env: str) -> List[Configuration]:
         brokerage = cli_data_downloaders
     elif env == "research":
         brokerage = cli_data_downloaders
+    elif env == "download":
+        brokerage = cli_data_downloaders
     else:
         raise ValueError("Acceptable values for 'env' are: 'live-cloud', 'live-cli', 'backtest', 'research'")
 

--- a/lean/models/data.py
+++ b/lean/models/data.py
@@ -230,6 +230,11 @@ class DatasetDateOption(DatasetOption):
         date = prompt(f"{self.label} (yyyyMMdd)", type=DateParameter())
         return OptionResult(value=date, label=date.strftime("%Y-%m-%d"))
 
+    def configure_interactive_with_default(self, default_date: str) -> OptionResult:
+        date = prompt(f"{self.label} (yyyyMMdd) or just press Enter to use the default date [{default_date}]",
+                      show_default=False, default=default_date, type=DateParameter())
+        return OptionResult(value=date, label=date.strftime("%Y-%m-%d"))
+
     def configure_non_interactive(self, user_input: str) -> OptionResult:
         for date_format in ["%Y%m%d", "%Y-%m-%d"]:
             try:

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -37,6 +37,7 @@ class JsonModule(ABC):
         self._product_id: int = json_module_data["product-id"] if "product-id" in json_module_data else 0
         self._id: str = json_module_data["id"]
         self._display_name: str = json_module_data["display-id"]
+        self._specifications_url: str = json_module_data["specifications"] if "specifications" in json_module_data else None
         self._installs: bool = json_module_data["installs"] if ("installs" in json_module_data
                                                                 and platform == MODULE_CLI_PLATFORM) else False
         self._lean_configs: List[Configuration] = []

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -262,6 +262,10 @@ class JsonModule(ABC):
         from lean.container import container
         container.lean_config_manager.set_properties(settings)
 
+    @property
+    def specifications_url(self):
+        return self._specifications_url
+
 
 class LiveInitialStateInput(str, Enum):
     Required = "required"

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -51,19 +51,25 @@ def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]
 
     if is_crypto_configs:
         return {
-            "data-types": ["Trade", "Quote"],
-            "data-resolutions": ["Minute", "Hour", "Daily"],
-            "data-supported": ["Crypto", "CryptoFuture"],
-            "data-markets": ["Binance", "Kraken"]
+            "module-specification": {
+                "download": {
+                    "data-types": ["Trade", "Quote"],
+                    "data-resolutions": ["Minute", "Hour", "Daily"],
+                    "data-supported": ["Crypto", "CryptoFuture"],
+                    "data-markets": ["Binance", "Kraken"]
+                }
+            }
         }
 
     data_provider_config_file_json: Dict[str, Any] = {
-        "data-types": ["Trade", "Quote"],  # Supported data types: Trade and Quote
-        "data-resolutions": ["Second", "Minute", "Hour", "Daily"],
-        # Supported data resolutions: Second, Minute, Hour, Daily
-        "data-supported": ["Equity", "Option", "Index", "IndexOption"],
-        # Supported asset classes: Equity, Equity Options, Indexes, Index Options
-        "data-markets": ["NYSE", "USA"]
+        "module-specification": {
+            "download": {
+                "data-types": ["Trade", "Quote"],
+                "data-resolutions": ["Second", "Minute", "Hour", "Daily"],
+                "data-supported": ["Equity", "Option", "Index", "IndexOption"],
+                "data-markets": ["NYSE", "USA"]
+            }
+        }
     }
 
     return data_provider_config_file_json

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -18,11 +18,13 @@ from tests.conftest import initialize_container
 
 test_files = Path(os.path.join(os.path.dirname(os.path.realpath(__file__)), "testFiles"))
 
+
 # Load in our test files into fake filesystem
 @pytest.fixture
 def setup(fs):
     fs.add_real_directory(test_files, read_only=False)
     yield fs
+
 
 def test_bulk_extraction(setup):
     fake_tar = Path(os.path.join(test_files, "20220222_coinapi_crypto_ftx_price_aggregation.tar"))
@@ -35,16 +37,17 @@ def test_bulk_extraction(setup):
     file = os.path.join(out, "crypto/ftx/daily/imxusd_trade.zip")
     assert os.path.exists(file)
 
+
 def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]:
     """
-	Retrieve the configuration settings for a financial data provider.
+    Retrieve the configuration settings for a financial data provider.
 
-	This method encapsulates the configuration settings typically found in a data provider config JSON file,
-	as referenced by a file named <provider_name>.json in an example from a GitHub repository.
+    This method encapsulates the configuration settings typically found in a data provider config JSON file,
+    as referenced by a file named <provider_name>.json in an example from a GitHub repository.
 
-	Returns:
-	Dict[str, Any]: Configuration settings including supported data types, resolutions, and asset classes.
-	"""
+    Returns:
+        Dict[str, Any]: Configuration settings including supported data types, resolutions, and asset classes.
+    """
 
     if is_crypto_configs:
         return {
@@ -62,22 +65,23 @@ def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]
         # Supported asset classes: Equity, Equity Options, Indexes, Index Options
         "data-markets": ["NYSE", "USA"]
     }
-    
-	return data_provider_config_file_json
+
+    return data_provider_config_file_json
+
 
 def _create_lean_data_download(data_provider_name: str,
-							  data_type: str,
-							  resolution: str,
-							  security_type: str,
-							  tickers: List[str],
-							  start_date: str,
-							  end_date: str,
-							  data_provider_config_file_json: Dict[str, Any],
-							  market: str = None,
-							  extra_run_command: List[str] = None):
-	"""
+                               data_type: str,
+                               resolution: str,
+                               security_type: str,
+                               tickers: List[str],
+                               start_date: str,
+                               end_date: str,
+                               data_provider_config_file_json: Dict[str, Any],
+                               market: str = None,
+                               extra_run_command: List[str] = None):
+    """
     Create a data download command for the Lean algorithmic trading engine.
-    
+
     This method constructs and invokes a Lean CLI command to download historical data from a specified data provider.
     It utilizes a mock data provider configuration JSON and may include extra run commands if provided.
 
@@ -95,12 +99,12 @@ def _create_lean_data_download(data_provider_name: str,
     Returns:
     CompletedProcess: Result of the Lean CLI command execution.
     """
-	# add additional property in module config file
-	for data_provider in cli_data_downloaders:
-		data_provider.__setattr__("_specifications_url", "")
+    # add additional property in module config file
+    for data_provider in cli_data_downloaders:
+        data_provider.__setattr__("_specifications_url", "")
 
-	create_fake_lean_cli_directory()
-	container = initialize_container()
+    create_fake_lean_cli_directory()
+    container = initialize_container()
 
     with mock.patch.object(container.lean_runner, "get_basic_docker_config_without_algo",
                            return_value={"commands": [], "mounts": []}):
@@ -122,57 +126,80 @@ def _create_lean_data_download(data_provider_name: str,
                 if extra_run_command:
                     run_parameters += extra_run_command
 
-			return CliRunner().invoke(lean, run_parameters)
+                return CliRunner().invoke(lean, run_parameters)
+
 
 @pytest.mark.parametrize("data_provider,market,is_crypto,security_type,tickers,data_provider_parameters",
-						 [("Polygon", "NYSE", False, "Equity", ["AAPL"], ["--polygon-api-key", "123"]),
-						  ("Binance", "Binance", True, "CryptoFuture", ["BTCUSDT"], ["--binance-exchange-name", "BinanceUS", "--binanceus-api-key", "123", "--binanceus-api-secret", "123"]),
-						  ("CoinApi", "Kraken", True, "Crypto", ["BTCUSDC", "ETHUSD"], ["--coinapi-api-key", "123", "--coinapi-product", "Free"]),
-						  ("Interactive Brokers", "USA", False, "Index", ["INTL","NVDA"], ["--ib-user-name", "123", "--ib-account", "Individual", "--ib-password", "123"])])
-def test_download_data_non_interactive(data_provider: str, market: str, is_crypto: bool, security_type: str, tickers: List[str], data_provider_parameters: List[str]):
-	run_data_download = _create_lean_data_download(
-		data_provider, "Trade", "Minute", security_type, tickers, "20240101", "20240202", _get_data_provider_config(is_crypto), market, data_provider_parameters)
-	assert run_data_download.exit_code == 0
+                         [("Polygon", "NYSE", False, "Equity", ["AAPL"], ["--polygon-api-key", "123"]),
+                          ("Binance", "Binance", True, "CryptoFuture", ["BTCUSDT"],
+                           ["--binance-exchange-name", "BinanceUS", "--binanceus-api-key", "123",
+                            "--binanceus-api-secret", "123"]),
+                          ("CoinApi", "Kraken", True, "Crypto", ["BTCUSDC", "ETHUSD"],
+                           ["--coinapi-api-key", "123", "--coinapi-product", "Free"]),
+                          ("Interactive Brokers", "USA", False, "Index", ["INTL", "NVDA"],
+                           ["--ib-user-name", "123", "--ib-account", "Individual", "--ib-password", "123"])])
+def test_download_data_non_interactive(data_provider: str, market: str, is_crypto: bool, security_type: str,
+                                       tickers: List[str], data_provider_parameters: List[str]):
+    run_data_download = _create_lean_data_download(
+        data_provider, "Trade", "Minute", security_type, tickers, "20240101", "20240202",
+        _get_data_provider_config(is_crypto), market, data_provider_parameters)
+    assert run_data_download.exit_code == 0
+
 
 @pytest.mark.parametrize("data_provider,market,is_crypto,security_type,missed_parameters",
-						 [("Polygon", "NYSE", False, "Equity", "--polygon-api-key"),
-						  ("Binance", "Binance", True, "Crypto", "--binance-exchange-name"),
-						  ("Interactive Brokers", "USA", False, "Equity", "--ib-user-name, --ib-account, --ib-password")])
-def test_download_data_non_interactive_data_provider_missed_param(data_provider: str, market: str, is_crypto: bool, security_type: str, missed_parameters: str):
-	run_data_download = _create_lean_data_download(data_provider, "Trade", "Minute", security_type, ["AAPL"], "20240101", "20240202", _get_data_provider_config(is_crypto), market)
-	assert run_data_download.exit_code == 1
-	
-	error_msg = str(run_data_download.exc_info[1])
-	assert missed_parameters in error_msg
+                         [("Polygon", "NYSE", False, "Equity", "--polygon-api-key"),
+                          ("Binance", "Binance", True, "Crypto", "--binance-exchange-name"),
+                          ("Interactive Brokers", "USA", False, "Equity",
+                           "--ib-user-name, --ib-account, --ib-password")])
+def test_download_data_non_interactive_data_provider_missed_param(data_provider: str, market: str, is_crypto: bool,
+                                                                  security_type: str, missed_parameters: str):
+    run_data_download = _create_lean_data_download(data_provider, "Trade", "Minute", security_type, ["AAPL"],
+                                                   "20240101", "20240202", _get_data_provider_config(is_crypto), market)
+    assert run_data_download.exit_code == 1
+
+    error_msg = str(run_data_download.exc_info[1])
+    assert missed_parameters in error_msg
+
 
 @pytest.mark.parametrize("data_provider,wrong_security_type",
-						 [("Polygon", "Future"),("Polygon", "Crypto"),("Polygon", "Forex")])
+                         [("Polygon", "Future"), ("Polygon", "Crypto"), ("Polygon", "Forex")])
 def test_download_data_non_interactive_wrong_security_type(data_provider: str, wrong_security_type: str):
-	run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", wrong_security_type, ["AAPL"], "20240101", "20240202", _get_data_provider_config(), extra_run_command=["--polygon-api-key", "123"])
-	assert run_data_download.exit_code == 1
-	
-	error_msg = str(run_data_download.exc_info[1])
-	assert f"The {data_provider} data provider does not support {wrong_security_type}." in error_msg
+    run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", wrong_security_type, ["AAPL"],
+                                                   "20240101", "20240202", _get_data_provider_config(),
+                                                   extra_run_command=["--polygon-api-key", "123"])
+    assert run_data_download.exit_code == 1
 
-@pytest.mark.parametrize("data_provider,start_date,end_date", [("Polygon", "20240101", "20230202"), ("Polygon", "2024-01-01", "2023-02-02")])
+    error_msg = str(run_data_download.exc_info[1])
+    assert f"The {data_provider} data provider does not support {wrong_security_type}." in error_msg
+
+
+@pytest.mark.parametrize("data_provider,start_date,end_date",
+                         [("Polygon", "20240101", "20230202"), ("Polygon", "2024-01-01", "2023-02-02")])
 def test_download_data_non_interactive_wrong_start_end_date(data_provider: str, start_date: str, end_date: str):
-	run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", "Equity", ["AAPL"], start_date, end_date, _get_data_provider_config(), "USA", extra_run_command=["--polygon-api-key", "123"])
-	assert run_data_download.exit_code == 1
+    run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", "Equity", ["AAPL"], start_date,
+                                                   end_date, _get_data_provider_config(), "USA",
+                                                   extra_run_command=["--polygon-api-key", "123"])
+    assert run_data_download.exit_code == 1
 
-	error_msg = str(run_data_download.exc_info[1])
-	assert f"Historical start date cannot be greater than or equal to historical end date." in error_msg
+    error_msg = str(run_data_download.exc_info[1])
+    assert f"Historical start date cannot be greater than or equal to historical end date." in error_msg
 
-@pytest.mark.parametrize("wrong_data_type",[("OpenInterest")])
+
+@pytest.mark.parametrize("wrong_data_type", [("OpenInterest")])
 def test_download_data_non_interactive_wrong_data_type(wrong_data_type: str):
-	run_data_download = _create_lean_data_download("Polygon", wrong_data_type, "Hour", "Equity", ["AAPL"], "20240101", "20240202", _get_data_provider_config(), extra_run_command=["--polygon-api-key", "123"])
-	assert run_data_download.exit_code == 1
-	
-	error_msg = str(run_data_download.exc_info[1])
-	assert f"The Polygon data provider does not support {wrong_data_type}." in error_msg
+    run_data_download = _create_lean_data_download("Polygon", wrong_data_type, "Hour", "Equity", ["AAPL"], "20240101",
+                                                   "20240202", _get_data_provider_config(),
+                                                   extra_run_command=["--polygon-api-key", "123"])
+    assert run_data_download.exit_code == 1
+
+    error_msg = str(run_data_download.exc_info[1])
+    assert f"The Polygon data provider does not support {wrong_data_type}." in error_msg
+
 
 def test_non_interactive_bulk_select():
-	# TODO
+    # TODO
     pass
+
 
 def test_interactive_bulk_select():
     pytest.skip("This test is interactive")
@@ -189,21 +216,26 @@ def test_interactive_bulk_select():
     products = _select_products_interactive(organization, testSets)
     # No assertion, since interactive has multiple results
 
+
 def test_dataset_requirements():
 	organization = create_api_organization()
 	datasource = json.loads(bulk_datasource)
 	testSet = Dataset(name="testSet",
+    organization = create_api_organization()
+    datasource = json.loads(bulk_datasource)
+    testSet = Dataset(name="testSet",
                       vendor="testVendor",
                       categories=["testData"],
                       options=datasource["options"],
                       paths=datasource["paths"],
                       requirements=datasource.get("requirements", {}))
-    
-	for id, name in testSet.requirements.items():
-		assert not organization.has_security_master_subscription(id)
-	assert id==39
 
-bulk_datasource="""
+    for id, name in testSet.requirements.items():
+        assert not organization.has_security_master_subscription(id)
+    assert id == 39
+
+
+bulk_datasource = """
 {
 	"requirements": {
         "39": "quantconnect-us-equity-security-master"
@@ -389,15 +421,16 @@ bulk_datasource="""
 }
 """
 
-def test_validate_datafile() -> None:
 
-	try:
-		value = "/^equity\\/usa\\/(factor_files|map_files)\\/[^\\/]+.zip$/m"
-		target = re.compile(value[value.index("/") + 1:value.rindex("/")])
-		vendor = QCDataVendor(vendorName="Algoseek", regex=target)
-		DataFile(file='equity/usa/daily/aal.zip', vendor=vendor)
-	except Exception as err:
-		pytest.fail(f"{err}")
+def test_validate_datafile() -> None:
+    try:
+        value = "/^equity\\/usa\\/(factor_files|map_files)\\/[^\\/]+.zip$/m"
+        target = re.compile(value[value.index("/") + 1:value.rindex("/")])
+        vendor = QCDataVendor(vendorName="Algoseek", regex=target)
+        DataFile(file='equity/usa/daily/aal.zip', vendor=vendor)
+    except Exception as err:
+        pytest.fail(f"{err}")
+
 
 def test_filter_pending_datasets() -> None:
     from lean.commands.data.download import _get_available_datasets, _get_data_information

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -36,7 +36,7 @@ def test_bulk_extraction(setup):
     assert os.path.exists(file)
 
 def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]:
-	"""
+    """
 	Retrieve the configuration settings for a financial data provider.
 
 	This method encapsulates the configuration settings typically found in a data provider config JSON file,
@@ -46,19 +46,21 @@ def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]
 	Dict[str, Any]: Configuration settings including supported data types, resolutions, and asset classes.
 	"""
 
-	if is_crypto_configs:
-		return {
-			"data-types": [ "Trade", "Quote" ],
-			"data-resolutions": [ "Minute", "Hour", "Daily" ],
-			"data-supported": [ "Crypto", "CryptoFuture" ],
-			"data-markets": [ "Binance", "Kraken"]
-		   }
-	
-	data_provider_config_file_json: Dict[str, Any] = {
-        "data-types": [ "Trade", "Quote" ],  # Supported data types: Trade and Quote
-        "data-resolutions": [ "Second", "Minute", "Hour", "Daily" ],  # Supported data resolutions: Second, Minute, Hour, Daily
-        "data-supported": [ "Equity", "Option", "Index", "IndexOption" ], # Supported asset classes: Equity, Equity Options, Indexes, Index Options
-		"data-markets": [ "NYSE", "USA"]
+    if is_crypto_configs:
+        return {
+            "data-types": ["Trade", "Quote"],
+            "data-resolutions": ["Minute", "Hour", "Daily"],
+            "data-supported": ["Crypto", "CryptoFuture"],
+            "data-markets": ["Binance", "Kraken"]
+        }
+
+    data_provider_config_file_json: Dict[str, Any] = {
+        "data-types": ["Trade", "Quote"],  # Supported data types: Trade and Quote
+        "data-resolutions": ["Second", "Minute", "Hour", "Daily"],
+        # Supported data resolutions: Second, Minute, Hour, Daily
+        "data-supported": ["Equity", "Option", "Index", "IndexOption"],
+        # Supported asset classes: Equity, Equity Options, Indexes, Index Options
+        "data-markets": ["NYSE", "USA"]
     }
     
 	return data_provider_config_file_json
@@ -100,22 +102,25 @@ def _create_lean_data_download(data_provider_name: str,
 	create_fake_lean_cli_directory()
 	container = initialize_container()
 
-	with mock.patch.object(container.lean_runner, "get_basic_docker_config_without_algo", return_value={ "commands": [] }):
-		with mock.patch.object(container.api_client.data, "download_public_file_json", return_value=data_provider_config_file_json):
-			run_parameters = [
-				"data", "download",
-				"--data-provider-historical", data_provider_name,
-				"--data-type", data_type,
-				"--resolution", resolution,
-				"--security-type", security_type,
-				"--tickers", ','.join(tickers),
-				"--start-date", start_date,
-				"--end-date", end_date,
-				]
-			if market:
-				run_parameters.extend(["--market", market])
-			if extra_run_command:
-				run_parameters += extra_run_command
+    with mock.patch.object(container.lean_runner, "get_basic_docker_config_without_algo",
+                           return_value={"commands": [], "mounts": []}):
+        with mock.patch.object(container.api_client.data, "download_public_file_json",
+                               return_value=data_provider_config_file_json):
+            with mock.patch.object(container.api_client.organizations, "get", return_value=create_api_organization()):
+                run_parameters = [
+                    "data", "download",
+                    "--data-provider-historical", data_provider_name,
+                    "--data-type", data_type,
+                    "--resolution", resolution,
+                    "--security-type", security_type,
+                    "--tickers", ','.join(tickers),
+                    "--start-date", start_date,
+                    "--end-date", end_date,
+                ]
+                if market:
+                    run_parameters.extend(["--market", market])
+                if extra_run_command:
+                    run_parameters += extra_run_command
 
 			return CliRunner().invoke(lean, run_parameters)
 

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -41,7 +41,8 @@ def test_download_data_non_interactive():
 	container = initialize_container()
 
 	with mock.patch.object(container.lean_runner, "get_basic_docker_config_without_algo", return_value={ "commands": [] }):
-		result = CliRunner().invoke(lean, ["data", "download", 
+		with mock.patch.object(container.api_client.data, "download_public_file_json", return_value={ "data-supported" : [ "Equity", "Equity Options", "Indexes", "Index Options" ] }):
+			result = CliRunner().invoke(lean, ["data", "download", 
 										"--data-provider-historical", "Polygon",
 										"--polygon-api-key", "123",
 										"--data-type", "Trade",
@@ -58,15 +59,19 @@ def test_download_data_non_interactive_data_provider_missed_param():
 
 	container = initialize_container()
 
+	    # with mock.patch.object(container.api_client.projects, 'get_all', return_value=cloud_projects) as mock_get_all,\
+        #  mock.patch.object(container.api_client.projects, 'delete', return_value=None) as mock_delete:
+
 	with mock.patch.object(container.lean_runner, "get_basic_docker_config_without_algo", return_value={ "commands": [] }):
-		result = CliRunner().invoke(lean, ["data", "download", 
-										"--data-provider-historical", "Polygon",
-										"--data-type", "Trade",
-										"--resolution", "Minute",
-										"--ticker-security-type", "Equity",
-										"--tickers", "AAPL",
-										"--start-date", "20240101",
-										"--end-date", "20240202"])
+		with mock.patch.object(container.api_client.data, "download_public_file_json", return_value={ "data-supported" : [ "Equity", "Equity Options", "Indexes", "Index Options" ] }):
+			result = CliRunner().invoke(lean, ["data", "download", 
+									  "--data-provider-historical", "Polygon",
+									  "--data-type", "Trade",
+									  "--resolution", "Minute",
+									  "--ticker-security-type", "Equity",
+									  "--tickers", "AAPL",
+									  "--start-date", "20240101",
+									  "--end-date", "20240202"])
 
 	assert result.exit_code == 1
 	

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -124,11 +124,7 @@ def test_download_data_non_interactive_data_provider_missed_param(data_provider:
 @pytest.mark.parametrize("data_provider,wrong_security_type",
 						 [("Polygon", "Future"),("Polygon", "Crypto"),("Polygon", "Forex")])
 def test_download_data_non_interactive_wrong_security_type(data_provider: str, wrong_security_type: str):
-	data_provider_config = {
-        "data-supported": [ "Equity", "Equity Options", "Indexes", "Index Options" ]
-    }
-
-	run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", wrong_security_type, ["AAPL"], "20240101", "20240202", data_provider_config, ["--polygon-api-key", "123"])
+	run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", wrong_security_type, ["AAPL"], "20240101", "20240202", _get_data_provider_config(), ["--polygon-api-key", "123"])
 	assert run_data_download.exit_code == 1
 	
 	error_msg = str(run_data_download.exc_info[1])

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -179,7 +179,8 @@ def test_download_data_non_interactive_wrong_security_type(data_provider: str, w
     assert run_data_download.exit_code == 1
 
     error_msg = str(run_data_download.exc_info[1])
-    assert f"The {data_provider} data provider does not support QCSecurityType.{wrong_security_type}." in error_msg
+    assert data_provider in error_msg
+    assert wrong_security_type in error_msg
 
 
 @pytest.mark.parametrize("data_provider,start_date,end_date",
@@ -194,7 +195,7 @@ def test_download_data_non_interactive_wrong_start_end_date(data_provider: str, 
     assert f"Historical start date cannot be greater than or equal to historical end date." in error_msg
 
 
-@pytest.mark.parametrize("wrong_data_type", [("OpenInterest")])
+@pytest.mark.parametrize("wrong_data_type", ["OpenInterest"])
 def test_download_data_non_interactive_wrong_data_type(wrong_data_type: str):
     run_data_download = _create_lean_data_download("Polygon", wrong_data_type, "Hour", "Equity", ["AAPL"], "20240101",
                                                    "20240202", _get_data_provider_config(),
@@ -202,7 +203,7 @@ def test_download_data_non_interactive_wrong_data_type(wrong_data_type: str):
     assert run_data_download.exit_code == 1
 
     error_msg = str(run_data_download.exc_info[1])
-    assert f"The Polygon data provider does not support QCDataType.{wrong_data_type}." in error_msg
+    assert wrong_data_type in error_msg
 
 
 def test_non_interactive_bulk_select():

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -146,21 +146,6 @@ def test_download_data_non_interactive(data_provider: str, market: str, is_crypt
     assert run_data_download.exit_code == 0
 
 
-@pytest.mark.parametrize("data_provider,market,is_crypto,security_type,missed_parameters",
-                         [("Polygon", "NYSE", False, "Equity", "--polygon-api-key"),
-                          ("Binance", "Binance", True, "Crypto", "--binance-exchange-name"),
-                          ("Interactive Brokers", "USA", False, "Equity",
-                           "--ib-user-name, --ib-account, --ib-password")])
-def test_download_data_non_interactive_data_provider_missed_param(data_provider: str, market: str, is_crypto: bool,
-                                                                  security_type: str, missed_parameters: str):
-    run_data_download = _create_lean_data_download(data_provider, "Trade", "Minute", security_type, ["AAPL"],
-                                                   "20240101", "20240202", _get_data_provider_config(is_crypto), market)
-    assert run_data_download.exit_code == 1
-
-    error_msg = str(run_data_download.exc_info[1])
-    assert missed_parameters in error_msg
-
-
 @pytest.mark.parametrize("data_type,resolution",
                          [("Trade", "Hour"), ("trade", "hour"), ("TRADE", "HOUR"), ("TrAdE", "HoUr")])
 def test_download_data_non_interactive_insensitive_input_param(data_type: str, resolution: str):

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -161,6 +161,15 @@ def test_download_data_non_interactive_data_provider_missed_param(data_provider:
     assert missed_parameters in error_msg
 
 
+@pytest.mark.parametrize("data_type,resolution",
+                         [("Trade", "Hour"), ("trade", "hour"), ("TRADE", "HOUR"), ("TrAdE", "HoUr")])
+def test_download_data_non_interactive_insensitive_input_param(data_type: str, resolution: str):
+    run_data_download = _create_lean_data_download(
+        "Polygon", data_type, resolution, "Equity", ["AAPL"], "20240101", "20240202",
+        _get_data_provider_config(False), "NYSE", ["--polygon-api-key", "123"])
+    assert run_data_download.exit_code == 0
+
+
 @pytest.mark.parametrize("data_provider,wrong_security_type",
                          [("Polygon", "Future"), ("Polygon", "Crypto"), ("Polygon", "Forex")])
 def test_download_data_non_interactive_wrong_security_type(data_provider: str, wrong_security_type: str):

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -82,6 +82,10 @@ def _create_lean_data_download(data_provider_name: str,
     Returns:
     CompletedProcess: Result of the Lean CLI command execution.
     """
+	# add additional property in module config file
+	for data_provider in cli_data_downloaders:
+		data_provider.__setattr__("_specifications_url", "")
+
 	create_fake_lean_cli_directory()
 	container = initialize_container()
 

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -1,22 +1,16 @@
 import json
 from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
-import click
 import pytest
 import os
 import re
 from pathlib import Path
 
 from lean.commands.data.download import *
-from lean.commands.data.download import _select_products_non_interactive
 from lean.container import container
 from lean.models.api import QCDataset, QCOrganizationCredit, QCOrganizationData
 from tests.test_helpers import create_api_organization
-from click.testing import CliRunner
-from lean.commands import lean
-from tests.test_helpers import create_fake_lean_cli_directory
-from tests.conftest import initialize_container
 
 test_files = Path(os.path.join(os.path.dirname(os.path.realpath(__file__)), "testFiles"))
 
@@ -37,62 +31,6 @@ def test_bulk_extraction(setup):
     file = os.path.join(out, "crypto/ftx/daily/imxusd_trade.zip")
     assert os.path.exists(file)
 
-def test_invoke_interactive():
-	create_fake_lean_cli_directory()
-	result = CliRunner().invoke(lean, ["data", "download", "--data-provider-historical", "Binance"])
-
-	assert result.exit_code == 0
-
-def test_select_products_non_interactive():
-	organization = create_api_organization()
-	datasource = json.loads(bulk_datasource)
-	testDataSet = [Dataset(name="US Equity Options",
-                      vendor="testVendor",
-                      categories=["testData"],
-                      options=datasource["options"],
-                      paths=datasource["paths"],
-                      requirements=datasource.get("requirements", {}))]
-	force = True
-
-	
-	mock_context = Mock()
-	mock_context.params = {"dataset": "US Equity Options", "data-type": "Trade", "ticker": "AAPL", "resolution": "Daily", "start": "20240101", "end": "20240404"}
-
-	products = _select_products_non_interactive(organization, testDataSet, mock_context, force)
-	
-	assert products
-
-	# mocking 
-	create_fake_lean_cli_directory()
-	
-	api_client = mock.MagicMock()
-	
-	test_datasets = [
-        QCDataset(id=1, name="Pending Dataset", delivery=QCDatasetDelivery.DownloadOnly, vendorName="Vendor", tags=[], pending=True),
-        QCDataset(id=2, name="Non-Pending Dataset", delivery=QCDatasetDelivery.DownloadOnly, vendorName="Vendor", tags=[], pending=False)
-    ]
-	api_client.list_datasets = MagicMock(return_value=test_datasets)
-	container.api_client.market = api_client
-	container.api_client.organizations.get.return_value = create_api_organization()
-	
-	datasources = {
-        str(test_datasets[0].id): {
-            'options': [],
-            'paths': [],
-            'requirements': {},
-        },
-        str(test_datasets[1].id): {
-            'options': [],
-            'paths': [],
-            'requirements': {},
-        }
-    }
-	container.api_client.data.get_info = MagicMock(return_value=QCDataInformation(datasources=datasources, prices=[], agreement=""))
-
-	# initialize_container(api_client_to_use=api_client)
-	result = CliRunner().invoke(lean, ["data", "download", "--dataset", "US Equity Options"])
-
-	assert result.exit_code == 0
 
 def test_non_interactive_bulk_select():
 	# TODO

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -54,9 +54,9 @@ def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]
             "module-specification": {
                 "download": {
                     "data-types": ["Trade", "Quote"],
-                    "data-resolutions": ["Minute", "Hour", "Daily"],
-                    "data-supported": ["Crypto", "CryptoFuture"],
-                    "data-markets": ["Binance", "Kraken"]
+                    "resolutions": ["Minute", "Hour", "Daily"],
+                    "security-types": ["Crypto", "CryptoFuture"],
+                    "markets": ["Binance", "Kraken"]
                 }
             }
         }
@@ -65,9 +65,9 @@ def _get_data_provider_config(is_crypto_configs: bool = False) -> Dict[str, Any]
         "module-specification": {
             "download": {
                 "data-types": ["Trade", "Quote"],
-                "data-resolutions": ["Second", "Minute", "Hour", "Daily"],
-                "data-supported": ["Equity", "Option", "Index", "IndexOption"],
-                "data-markets": ["NYSE", "USA"]
+                "resolutions": ["Second", "Minute", "Hour", "Daily"],
+                "security-types": ["Equity", "Option", "Index", "IndexOption"],
+                "markets": ["NYSE", "USA"]
             }
         }
     }

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -218,9 +218,6 @@ def test_interactive_bulk_select():
 
 
 def test_dataset_requirements():
-	organization = create_api_organization()
-	datasource = json.loads(bulk_datasource)
-	testSet = Dataset(name="testSet",
     organization = create_api_organization()
     datasource = json.loads(bulk_datasource)
     testSet = Dataset(name="testSet",

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -124,7 +124,11 @@ def test_download_data_non_interactive_data_provider_missed_param(data_provider:
 @pytest.mark.parametrize("data_provider,wrong_security_type",
 						 [("Polygon", "Future"),("Polygon", "Crypto"),("Polygon", "Forex")])
 def test_download_data_non_interactive_wrong_security_type(data_provider: str, wrong_security_type: str):
-	run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", wrong_security_type, ["AAPL"], "20240101", "20240202", _get_data_provider_config(), ["--polygon-api-key", "123"])
+	data_provider_config = {
+        "data-supported": [ "Equity", "Equity Options", "Indexes", "Index Options" ]
+    }
+
+	run_data_download = _create_lean_data_download(data_provider, "Trade", "Hour", wrong_security_type, ["AAPL"], "20240101", "20240202", data_provider_config, ["--polygon-api-key", "123"])
 	assert run_data_download.exit_code == 1
 	
 	error_msg = str(run_data_download.exc_info[1])

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -179,7 +179,7 @@ def test_download_data_non_interactive_wrong_security_type(data_provider: str, w
     assert run_data_download.exit_code == 1
 
     error_msg = str(run_data_download.exc_info[1])
-    assert f"The {data_provider} data provider does not support {wrong_security_type}." in error_msg
+    assert f"The {data_provider} data provider does not support QCSecurityType.{wrong_security_type}." in error_msg
 
 
 @pytest.mark.parametrize("data_provider,start_date,end_date",
@@ -202,7 +202,7 @@ def test_download_data_non_interactive_wrong_data_type(wrong_data_type: str):
     assert run_data_download.exit_code == 1
 
     error_msg = str(run_data_download.exc_info[1])
-    assert f"The Polygon data provider does not support {wrong_data_type}." in error_msg
+    assert f"The Polygon data provider does not support QCDataType.{wrong_data_type}." in error_msg
 
 
 def test_non_interactive_bulk_select():


### PR DESCRIPTION
#### Description
This pull request introduces a new command, `data download`, to the lean-cli tool. This command facilitates downloading various data types such as Trade, Quote, and Open Interest from multiple Historical Data Providers like Polygon, Binance, Interactive Brokers, etc. The command supports different resolutions like tick, second, minute, hour, and day, as well as different security types depending on the support available from the Data Provider. The command invokes an executable app from Lean to perform the data download.

#### Related Issue
https://github.com/QuantConnect/lean-cli/issues/388

#### Related Pull Request
- Lean: https://github.com/QuantConnect/Lean/pull/7975

#### Motivation and Context
The motivation behind this feature is to enhance the user experience by providing an easy-to-use command for downloading different types of data required for developing trading algorithms in Lean. By incorporating this feature into lean-cli, users can effortlessly download data and proceed with algorithm development without needing to manually handle data retrieval from various providers.

#### How Has This Been Tested?
This feature has been thoroughly tested to ensure its functionality and reliability:
- Unit Tests: Created unit tests to validate the command's logic and behavior.
- Manual Testing: Manually tested the command in both interactive and non-interactive modes to ensure it behaves as expected and handles different input scenarios correctly.
- Local Testing with Custom Docker Images: Tested the command in a local environment using custom Docker images and the latest development version of Lean to verify its compatibility and performance.

### Additional manual test cases:
#### Interactive Brokers [Security type: Equity]
```
lean data download --data-provider-historical "Interactive Brokers" --data-type Quote --resolution Daily --security-type Equity --tickers NVDA,AMD --start-date 20240303 --end-date 20240404
```
##### Result:
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/f2f934db-26c5-47c4-a090-8d46e292b7cf)

#### Binance [Security type: Crypto]
```
lean data download --data-provider-historical Binance --data-type Trade --resolution Daily --security-type Crypto --tickers BTCUSDT,ETHUSDT --start-date 20240303 --end-date 20240404
```
##### Result
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/75c76784-e580-426c-8b18-62e09c23294f)

#### FactSet [Security type: IndexOption]
```
lean data download --data-provider-historical FactSet --data-type Trade --resolution Daily --security-type IndexOption --tickers SPX --start-date 20240422 --end-date 20240423
```
##### Result:
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/1c79ce40-785b-42eb-aafb-7b9e62d41581)

#### Polygon [Security type: Equity]
```
lean data download --data-provider-historical Polygon --data-type Trade --resolution Hour --security-type Equity --tickers SOFI,TSLA,NIO --start-date 20200101 --end-date 20240404
```
##### Result:
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/76d6b7a4-4a87-4155-a16d-a8c709fd8487)

#### IEX [Security type: Equity]
```
lean data download --data-provider-historical IEX --data-type Trade --resolution Hour --security-type Equity --tickers AMD --start-date 20200101 --end-date 20240404
```
##### Result: [wrong resolution]
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/6d6c68f1-beed-4fab-b62c-333275cfab98)

#### IEX [Security type: Equity]
```
lean data download --data-provider-historical IEX --data-type Trade --resolution Daily --security-type Equity --tickers GOOGL --start-date 20100101 --end-date 20240404
```
#### Result
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/f9f4e90e-4233-4514-97da-78711fd18843)

#### Coinbase Advanced Trade [Security type: Crypto]
> pay attention `--market Coinbase`
```
lean data download --data-provider-historical "Coinbase Advanced Trade" --data-type Trade --resolution hour --security-type Crypto --tickers BTCUSD --market Coinbase --start-date 20230101 --end-date 20240404
```
![image](https://github.com/QuantConnect/lean-cli/assets/45608740/a11ed5b3-3c44-42bb-aed1-f38d5ba9943d)


#### Example of running
1. Interactive Mode:
Run ⬇ and follow the on-screen instructions to select the Data Provider, Data Type, Resolution, Security Type, tickers, start date, and end date.
```
lean data download
```
2. Non-Interactive Mode:
Run ⬇
```
 lean data download --data-provider-historical Polygon --data-type Trade --resolution Minute --ticker-security-type Equity --tickers AAPL,QQQ --start-date 20240101 --end-date 20240202
```
#### Conclusion
The main goal of this feature is to be user-friendly and assist users in downloading various data types required for creating new trading algorithms in Lean. By providing a seamless data retrieval process, users can focus more on algorithm development and less on data management.