### PR TITLE
Add missing tag for docker manager image get

### DIFF
--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -39,7 +39,7 @@ class DockerManager:
         self._platform_manager = platform_manager
 
     def get_image_label(self, image: DockerImage, label: str, default: str) -> str:
-        docker_image = self._get_docker_client().images.get(image.name)
+        docker_image = self._get_docker_client().images.get(str(image))
 
         for name, value in docker_image.labels.items():
             if name == label:


### PR DESCRIPTION
- Add missing tag for docker manager image get call, it was causing it to always use latest, which might not be the case for custom images. Tested reproducing issue


See https://github.com/QuantConnect/lean-cli/pull/441