### PR TITLE
Fix get last portfolio holdings bug

### DIFF
--- a/lean/commands/cloud/status.py
+++ b/lean/commands/cloud/status.py
@@ -31,7 +31,7 @@ def status(project: str) -> None:
     cloud_project_manager = container.cloud_project_manager
     cloud_project = cloud_project_manager.get_cloud_project(project, False)
 
-    live_algorithm = next((d for d in api_client.live.get_all() if d.projectId == cloud_project.projectId), None)
+    live_algorithm = api_client.live.get_project_by_id(cloud_project.projectId)
 
     logger.info(f"Project id: {cloud_project.projectId}")
     logger.info(f"Project name: {cloud_project.name}")

--- a/lean/commands/cloud/status.py
+++ b/lean/commands/cloud/status.py
@@ -59,7 +59,3 @@ def status(project: str) -> None:
 
     if live_algorithm.stopped is not None:
         logger.info(f"Stopped: {live_algorithm.stopped.strftime('%Y-%m-%d %H:%M:%S')} UTC")
-
-    if live_algorithm.error != "":
-        logger.info("Error:")
-        logger.info(live_algorithm.error)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -292,16 +292,13 @@ def deploy(project: Path,
 
     _start_iqconnect_if_necessary(lean_config, environment_name)
 
-    if not output.exists():
-        output.mkdir(parents=True)
-
     if python_venv is not None and python_venv != "":
         lean_config["python-venv"] = f'{"/" if python_venv[0] != "/" else ""}{python_venv}'
 
     cash_balance_option, holdings_option, last_cash, last_holdings = get_last_portfolio_cash_holdings(container.api_client, brokerage_instance,
                                                                                                       project_config.get("cloud-id", None), project)
 
-    if environment is None and brokerage is None and len(data_provider_live) == 0:   # condition for using interactive panel
+    if environment is None and brokerage is None:   # condition for using interactive panel
         if cash_balance_option != LiveInitialStateInput.NotSupported:
             live_cash_balance = _configure_initial_cash_interactively(logger, cash_balance_option, last_cash)
 
@@ -340,6 +337,9 @@ def deploy(project: Path,
             given_algorithm_id = int(value)
         else:
             lean_config[key] = value
+
+    if not output.exists():
+        output.mkdir(parents=True)
 
     output_config_manager = container.output_config_manager
     lean_config["algorithm-id"] = f"L-{output_config_manager.get_live_deployment_id(output, given_algorithm_id)}"

--- a/lean/components/api/api_client.py
+++ b/lean/components/api/api_client.py
@@ -142,6 +142,12 @@ class APIClient:
             version = 99999999
         headers["User-Agent"] = f"Lean CLI {version}"
 
+        self._logger.info(f'full_url: {full_url}')
+        self._logger.info(f'headers: {headers}')
+        self._logger.info(f'self._user_id: {self._user_id}')
+        self._logger.info(f'password: {password}')
+        self._logger.info(f'options: {options}')
+
         response = self._http_client.request(method,
                                              full_url,
                                              headers=headers,
@@ -149,8 +155,8 @@ class APIClient:
                                              raise_for_status=False,
                                              **options)
 
-        if self._logger.debug_logging_enabled:
-            self._logger.debug(f"Request response: {response.text}")
+        self._logger.debug(f"Request response: {response.text}")
+        # if self._logger.debug_logging_enabled:
 
         if 500 <= response.status_code < 600 and retry_http_5xx:
             return self._request(method, endpoint, options, False)

--- a/lean/components/api/api_client.py
+++ b/lean/components/api/api_client.py
@@ -142,12 +142,6 @@ class APIClient:
             version = 99999999
         headers["User-Agent"] = f"Lean CLI {version}"
 
-        self._logger.info(f'full_url: {full_url}')
-        self._logger.info(f'headers: {headers}')
-        self._logger.info(f'self._user_id: {self._user_id}')
-        self._logger.info(f'password: {password}')
-        self._logger.info(f'options: {options}')
-
         response = self._http_client.request(method,
                                              full_url,
                                              headers=headers,
@@ -155,8 +149,8 @@ class APIClient:
                                              raise_for_status=False,
                                              **options)
 
-        self._logger.debug(f"Request response: {response.text}")
-        # if self._logger.debug_logging_enabled:
+        if self._logger.debug_logging_enabled:
+            self._logger.debug(f"Request response: {response.text}")
 
         if 500 <= response.status_code < 600 and retry_http_5xx:
             return self._request(method, endpoint, options, False)

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -29,8 +29,7 @@ class LiveClient:
         self._api = api_client
 
     def get_project_by_id(self,
-                          project_id: str,
-                          status: Optional[QCLiveAlgorithmStatus] = None) -> QCFullLiveAlgorithm:
+                          project_id: str) -> QCFullLiveAlgorithm:
         """Retrieves all live algorithms.
 
         :param status: the status to filter by or None if no status filter should be applied
@@ -38,10 +37,6 @@ class LiveClient:
         :return: a live algorithm which match the given filters
         """
         parameters = {"projectId": project_id}
-
-        if status is not None:
-            parameters["status"] = status.value
-
         response = self._api.get("live/read", parameters)
 
         if response:

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -32,7 +32,6 @@ class LiveClient:
                           project_id: str) -> QCFullLiveAlgorithm:
         """Retrieves all live algorithms.
 
-        :param status: the status to filter by or None if no status filter should be applied
         :param project_id: the project id
         :return: a live algorithm which match the given filters
         """

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -37,8 +37,6 @@ class LiveClient:
         :param project_id: the project id
         :return: a live algorithm which match the given filters
         """
-        from lean.container import container
-
         parameters = {"projectId": project_id}
 
         if status is not None:

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -45,7 +45,8 @@ class LiveClient:
         response = self._api.get("live/read", parameters)
 
         if response:
-            return QCFullLiveAlgorithm(data=response)
+            response["projectId"] = project_id
+            return QCFullLiveAlgorithm(**response)
 
         return None
 

--- a/lean/components/api/live_client.py
+++ b/lean/components/api/live_client.py
@@ -28,29 +28,28 @@ class LiveClient:
         """
         self._api = api_client
 
