### PR TITLE
Add OAuth API Client

### DIFF
--- a/lean/components/api/api_client.py
+++ b/lean/components/api/api_client.py
@@ -13,6 +13,7 @@
 
 from typing import Any, Dict
 
+from lean.components.api.auth0_client import Auth0Client
 from lean.components.api.account_client import AccountClient
 from lean.components.api.backtest_client import BacktestClient
 from lean.components.api.compile_client import CompileClient
@@ -52,6 +53,7 @@ class APIClient:
         self.set_user_token(user_id, api_token)
 
         # Create the clients containing the methods to send requests to the various API endpoints
+        self.auth0 = Auth0Client(self)
         self.accounts = AccountClient(self)
         self.backtests = BacktestClient(self)
         self.compiles = CompileClient(self)

--- a/lean/components/api/auth0_client.py
+++ b/lean/components/api/auth0_client.py
@@ -1,0 +1,56 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lean.components.api.api_client import *
+from lean.components.util.logger import Logger
+from lean.constants import API_BASE_URL
+from lean.models.api import QCAuth0Authorization
+from lean.models.errors import RequestFailedError
+
+class Auth0Client:
+    """The Auth0Client class contains methods to interact with live/auth0/* API endpoints."""
+
+    def __init__(self, api_client: 'APIClient') -> None:
+        """Creates a new Auth0Client instance.
+
+        :param api_client: the APIClient instance to use when making requests
+        """
+        self._api = api_client
+
+
+    def read(self, brokerage_id: str) -> QCAuth0Authorization:
+        """Reads the authorization data for a brokerage.
+
+        :param brokerage_id: the id of the brokerage to read the authorization data for
+        :return: the authorization data for the specified brokerage
+        """
+        try:
+            payload = {
+                "brokerage": brokerage_id
+            }
+
+            data = self._api.post("live/auth0/read", payload)
+            return QCAuth0Authorization(**data["authorization"])
+        except RequestFailedError as e:
+            return QCAuth0Authorization(authorization=None)
+
+    def authorize(self, brokerage_id: str, logger: Logger) -> None:
+        """Starts the authorization process for a brokerage.
+
+        :param brokerage_id: the id of the brokerage to start the authorization process for
+        :param logger: the logger instance to use
+        """
+
+        full_url = f"{API_BASE_URL}ive/auth0/authorize?brokerage={brokerage_id}"
+        logger.info(f"Please open the following URL in your browser to authorize the LEAN CLI.")
+        logger.info(full_url)

--- a/lean/components/util/auth0_helper.py
+++ b/lean/components/util/auth0_helper.py
@@ -1,0 +1,41 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lean.models.api import QCAuth0Authorization
+from lean.components.api.api_client import Auth0Client
+from lean.components.util.logger import Logger
+
+def get_authorization(auth0_client: Auth0Client, brokerage_id: str, logger: Logger) -> QCAuth0Authorization:
+        """Gets the authorization data for a brokerage, authorizing if necessary.
+
+        :param brokerage_id: the id of the brokerage to get the authorization data for
+        :return: the authorization data for the specified brokerage
+        """
+        from time import time, sleep
+
+        data = auth0_client.read(brokerage_id)
+        if data.authorization is not None:
+            return data
+
+        start_time = time()
+        auth0_client.authorize(brokerage_id, logger)
+
+        # keep checking for new data every 5 seconds for 7 minutes
+        while time() - start_time < 420:
+            sleep(5)
+            data = auth0_client.read(brokerage_id)
+            if data.authorization is None:
+                continue
+            return data
+
+        raise Exception("Authorization failed")

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -21,6 +21,8 @@ from lean.models.pydantic import WrappedBaseModel, validator
 # The models in this module are all parts of responses from the QuantConnect API
 # The keys of properties are not changed, so they don't obey the rest of the project's naming conventions
 
+class QCAuth0Authorization(WrappedBaseModel):
+    authorization: Optional[Dict[str, str]]
 
 class ProjectEncryptionKey(WrappedBaseModel):
     id: str


### PR DESCRIPTION
- Implements auth0 api client and helper method required to get auth information

Possible configuration we can add:

```
class AuthConfiguration(Configuration):

    def __init__(self, config_json_object):
        super().__init__(config_json_object)
        self._is_required_from_user = False

    def factory(config_json_object) -> 'AuthConfiguration':
        return AuthConfiguration(config_json_object)

```