### PR TITLE
Fix 479 no update command

### DIFF
--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -16,7 +16,7 @@ from typing import List, Optional, Tuple
 from click import command, option, argument, Choice
 
 from lean.click import LeanCommand, PathParameter
-from lean.constants import DEFAULT_ENGINE_IMAGE, LEAN_ROOT_PATH
+from lean.constants import DEFAULT_ENGINE_IMAGE, LEAN_ROOT_PATH, CONTAINER_LABEL_LEAN_VERSION_NAME
 from lean.container import container, Logger
 from lean.models.utils import DebuggingMethod
 from lean.models.cli import cli_data_downloaders, cli_addon_modules
@@ -359,20 +359,23 @@ def backtest(project: Path,
     organization_id = container.organization_manager.try_get_working_organization_id()
     paths_to_mount = None
 
-    if data_provider_historical is not None:
-        data_provider = non_interactive_config_build_for_name(lean_config, data_provider_historical,
-                                                              cli_data_downloaders, kwargs, logger, environment_name)
-        data_provider.ensure_module_installed(organization_id)
-        container.lean_config_manager.set_properties(data_provider.get_settings())
-        paths_to_mount = data_provider.get_paths_to_mount()
-
-    lean_config_manager.configure_data_purchase_limit(lean_config, data_purchase_limit)
-
     cli_config_manager = container.cli_config_manager
     project_config_manager = container.project_config_manager
 
     project_config = project_config_manager.get_project_config(algorithm_file.parent)
     engine_image = cli_config_manager.get_engine_image(image or project_config.get("engine-image", None))
+
+    container_module_version = container.docker_manager.get_image_label(engine_image,
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+
+    if data_provider_historical is not None:
+        data_provider = non_interactive_config_build_for_name(lean_config, data_provider_historical,
+                                                              cli_data_downloaders, kwargs, logger, environment_name)
+        data_provider.ensure_module_installed(organization_id, container_module_version)
+        container.lean_config_manager.set_properties(data_provider.get_settings())
+        paths_to_mount = data_provider.get_paths_to_mount()
+
+    lean_config_manager.configure_data_purchase_limit(lean_config, data_purchase_limit)
 
     if str(engine_image) != DEFAULT_ENGINE_IMAGE:
         logger.warn(f'A custom engine image: "{engine_image}" is being used!')

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -366,7 +366,7 @@ def backtest(project: Path,
     engine_image = cli_config_manager.get_engine_image(image or project_config.get("engine-image", None))
 
     container_module_version = container.docker_manager.get_image_label(engine_image,
-                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, None)
 
     if data_provider_historical is not None:
         data_provider = non_interactive_config_build_for_name(lean_config, data_provider_historical,

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -684,8 +684,7 @@ def download(ctx: Context,
         container.update_manager.pull_docker_image_if_necessary(engine_image, update, no_update)
 
         container_module_version = container.docker_manager.get_image_label(engine_image,
-                                                                            CONTAINER_LABEL_LEAN_VERSION_NAME,
-                                                                            "Unknown")
+                                                                            CONTAINER_LABEL_LEAN_VERSION_NAME, None)
 
         data_downloader_provider = config_build_for_name(lean_config, data_downloader_provider.get_name(),
                                                          cli_data_downloaders, kwargs, logger, interactive=True)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -278,7 +278,7 @@ def deploy(project: Path,
     engine_image = cli_config_manager.get_engine_image(image or project_config.get("engine-image", None))
 
     container_module_version = container.docker_manager.get_image_label(engine_image,
-                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, None)
 
     organization_id = container.organization_manager.try_get_working_organization_id()
     paths_to_mount = {}

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from click import option, argument, Choice
 from lean.click import LeanCommand, PathParameter
 from lean.components.util.name_rename import rename_internal_config_to_user_friendly_format
-from lean.constants import DEFAULT_ENGINE_IMAGE
+from lean.constants import DEFAULT_ENGINE_IMAGE, CONTAINER_LABEL_LEAN_VERSION_NAME
 from lean.container import container
 from lean.models.cli import (cli_brokerages, cli_data_queue_handlers, cli_data_downloaders,
                              cli_addon_modules, cli_history_provider)
@@ -271,22 +271,25 @@ def deploy(project: Path,
                                                                  kwargs, logger, interactive=True,
                                                                  environment_name=environment_name))
 
-    organization_id = container.organization_manager.try_get_working_organization_id()
-    paths_to_mount = {}
-    for module in (data_provider_live_instances + [data_downloader_instances, brokerage_instance]
-                   + history_providers_instances):
-        module.ensure_module_installed(organization_id)
-        paths_to_mount.update(module.get_paths_to_mount())
-
-    if not lean_config["environments"][environment_name]["live-mode"]:
-        raise MoreInfoError(f"The '{environment_name}' is not a live trading environment (live-mode is set to false)",
-                            "https://www.lean.io/docs/v2/lean-cli/live-trading/brokerages/quantconnect-paper-trading")
-
     project_config_manager = container.project_config_manager
     cli_config_manager = container.cli_config_manager
 
     project_config = project_config_manager.get_project_config(algorithm_file.parent)
     engine_image = cli_config_manager.get_engine_image(image or project_config.get("engine-image", None))
+
+    container_module_version = container.docker_manager.get_image_label(engine_image,
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+
+    organization_id = container.organization_manager.try_get_working_organization_id()
+    paths_to_mount = {}
+    for module in (data_provider_live_instances + [data_downloader_instances, brokerage_instance]
+                   + history_providers_instances):
+        module.ensure_module_installed(organization_id, container_module_version)
+        paths_to_mount.update(module.get_paths_to_mount())
+
+    if not lean_config["environments"][environment_name]["live-mode"]:
+        raise MoreInfoError(f"The '{environment_name}' is not a live trading environment (live-mode is set to false)",
+                            "https://www.lean.io/docs/v2/lean-cli/live-trading/brokerages/quantconnect-paper-trading")
 
     container.update_manager.pull_docker_image_if_necessary(engine_image, update, no_update)
 

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -19,7 +19,7 @@ from click import command, argument, option, Choice, IntRange
 
 from lean.click import LeanCommand, PathParameter, ensure_options
 from lean.components.docker.lean_runner import LeanRunner
-from lean.constants import DEFAULT_ENGINE_IMAGE
+from lean.constants import DEFAULT_ENGINE_IMAGE, CONTAINER_LABEL_LEAN_VERSION_NAME
 from lean.container import container
 from lean.models.api import QCParameter, QCBacktest
 from lean.models.click_options import options_from_json, get_configs_for_options
@@ -307,10 +307,12 @@ def optimize(project: Path,
 
     paths_to_mount = None
 
+    container_module_version = container.docker_manager.get_image_label(engine_image,                                                                 CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+
     if data_provider_historical is not None:
         data_provider = non_interactive_config_build_for_name(lean_config, data_provider_historical,
                                                               cli_data_downloaders, kwargs, logger, environment_name)
-        data_provider.ensure_module_installed(organization_id)
+        data_provider.ensure_module_installed(organization_id, container_module_version)
         container.lean_config_manager.set_properties(data_provider.get_settings())
         paths_to_mount = data_provider.get_paths_to_mount()
 

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -307,7 +307,8 @@ def optimize(project: Path,
 
     paths_to_mount = None
 
-    container_module_version = container.docker_manager.get_image_label(engine_image,                                                                 CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+    container_module_version = container.docker_manager.get_image_label(engine_image,
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, None)
 
     if data_provider_historical is not None:
         data_provider = non_interactive_config_build_for_name(lean_config, data_provider_historical,

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -16,7 +16,7 @@ from typing import Optional, Tuple
 from click import command, argument, option, Choice
 from lean.click import LeanCommand, PathParameter
 from lean.components.docker.lean_runner import LeanRunner
-from lean.constants import DEFAULT_RESEARCH_IMAGE, LEAN_ROOT_PATH
+from lean.constants import DEFAULT_RESEARCH_IMAGE, LEAN_ROOT_PATH, CONTAINER_LABEL_LEAN_VERSION_NAME
 from lean.container import container
 from lean.models.cli import cli_data_downloaders
 from lean.components.util.name_extraction import convert_to_class_name
@@ -113,13 +113,27 @@ def research(project: Path,
     if download_data:
         data_provider_historical = "QuantConnect"
 
+    project_config_manager = container.project_config_manager
+    cli_config_manager = container.cli_config_manager
+
+    project_config = project_config_manager.get_project_config(algorithm_file.parent)
+    research_image = cli_config_manager.get_research_image(image or project_config.get("research-image", None))
+
+    container.update_manager.pull_docker_image_if_necessary(research_image, update, no_update)
+
+    container_module_version = container.docker_manager.get_image_label(research_image,
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+
+    if str(research_image) != DEFAULT_RESEARCH_IMAGE:
+        logger.warn(f'A custom research image: "{research_image}" is being used!')
+
     paths_to_mount = None
 
     if data_provider_historical is not None:
         organization_id = container.organization_manager.try_get_working_organization_id()
         data_provider = non_interactive_config_build_for_name(lean_config, data_provider_historical,
                                                               cli_data_downloaders, kwargs, logger, environment_name)
-        data_provider.ensure_module_installed(organization_id)
+        data_provider.ensure_module_installed(organization_id, container_module_version)
         container.lean_config_manager.set_properties(data_provider.get_settings())
         paths_to_mount = data_provider.get_paths_to_mount()
     lean_config_manager.configure_data_purchase_limit(lean_config, data_purchase_limit)
@@ -130,17 +144,6 @@ def research(project: Path,
     # Set extra config
     for key, value in extra_config:
         lean_config[key] = value
-
-    project_config_manager = container.project_config_manager
-    cli_config_manager = container.cli_config_manager
-
-    project_config = project_config_manager.get_project_config(algorithm_file.parent)
-    research_image = cli_config_manager.get_research_image(image or project_config.get("research-image", None))
-
-    container.update_manager.pull_docker_image_if_necessary(research_image, update, no_update)
-
-    if str(research_image) != DEFAULT_RESEARCH_IMAGE:
-        logger.warn(f'A custom research image: "{research_image}" is being used!')
 
     run_options = lean_runner.get_basic_docker_config(lean_config,
                                                       algorithm_file,

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -122,7 +122,7 @@ def research(project: Path,
     container.update_manager.pull_docker_image_if_necessary(research_image, update, no_update)
 
     container_module_version = container.docker_manager.get_image_label(research_image,
-                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, "Unknown")
+                                                                        CONTAINER_LABEL_LEAN_VERSION_NAME, None)
 
     if str(research_image) != DEFAULT_RESEARCH_IMAGE:
         logger.warn(f'A custom research image: "{research_image}" is being used!')

--- a/lean/components/cloud/module_manager.py
+++ b/lean/components/cloud/module_manager.py
@@ -61,7 +61,6 @@ class ModuleManager:
 
             if package.name not in packages_to_download or package.version > packages_to_download[package.name].version:
                 packages_to_download[package.name] = package
-                self._logger.debug(f'module_manager.install_module: {package.version}')
                 if module_version and package.version.split('.')[-1] == module_version:
                     self._logger.debug(f'module_manager.install_module:'
                                        f'Found requested version {module_version} for module {product_id}.')

--- a/lean/components/cloud/module_manager.py
+++ b/lean/components/cloud/module_manager.py
@@ -37,7 +37,7 @@ class ModuleManager:
         self._installed_product_ids: Set[int] = set()
         self._installed_packages: Dict[int, List[NuGetPackage]] = {}
 
-    def install_module(self, product_id: int, organization_id: str, module_version: str = None) -> None:
+    def install_module(self, product_id: int, organization_id: str, module_version: str) -> None:
         """
         Installs a module into the global modules' directory.
 
@@ -48,7 +48,7 @@ class ModuleManager:
         Args:
         product_id (int): The product id of the module to download.
         organization_id (str): The id of the organization that has a license for the module.
-        module_version (str, optional): The specific version of the module to install. If None, installs the latest version.
+        module_version (str): The specific version of the module to install. If None, installs the latest version.
         """
         if product_id in self._installed_product_ids:
             return

--- a/lean/components/cloud/module_manager.py
+++ b/lean/components/cloud/module_manager.py
@@ -53,15 +53,21 @@ class ModuleManager:
         if product_id in self._installed_product_ids:
             return
 
+        # Retrieve the list of module files for the specified product and organization
         module_files = self._api_client.modules.list_files(product_id, organization_id)
+        # Dictionaries to store the latest packages to download and specific version packages
         packages_to_download: Dict[str, NuGetPackage] = {}
         packages_to_download_specific_version: Dict[str, NuGetPackage] = {}
 
-        for file_name in module_files:
-            package = NuGetPackage.parse(file_name)
+        # Parse the module files into NuGetPackage objects and sort them by version
+        packages = [NuGetPackage.parse(file_name) for file_name in module_files]
+        sorted_packages = sorted(packages, key=lambda p: p.version)
 
+        for package in sorted_packages:
+            # Store the latest version of each package
             if package.name not in packages_to_download or package.version > packages_to_download[package.name].version:
                 packages_to_download[package.name] = package
+                # If a specific version is requested, keep track of the highest version <= module_version
                 if module_version and package.version.split('.')[-1] <= module_version:
                     packages_to_download_specific_version[package.name] = package
 

--- a/lean/components/cloud/module_manager.py
+++ b/lean/components/cloud/module_manager.py
@@ -63,8 +63,6 @@ class ModuleManager:
             if package.name not in packages_to_download or package.version > packages_to_download[package.name].version:
                 packages_to_download[package.name] = package
                 if module_version and package.version.split('.')[-1] <= module_version:
-                    self._logger.debug(f'module_manager.install_module:'
-                                       f'Found requested version {module_version} for module {product_id}.')
                     packages_to_download_specific_version[package.name] = package
 
         # Replace version packages based on module_version if available
@@ -72,6 +70,9 @@ class ModuleManager:
             packages_to_download[package_name] = package_specific_version
 
         for package in packages_to_download.values():
+            if module_version and package.version.split('.')[-1] != module_version:
+                self._logger.debug(f'Package "{package.name}" does not have the specified version {module_version}. '
+                                   f'Using available version {package.version} instead.')
             self._download_file(product_id, organization_id, package)
 
         self._installed_product_ids.add(product_id)

--- a/lean/components/cloud/module_manager.py
+++ b/lean/components/cloud/module_manager.py
@@ -72,7 +72,6 @@ class ModuleManager:
             packages_to_download[package_name] = package_specific_version
 
         for package in packages_to_download.values():
-            self._logger.info(f'install_module.package: {package}')
             self._download_file(product_id, organization_id, package)
 
         self._installed_product_ids.add(product_id)

--- a/lean/components/util/json_modules_handler.py
+++ b/lean/components/util/json_modules_handler.py
@@ -33,7 +33,6 @@ def build_and_configure_modules(target_modules: List[str], module_list: List[Jso
     for target_module_name in target_modules:
         module = non_interactive_config_build_for_name(lean_config, target_module_name, module_list, properties,
                                                        logger, environment_name)
-        module.ensure_module_installed(organization_id)
         lean_config["environments"][environment_name].update(module.get_settings())
 
 

--- a/lean/constants.py
+++ b/lean/constants.py
@@ -26,6 +26,9 @@ DEFAULT_LEAN_PYTHON_VERSION = "3.11"
 DEFAULT_LEAN_STRICT_PYTHON_VERSION = f"{DEFAULT_LEAN_PYTHON_VERSION}.7"
 DEFAULT_LEAN_DOTNET_FRAMEWORK = "net6.0"
 
+# Label name used in Docker containers to specify the version of Lean being used
+CONTAINER_LABEL_LEAN_VERSION_NAME = "lean_version"
+
 # The path to the root python directory in docker image
 DOCKER_PYTHON_SITE_PACKAGES_PATH = "/root/.local/lib/python{LEAN_PYTHON_VERSION}/site-packages"
 

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -246,11 +246,21 @@ class JsonModule(ABC):
                 if (isinstance(config, PathParameterUserInput)
                     and self._check_if_config_passes_filters(config, all_for_platform_type=False))}
 
-    def ensure_module_installed(self, organization_id: str) -> None:
+    def ensure_module_installed(self, organization_id: str, module_version: str = None) -> None:
+        """
+        Ensures that the specified module is installed. If the module is not installed, it will be installed.
+
+        Args:
+            organization_id (str): The ID of the organization where the module should be installed.
+            module_version (str, optional): The version of the module to install. If not provided,
+            the latest version will be installed.
+
+        Returns:
+            None
+        """
         if not self._is_module_installed and self._installs:
             container.logger.debug(f"JsonModule.ensure_module_installed(): installing module {self}: {self._product_id}")
-            container.module_manager.install_module(
-                self._product_id, organization_id)
+            container.module_manager.install_module(self._product_id, organization_id, module_version)
             self._is_module_installed = True
 
     def get_default(self, lean_config: Dict[str, Any], key: str, environment_name: str, logger: Logger):

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -246,13 +246,13 @@ class JsonModule(ABC):
                 if (isinstance(config, PathParameterUserInput)
                     and self._check_if_config_passes_filters(config, all_for_platform_type=False))}
 
-    def ensure_module_installed(self, organization_id: str, module_version: str = None) -> None:
+    def ensure_module_installed(self, organization_id: str, module_version: str) -> None:
         """
         Ensures that the specified module is installed. If the module is not installed, it will be installed.
 
         Args:
             organization_id (str): The ID of the organization where the module should be installed.
-            module_version (str, optional): The version of the module to install. If not provided,
+            module_version (str): The version of the module to install. If not provided,
             the latest version will be installed.
 
         Returns:


### PR DESCRIPTION
### Description
This update modifies the behavior of module versioning, making it dependent on the `lean_version` specified within the container. For example, if the container is set with `lean_version = 2.5.16563`, then when specifying a data provider, such as --data-provider-historical Alpaca, the corresponding version of the Alpaca module will be downloaded that matches this specific `lean_version`.

### Related Issue
Closes #479 

### Motivation and Context
This change is crucial for maintaining version consistency across the project. By tying the module versions directly to the `lean_version`, we ensure that all components—such as data providers like Alpaca—are using the appropriate versions that are compatible with the specified `lean_version`. This reduces the risk of incompatibilities and streamlines the module management process.

### How Has This Been Tested?
#### lean research
In advance, I have create custom 🐳 **research image** with labels:
```
...
"Labels": {
    "lean_version": "16563"
    ...
}
...
```
- `lean research mynewalgo --data-provider-historical alpaca`
![image](https://github.com/user-attachments/assets/ba706418-d6fb-43d4-8bff-da956ba2188c)
#### lean backtest
- `lean backtest mynewalgo --data-provider-historical alpaca`
![image](https://github.com/user-attachments/assets/eff6d927-a41c-400b-aac7-bbfc820c6f67)

#### lean data download
- `lean data download --data-provider-historical alpaca --data-type trade --resolution daily --security-type Equity --ticker AAPL --start 20240101 --end 20240801`
![image](https://github.com/user-attachments/assets/a0353045-c0c3-4145-b9a9-2d1920e3187a)

#### lean live deploy
- `lean live deploy mynewalgo --brokerage "Paper Trading" --data-provider-live "Alpaca"`
![image](https://github.com/user-attachments/assets/903260e9-6e9f-499a-a855-0201cc378f8b)
- `lean live deploy mynewalgo --brokerage "Paper Trading" --data-provider-live "Interactive Brokers"` 
  - use latest version of image `2.5.16567` 🐳 without label `lean_version`.
![image](https://github.com/user-attachments/assets/463a6927-d09e-40a5-b717-9cddf9bc1ce5)

- `lean live deploy mynewalgo --brokerage "Interactive Brokers" --data-provider-live "Kraken"`
> We use custom version of container with label look at screen bellow. Also, we have downloaded last available version of `QuantConnect.Brokerages.InteractiveBrokers.ToolBox.2.5.`**`16550`**.

![image](https://github.com/user-attachments/assets/058bc149-b5aa-4aa9-8223-35ca9a903d20)

- `lean live deploy mynewalgo --brokerage "Coinbase Advanced Trade" --data-provider-live "Kraken"`
> use latest version of container 🐳 **without label**

![image](https://github.com/user-attachments/assets/94211956-88b9-4373-9311-5d3185a7f38a)

- `lean live deploy mynewalgo --brokerage "Coinbase Advanced Trade" --data-provider-live "Kraken"`
> We have used label version bigger than available package in cloud. It's mean, we will use maximum available package in cloud `<=`

![image](https://github.com/user-attachments/assets/11d629f7-bc4b-4614-9ce8-9298f626dec2)

- `lean live deploy mynewalgo --brokerage "Interactive Brokers" --data-provider-live "Kraken" --verbose`
> add log debug message.

![image](https://github.com/user-attachments/assets/a649ca12-2bda-43c5-9aad-72fa3e6b3ee4)

