### PR TITLE
Fix: bug with default market in download

### DIFF
--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -615,10 +615,7 @@ def download(ctx: Context,
                                                                                     QCResolution.get_all_members(),
                                                                                     "resolutions")
         data_provider_support_markets = _get_download_specification_from_config(data_provider_config_json,
-                                                                                [market], "markets")
-        # take default market
-        if not data_provider_support_markets:
-            data_provider_support_markets = ["USA"]
+                                                                                ["USA"], "markets")
 
         security_type = _get_user_input_or_prompt(security_type, data_provider_support_security_types,
                                                   data_provider_historical, "Select a Ticker's security type")

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -510,7 +510,7 @@ def _configure_date_option(date_value: str, option_id: str, option_label: str) -
         help="Specify the resolution of the historical data")
 @option("--security-type", type=Choice(QCSecurityType.get_all_members(), case_sensitive=False),
     help="Specify the security type of the historical data")
-@option("--market", type=str, default="USA",
+@option("--market", type=str,
         help="Specify the market name for tickers (e.g., 'USA', 'NYMEX', 'Binance')")
 @option("--tickers",
         type=str,
@@ -616,6 +616,9 @@ def download(ctx: Context,
                                                                                     "resolutions")
         data_provider_support_markets = _get_download_specification_from_config(data_provider_config_json,
                                                                                 [market], "markets")
+        # take default market
+        if not data_provider_support_markets:
+            data_provider_support_markets = ["USA"]
 
         security_type = _get_user_input_or_prompt(security_type, data_provider_support_security_types,
                                                   data_provider_historical, "Select a Ticker's security type")
@@ -624,7 +627,7 @@ def download(ctx: Context,
         resolution = _get_user_input_or_prompt(resolution, data_provider_support_resolutions,
                                                data_provider_historical, "Select a Resolution")
         market = _get_user_input_or_prompt(market, data_provider_support_markets,
-                                           data_provider_historical,"Select a Market")
+                                           data_provider_historical, "Select a Market")
 
         if not tickers:
             tickers = ','.join(DatasetTextOption(id="id",


### PR DESCRIPTION
### Issue:
Fixes bug with default market name USA not being retrieved from the configuration file of data providers.
### Related Pull Request
- https://github.com/QuantConnect/lean-cli/pull/447
### Description:
This pull request addresses an issue where the default market name "USA" was not being fetched from the configuration file of data providers. The bug caused the system to use an incorrect default market name, leading to unexpected behavior in certain scenarios.

### Changes Made:
- Added logic to retrieve the default market name "USA" from the configuration file of data providers.
- Implemented checks to ensure the correct retrieval and usage of the default market name.
### Testing:
This fix has been thoroughly tested by running the updated code locally using the Lean development library. The testing process included verifying that the default market name is fetched correctly from the configuration file and that the system behaves as expected in various scenarios.

### Outcome:
With this fix, the system now properly retrieves the default market name "USA" from the configuration file of data providers, resolving the bug and ensuring consistent behavior across different environments.