### PR TITLE
Remove: optional parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
-  --iqfeed-host TEXT              The IQFeed host address
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -207,8 +206,6 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
-                                  Your Bybit VIP Level
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -859,7 +856,6 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
-  --iqfeed-host TEXT              The IQFeed host address
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -890,8 +886,6 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
-                                  Your Bybit VIP Level
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -1362,7 +1356,6 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
-  --iqfeed-host TEXT              The IQFeed host address
   --polygon-api-key TEXT          Your Polygon.io API Key
   --iex-cloud-api-key TEXT        Your iexcloud.io API token publishable key
   --iex-price-plan [Launch|Grow|Enterprise]
@@ -1730,7 +1723,6 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
-  --iqfeed-host TEXT              The IQFeed host address
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -1761,8 +1753,6 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
-                                  Your Bybit VIP Level
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -1903,7 +1893,6 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
-  --iqfeed-host TEXT              The IQFeed host address
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -1934,8 +1923,6 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
-                                  Your Bybit VIP Level
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
+  --iqfeed-host TEXT              The IQFeed host address (Optional).
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -856,6 +857,7 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
+  --iqfeed-host TEXT              The IQFeed host address (Optional).
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -1356,6 +1358,7 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
+  --iqfeed-host TEXT              The IQFeed host address (Optional).
   --polygon-api-key TEXT          Your Polygon.io API Key
   --iex-cloud-api-key TEXT        Your iexcloud.io API token publishable key
   --iex-price-plan [Launch|Grow|Enterprise]
@@ -1723,6 +1726,7 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
+  --iqfeed-host TEXT              The IQFeed host address (Optional).
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file
@@ -1893,6 +1897,7 @@ Options:
   --iqfeed-username TEXT          Your IQFeed username
   --iqfeed-password TEXT          Your IQFeed password
   --iqfeed-version TEXT           The product version of your IQFeed developer account
+  --iqfeed-host TEXT              The IQFeed host address (Optional).
   --polygon-api-key TEXT          Your Polygon.io API Key
   --factset-auth-config-file FILE
                                   The path to the FactSet authentication configuration file


### PR DESCRIPTION
### Description
#### Terminal Link
All parameters should be mandatory for Terminal Link, as they are necessary for the brokerage to run properly - [code](https://github.com/QuantConnect/Lean.Brokerages.TerminalLink/blob/75c51de53831a5017adbfa3e91d3ebb2d912b3f2/QuantConnect.TerminalLink/TerminalLinkBrokerage.DataQueueHandler.cs#L103)
#### IQFeed
We can use the `--iqfeed-host` property internally.
#### ByBit
Make `--bybit-vip-level` optional and only use it when operating like a brokerage - [code](https://github.com/QuantConnect/Lean.Brokerages.ByBit/blob/d1703f14870608a93ab69d2b1c4b38c1f23475e5/QuantConnect.BybitBrokerage/BybitBrokerage.DataQueueHandler.cs#L70)
### Related Issue
Closes https://github.com/QuantConnect/lean-cli/issues/480