-    def get_all(self,
-                status: Optional[QCLiveAlgorithmStatus] = None,
-                # Values less than 86400 cause errors on Windows: https://bugs.python.org/issue37527
-                start: datetime = datetime.fromtimestamp(86400),
-                end: datetime = datetime.now()) -> List[QCFullLiveAlgorithm]:
+    def get_project_by_id(self,
+                          project_id: str,
+                          status: Optional[QCLiveAlgorithmStatus] = None) -> QCFullLiveAlgorithm:
         """Retrieves all live algorithms.
 
         :param status: the status to filter by or None if no status filter should be applied
-        :param start: the earliest launch time the returned algorithms should have
-        :param end: the latest launch time the returned algorithms should have
-        :return: a list of live algorithms which match the given filters
+        :param project_id: the project id
+        :return: a live algorithm which match the given filters
         """
-        from math import floor
-        parameters = {
-            "start": floor(start.timestamp()),
-            "end": floor(end.timestamp())
-        }
+        from lean.container import container
+
+        parameters = {"projectId": project_id}
 
         if status is not None:
             parameters["status"] = status.value
 
-        data = self._api.get("live/read", parameters)
-        return [QCFullLiveAlgorithm(**algorithm) for algorithm in data["live"]]
+        response = self._api.get("live/read", parameters)
+
+        if response:
+            return QCFullLiveAlgorithm(data=response)
+
+        return None
 
     def start(self,
               project_id: int,

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -70,7 +70,7 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
         output_directory = container.output_config_manager.get_latest_output_directory("live")
         if not output_directory:
             return None
-        previous_state_file = get_latest_result_json_file(output_directory)
+        previous_state_file = get_latest_result_json_file(output_directory, True)
         if not previous_state_file:
             return None
         previous_portfolio_state = {x.lower(): y for x, y in loads(open(previous_state_file, "r", encoding="utf-8").read()).items()}
@@ -111,7 +111,7 @@ def get_last_portfolio_cash_holdings(api_client: APIClient, brokerage_instance: 
     return cash_balance_option, holdings_option, last_cash, last_holdings
 
 
-def _configure_initial_cash_interactively(logger: Logger, cash_input_option: LiveInitialStateInput, previous_cash_state: List[Dict[str, Any]]) -> List[Dict[str, float]]:
+def _configure_initial_cash_interactively(logger: Logger, cash_input_option: LiveInitialStateInput, previous_cash_state: Dict[str, Any]) -> List[Dict[str, float]]:
     cash_list = []
     previous_cash_balance = []
     if previous_cash_state:
@@ -140,7 +140,7 @@ def _configure_initial_cash_interactively(logger: Logger, cash_input_option: Liv
         return []
 
 
-def configure_initial_cash_balance(logger: Logger, cash_input_option: LiveInitialStateInput, live_cash_balance: str, previous_cash_state: List[Dict[str, Any]])\
+def configure_initial_cash_balance(logger: Logger, cash_input_option: LiveInitialStateInput, live_cash_balance: str, previous_cash_state: Dict[str, Any])\
     -> List[Dict[str, float]]:
     """Interactively configures the intial cash balance.
 
@@ -160,7 +160,7 @@ def configure_initial_cash_balance(logger: Logger, cash_input_option: LiveInitia
         return _configure_initial_cash_interactively(logger, cash_input_option, previous_cash_state)
 
 
-def _configure_initial_holdings_interactively(logger: Logger, holdings_option: LiveInitialStateInput, previous_holdings: List[Dict[str, Any]]) -> List[Dict[str, float]]:
+def _configure_initial_holdings_interactively(logger: Logger, holdings_option: LiveInitialStateInput, previous_holdings: Dict[str, Any]) -> List[Dict[str, float]]:
     holdings = []
     last_holdings = []
     if previous_holdings:
@@ -192,7 +192,7 @@ def _configure_initial_holdings_interactively(logger: Logger, holdings_option: L
         return []
 
 
-def configure_initial_holdings(logger: Logger, holdings_option: LiveInitialStateInput, live_holdings: str, previous_holdings: List[Dict[str, Any]])\
+def configure_initial_holdings(logger: Logger, holdings_option: LiveInitialStateInput, live_holdings: str, previous_holdings: Dict[str, Any])\
     -> List[Dict[str, float]]:
     """Interactively configures the intial portfolio holdings.
 
@@ -212,7 +212,7 @@ def configure_initial_holdings(logger: Logger, holdings_option: LiveInitialState
         return _configure_initial_holdings_interactively(logger, holdings_option, previous_holdings)
 
 
-def get_latest_result_json_file(output_directory: Path) -> Optional[Path]:
+def get_latest_result_json_file(output_directory: Path, is_previous_state_file: bool = False) -> Optional[Path]:
     from lean.container import container
 
     output_config_manager = container.output_config_manager
@@ -221,7 +221,11 @@ def get_latest_result_json_file(output_directory: Path) -> Optional[Path]:
     if output_id is None:
         return None
 
-    result_file = output_directory / f"{output_id}.json"
+    prefix = ""
+    if is_previous_state_file:
+        prefix = "L-"
+
+    result_file = output_directory / f"{prefix}{output_id}.json"
     if not result_file.exists():
         return None
 

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -26,11 +26,12 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
     from datetime import datetime
     from lean.container import container
 
-    cloud_deployment_list = api_client.get("live/read", { "projectId": project_id })
-    container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment_list}')
-
-    if "live" not in cloud_deployment_list:
+    if not project_id:
+        # Project is not initialized in the cloud, hence project_id is None
         return None
+
+    cloud_deployment_list = api_client.get("live/read", {"projectId": project_id})
+    container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment_list}')
 
     cloud_deployment_time = [datetime.strptime(instance["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC) for instance in cloud_deployment_list["live"]
                              if instance["projectId"] == project_id]

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -29,9 +29,8 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
     cloud_last_time = utc.localize(datetime.min)
     if project_id:
         cloud_deployment = api_client.get("live/read", {"projectId": project_id})
-        container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment}')
-        if cloud_deployment["success"]:
-            cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
+        if cloud_deployment["success"] and cloud_deployment["status"] != "Undefined":
+            cloud_last_time = datetime.strptime(cloud_deployment["stopped"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
 
     local_last_time = utc.localize(datetime.min)
     live_deployment_path = f"{project_name}/live"

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -26,10 +26,6 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
     from datetime import datetime
     from lean.container import container
 
-    if not project_id:
-        # Project is not initialized in the cloud, hence project_id is None
-        return None
-
     cloud_deployment = api_client.get("live/read", {"projectId": project_id})
     container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment}')
     cloud_last_time = utc.localize(datetime.min)
@@ -73,11 +69,11 @@ def get_last_portfolio_cash_holdings(api_client: APIClient, brokerage_instance: 
     from lean.container import container
     last_cash = []
     last_holdings = []
-    container.logger.info(f'brokerage_instance: {brokerage_instance}')
+    container.logger.debug(f'brokerage_instance: {brokerage_instance}')
     cash_balance_option = brokerage_instance._initial_cash_balance
     holdings_option = brokerage_instance._initial_holdings
-    container.logger.info(f'cash_balance_option: {cash_balance_option}')
-    container.logger.info(f'holdings_option: {holdings_option}')
+    container.logger.debug(f'cash_balance_option: {cash_balance_option}')
+    container.logger.debug(f'holdings_option: {holdings_option}')
     if cash_balance_option != LiveInitialStateInput.NotSupported or holdings_option != LiveInitialStateInput.NotSupported:
         last_portfolio = _get_last_portfolio(api_client, project_id, project)
         last_cash = last_portfolio["cash"] if last_portfolio else None

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -25,7 +25,11 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
     from json import loads
     from datetime import datetime
 
-    cloud_deployment_list = api_client.get("live/read")
+    if not project_id:
+        # Project is not initialized in the cloud, hence project_id is None
+        return None
+
+    cloud_deployment_list = api_client.get("live/read", { "projectId": project_id })
     cloud_deployment_time = [datetime.strptime(instance["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC) for instance in cloud_deployment_list["live"]
                              if instance["projectId"] == project_id]
     cloud_last_time = sorted(cloud_deployment_time, reverse = True)[0] if cloud_deployment_time else utc.localize(datetime.min)

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -46,9 +46,14 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
         cloud_deployment = api_client.get("live/read", {"projectId": project_id})
         if cloud_deployment["success"] and cloud_deployment["status"] != "Undefined":
             if cloud_deployment["stopped"] is not None:
-                cloud_last_time = datetime.strptime(cloud_deployment["stopped"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
+                cloud_last_time = datetime.strptime(cloud_deployment["stopped"], "%Y-%m-%d %H:%M:%S")
             else:
-                cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
+                cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S")
+    cloud_last_time = datetime(cloud_last_time.year, cloud_last_time.month,
+                               cloud_last_time.day, cloud_last_time.hour,
+                               cloud_last_time.minute,
+                               cloud_last_time.second,
+                               tzinfo=UTC)
 
     local_last_time = utc.localize(datetime.min)
     live_deployment_path = f"{project_name}/live"

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -32,7 +32,9 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
 
     cloud_deployment = api_client.get("live/read", {"projectId": project_id})
     container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment}')
-    cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
+    cloud_last_time = utc.localize(datetime.min)
+    if cloud_deployment["success"]:
+        cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
 
     local_last_time = utc.localize(datetime.min)
     live_deployment_path = f"{project_name}/live"

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -26,11 +26,12 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
     from datetime import datetime
     from lean.container import container
 
-    cloud_deployment = api_client.get("live/read", {"projectId": project_id})
-    container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment}')
     cloud_last_time = utc.localize(datetime.min)
-    if cloud_deployment["success"]:
-        cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
+    if project_id:
+        cloud_deployment = api_client.get("live/read", {"projectId": project_id})
+        container.logger.info(f'----- After cloud_deployment_list: {cloud_deployment}')
+        if cloud_deployment["success"]:
+            cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S").astimezone(UTC)
 
     local_last_time = utc.localize(datetime.min)
     live_deployment_path = f"{project_name}/live"

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -212,7 +212,7 @@ def configure_initial_holdings(logger: Logger, holdings_option: LiveInitialState
         return _configure_initial_holdings_interactively(logger, holdings_option, previous_holdings)
 
 
-def get_latest_result_json_file(output_directory: Path, is_previous_state_file: bool = False) -> Optional[Path]:
+def get_latest_result_json_file(output_directory: Path, is_live_trading: bool = False) -> Optional[Path]:
     from lean.container import container
 
     output_config_manager = container.output_config_manager
@@ -222,7 +222,7 @@ def get_latest_result_json_file(output_directory: Path, is_previous_state_file: 
         return None
 
     prefix = ""
-    if is_previous_state_file:
+    if is_live_trading:
         prefix = "L-"
 
     result_file = output_directory / f"{prefix}{output_id}.json"

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -19,7 +19,6 @@ from lean.components.api.api_client import APIClient
 from lean.components.util.logger import Logger
 from lean.models.json_module import LiveInitialStateInput, JsonModule
 from collections import UserDict
-from typing import Any
 
 
 class InsensitiveCaseDict(UserDict):

--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -24,7 +24,6 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
     from os import listdir, path
     from json import loads
     from datetime import datetime
-    from lean.container import container
 
     cloud_last_time = utc.localize(datetime.min)
     if project_id:

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -291,8 +291,6 @@ class QCFullLiveAlgorithm(QCMinimalLiveAlgorithm):
     launched: datetime
     stopped: Optional[datetime]
     brokerage: str
-    subscription: str
-    error: str
 
 
 class QCEmailNotificationMethod(WrappedBaseModel):

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -279,7 +279,7 @@ class QCMinimalLiveAlgorithm(WrappedBaseModel):
     def get_url(self) -> str:
         """Returns the url of the live deployment in the cloud.
 
-        :return: a url which when visited opens an Algorithm Lab tab containing the live deployment
+        :return: an url which when visited opens an Algorithm Lab tab containing the live deployment
         """
         return f"https://www.quantconnect.com/project/{self.projectId}/live"
 

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -65,7 +65,11 @@ def test_cloud_live_deploy() -> None:
 
     api_client = mock.Mock()
     api_client.nodes.get_all.return_value = create_qc_nodes()
-    api_client.get.return_value = {'portfolio': {"cash": {}}, 'live': []}
+    api_client.get.return_value = {
+        "status": "stopped",
+        "stopped": "2024-07-10 19:12:20",
+        "success": True,
+        "portfolio": {"holdings": {}, "cash": {}, "success": True}}
     container.api_client = api_client
 
     cloud_project_manager = mock.Mock()
@@ -98,7 +102,11 @@ def test_cloud_live_deploy_with_ib_using_hybrid_datafeed() -> None:
 
     api_client = mock.Mock()
     api_client.nodes.get_all.return_value = create_qc_nodes()
-    api_client.get.return_value = {'portfolio': {"cash": {}}, 'live': []}
+    api_client.get.return_value = {
+        "status": "stopped",
+        "stopped": "2024-07-10 19:12:20",
+        "success": True,
+        "portfolio": {"holdings": {}, "cash": {}, "success": True}}
     container.api_client = api_client
 
     cloud_project_manager = mock.Mock()
@@ -155,7 +163,11 @@ def test_cloud_live_deploy_with_notifications(notice_method: str, configs: str) 
 
     api_client = mock.Mock()
     api_client.nodes.get_all.return_value = create_qc_nodes()
-    api_client.get.return_value = {'portfolio': {"cash": {}}, 'live': []}
+    api_client.get.return_value = {
+        "status": "stopped",
+        "stopped": "2024-07-10 19:12:20",
+        "success": True,
+        "portfolio": {"holdings": {}, "cash": {}, "success": True}}
     container.api_client = api_client
 
     cloud_project_manager = mock.Mock()
@@ -238,7 +250,11 @@ def test_cloud_live_deploy_with_live_cash_balance(brokerage: str, cash: str) -> 
 
     api_client = mock.Mock()
     api_client.nodes.get_all.return_value = create_qc_nodes()
-    api_client.get.return_value = {'live': [], 'portfolio': {}}
+    api_client.get.return_value = {
+        "status": "stopped",
+        "stopped": "2024-07-10 19:12:20",
+        "success": True,
+        "portfolio": {}}
     container.api_client = api_client
 
     cloud_runner = mock.Mock()
@@ -315,7 +331,11 @@ def test_cloud_live_deploy_with_live_holdings(brokerage: str, holdings: str) -> 
 
     api_client = mock.Mock()
     api_client.nodes.get_all.return_value = create_qc_nodes()
-    api_client.get.return_value = {'live': [], 'portfolio': {}}
+    api_client.get.return_value = {
+        "status": "stopped",
+        "stopped": "2024-07-10 19:12:20",
+        "success": True,
+        "portfolio": {}}
     container.api_client = api_client
 
     cloud_runner = mock.Mock()

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -254,7 +254,7 @@ def test_cloud_live_deploy_with_live_cash_balance(brokerage: str, cash: str) -> 
         "status": "stopped",
         "stopped": "2024-07-10 19:12:20",
         "success": True,
-        "portfolio": {}}
+        "portfolio": {"cash": {}, "holdings": {}}}
     container.api_client = api_client
 
     cloud_runner = mock.Mock()
@@ -335,7 +335,7 @@ def test_cloud_live_deploy_with_live_holdings(brokerage: str, holdings: str) -> 
         "status": "stopped",
         "stopped": "2024-07-10 19:12:20",
         "success": True,
-        "portfolio": {}}
+        "portfolio": {"cash": {}, "holdings": {}}}
     container.api_client = api_client
 
     cloud_runner = mock.Mock()

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -1182,14 +1182,14 @@ def test_live_deploy_with_different_brokerage_and_different_live_data_provider_a
 
     is_exists = []
     if brokerage_product_id is None and data_provider_historical_name != "Local":
-        assert len(api_client.method_calls) == 3
+        assert len(api_client.method_calls) == 2
         for m_c, id in zip(api_client.method_calls, [data_provider_live_product_id, data_provider_historical_id]):
             if id in m_c[1]:
                 is_exists.append(True)
         assert is_exists
         assert len(is_exists) == 2
     elif brokerage_product_id is None and data_provider_historical_name == "Local":
-        assert len(api_client.method_calls) == 2
+        assert len(api_client.method_calls) == 1
         if data_provider_live_product_id in api_client.method_calls[0][1]:
             is_exists.append(True)
         assert is_exists
@@ -1243,7 +1243,7 @@ def test_live_non_interactive_deploy_paper_brokerage_different_live_data_provide
     api_client = mock.MagicMock()
     create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
 
-    assert len(api_client.method_calls) == 2
+    assert len(api_client.method_calls) == 1
     for m_c in api_client.method_calls:
         if data_provider_live_product_id in m_c[1]:
             is_exist = True


### PR DESCRIPTION
This PR is the continuation of this draft: https://github.com/QuantConnect/lean-cli/pull/473. Some endpoints were deprecated and the names for some properties were in capital case instead of camel case. The following test cases were proved (using PaperBrokerage and InteractiveBrokers Brokerage):
- both cloud & local previous deployments exist but local deployment newer
- both cloud & local previous deployments exist but cloud deployment newer
- no cloud previous deployments exist
  - because its not even a cloud project
  - it is a cloud project but it has not deployments in the cloud
- no local previous deployments exist
  - because its not even a local project
  - it is a local project but it has not deployments in the cloud
  
 Regarding the bug #468 , this bug was fixed adding `projectId` in the response from `live/read`, updating the call to the `QCFullLiveAlgorithm` constructor and removing some attributes unused from this same class