### PR TITLE
Hide Brokerage Settings By default

### DIFF
--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -317,7 +317,8 @@ def deploy(project: str,
 
     brokerage_settings = brokerage_instance.get_settings()
 
-    logger.info(f"Brokerage: {brokerage_settings}")
+    logger.info(f"Brokerage: {brokerage_instance.get_name()}")
+    logger.debug(f"Brokerage: {brokerage_settings}")
     logger.info(f"Project id: {cloud_project.projectId}")
     logger.info(f"Server name: {live_node.name}")
     logger.info(f"Server type: {live_node.sku}")


### PR DESCRIPTION
- Hide cloud brokerage live settings by default

Closes https://github.com/QuantConnect/lean-cli/issues/431

<img width="590" alt="image" src="https://github.com/QuantConnect/lean-cli/assets/18473240/46b04d6c-3e16-4ba5-a111-49cd9017cd2c">
