### PR TITLE
Python 3.12 support tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 -e .
 
 wheel
-pytest==7.1.2
-pyfakefs==5.4.1
-responses==0.21.0
+pytest>=7.1.2,<8
+pyfakefs>=5.4.1,<6
+responses~=0.21
 lxml-stubs==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@
 
 wheel
 pytest==7.1.2
-pyfakefs==4.6.3
+pyfakefs==5.4.1
 responses==0.21.0
 lxml-stubs==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ install_requires = [
     "joblib>=1.1.0",
     "setuptools",
     f"quantconnect-stubs{get_stubs_version_range()}",
-    "cryptography>=42.0.4,<43.0.0",
+    "cryptography>=41.0.4,<43.0.0",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,9 @@ install_requires = [
     "lxml>=4.9.0",
     "maskpass>=0.3.6",
     "joblib>=1.1.0",
-    "wrapt~=1.14.1",
     "setuptools",
     f"quantconnect-stubs{get_stubs_version_range()}",
-    "cryptography~=41.0.4"
+    "cryptography>=42.0.4,<43.0.0",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12"
     ],
     project_urls={
         "Documentation": "https://www.lean.io/docs/v2/lean-cli/key-concepts/getting-started",


### PR DESCRIPTION
- Upgrade pyfakefs version to support pathlib version in Python 3.12
- Added Python 3.12 to CI

Tested:
- Running tests with Python 3.8, 3.11 and 3.12 locally.
- Running manually some commands for sanity checks, including `backtest` and `cloud pull`.

Closes #446 