### PR TITLE
Extend verbose

### DIFF
--- a/lean/click.py
+++ b/lean/click.py
@@ -67,12 +67,12 @@ class VerboseOption(ClickOption):
         except:
             vscode_installed_extensions = "Not installed"
 
-        project_config = container.project_config_manager.get_project_config(Path(getcwd()))
-        engine_image = container.cli_config_manager.get_engine_image(project_config.get("engine-image", None))
         try:
-            container.docker_manager.get_image_label(engine_image, 'strict_python_version', "3.11.7")
-            container.docker_manager.get_image_label(engine_image, 'python_version', "3.11.7")
-            container.docker_manager.get_image_label(engine_image, 'target_framework', "net6.0")
+            project_config = container.project_config_manager.get_project_config(Path(getcwd()))
+            engine_image = container.cli_config_manager.get_engine_image(project_config.get("engine-image", None))
+            container.docker_manager.get_image_label(engine_image, 'strict_python_version', "Unknown")
+            container.docker_manager.get_image_label(engine_image, 'python_version', "Unknown")
+            container.docker_manager.get_image_label(engine_image, 'target_framework', "Unknown")
         except:
             pass
 


### PR DESCRIPTION
- Add dotnet version, if installed/available
- Add code version (vscode), if installed/available
- Add code extensions with versions, if installed/available
- Add engine-image labels (research-image didn't have labels

Example of the response from `lean --verbose`:
![image](https://github.com/QuantConnect/lean-cli/assets/47573394/fe576954-a472-445e-80c8-355b33a2eb68)

Closes #459 
