### PR TITLE
Feature: support new historical(download) providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,8 @@ Options:
                                   Specify the resolution of the historical data
   --security-type [Equity|Index|Forex|Cfd|Future|Crypto|CryptoFuture|Option|IndexOption|Commodity|FutureOption]
                                   Specify the security type of the historical data
-  --market TEXT                   Specify the market name for tickers (e.g., 'USA', 'NYMEX', 'Binance')
+  --market TEXT                   Specify the market name for tickers (e.g., 'USA', 'NYMEX', 'Binance') (if not provided
+                                  or empty the default market for the requested security type will be used)
   --ticker TEXT                   Specify comma separated list of tickers to use for historical data request.
   --start TEXT                    Specify the start date for the historical data request in the format yyyyMMdd.
   --end TEXT                      Specify the end date for the historical data request in the format yyyyMMdd. (defaults

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Options:
   -d, --detach                    Run the backtest in a detached Docker container and return immediately
   --debug [pycharm|ptvsd|debugpy|vsdbg|rider|local-platform]
                                   Enable a certain debugging method (see --help for more information)
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -209,6 +209,12 @@ Options:
   --bybit-api-secret TEXT         Your Bybit API secret
   --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
                                   Your Bybit VIP Level
+  --trade-station-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --trade-station-account-type [Cash|Margin|Futures|DVP]
+                                  Specifies the type of account on TradeStation
+  --alpaca-environment [live|paper]
+                                  Whether Live or Paper environment should be used
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the backtest when using
@@ -822,7 +828,7 @@ Usage: lean data download [OPTIONS]
   https://www.quantconnect.com/datasets
 
 Options:
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca]
                                   The name of the downloader data provider.
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -886,6 +892,12 @@ Options:
   --bybit-api-secret TEXT         Your Bybit API secret
   --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
                                   Your Bybit VIP Level
+  --trade-station-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --trade-station-account-type [Cash|Margin|Futures|DVP]
+                                  Specifies the type of account on TradeStation
+  --alpaca-environment [live|paper]
+                                  Whether Live or Paper environment should be used
   --dataset TEXT                  The name of the dataset to download non-interactively
   --overwrite                     Overwrite existing local data
   -y, --yes                       Automatically confirm payment confirmation prompts
@@ -1237,7 +1249,7 @@ Options:
                                   The brokerage to use
   --data-provider-live [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|TDAmeritrade|IQFeed|Polygon|IEX|CoinApi|ThetaData|Custom data only|Bybit|TradeStation|Alpaca]
                                   The live data provider to use
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit|TradeStation|Alpaca]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -1673,7 +1685,7 @@ Options:
   --parameter <TEXT FLOAT FLOAT FLOAT>...
                                   The 'parameter min max step' pairs configuring the parameters to optimize
   --constraint TEXT               The 'statistic operator value' pairs configuring the constraints of the optimization
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
@@ -1750,6 +1762,12 @@ Options:
   --bybit-api-secret TEXT         Your Bybit API secret
   --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
                                   Your Bybit VIP Level
+  --trade-station-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --trade-station-account-type [Cash|Margin|Futures|DVP]
+                                  Specifies the type of account on TradeStation
+  --alpaca-environment [live|paper]
+                                  Whether Live or Paper environment should be used
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
@@ -1853,7 +1871,7 @@ Usage: lean research [OPTIONS] PROJECT
 
 Options:
   --port INTEGER                  The port to run Jupyter Lab on (defaults to 8888)
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|IQFeed|Polygon|FactSet|IEX|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -1917,6 +1935,12 @@ Options:
   --bybit-api-secret TEXT         Your Bybit API secret
   --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
                                   Your Bybit VIP Level
+  --trade-station-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --trade-station-account-type [Cash|Margin|Futures|DVP]
+                                  Specifies the type of account on TradeStation
+  --alpaca-environment [live|paper]
+                                  Whether Live or Paper environment should be used
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the research session

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -706,7 +706,8 @@ def download(ctx: Context,
                          "--security-type", security_type,
                          "--market", market,
                          "--resolution", resolution,
-                         "--tickers", ticker]
+                         "--tickers", ticker,
+                         "--data-downloader-brokerage", data_downloader_provider.get_id()]
 
         run_options["commands"].append(' '.join(dll_arguments))
 

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -710,8 +710,7 @@ def download(ctx: Context,
                          "--end-date", end.value.strftime("%Y%m%d"),
                          "--security-type", security_type,
                          "--resolution", resolution,
-                         "--tickers", ticker,
-                         "--data-downloader-brokerage", data_downloader_provider.get_id()]
+                         "--tickers", ticker]
         # If no market is specified, Lean will use a default market value based on the SecurityType
         if market != "":
             dll_arguments.extend(["--market", market])

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -536,7 +536,8 @@ def _replace_data_type(ctx, param, value):
 @option("--security-type", type=Choice(QCSecurityType.get_all_members(), case_sensitive=False),
     help="Specify the security type of the historical data")
 @option("--market", type=str,
-        help="Specify the market name for tickers (e.g., 'USA', 'NYMEX', 'Binance')")
+        help="Specify the market name for tickers (e.g., 'USA', 'NYMEX', 'Binance')"
+             " (if not provided or empty the default market for the requested security type will be used)")
 @option("--ticker",
         type=str,
         help="Specify comma separated list of tickers to use for historical data request.")

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -638,7 +638,7 @@ def download(ctx: Context,
                                                                                     QCResolution.get_all_members(),
                                                                                     "resolutions")
         data_provider_support_markets = _get_download_specification_from_config(data_provider_config_json,
-                                                                                ["USA"], "markets")
+                                                                                ["USA", "Coinbase"], "markets")
 
         security_type = _get_user_input_or_prompt(security_type, data_provider_support_security_types,
                                                   data_provider_historical, "Select a Ticker's security type")


### PR DESCRIPTION
### Description
This Pull Request introduces several new features and improvements to our data downloader:

1. **New (optional) parameter in `lean data downloader`**: `--data-downloader-brokerage`
    - A new command has been added to the download parameters. This command is used when we utilize a generic historical provider of brokerages.
    
2. **Historical Provider for Alpaca and TradeStation**
    - Added support for Alpaca as a historical data provider.
    - Added support for TradeStation as a historical data provider.
    - This enhancement allows users to fetch historical data from these two popular brokerage services.

3. **Default Market for Crypto SecurityType**
    - A default market is now assigned when using the Crypto SecurityType.
    - This update simplifies the process of downloading historical data for cryptocurrency by automatically selecting a default market.
