### PR TITLE
Fix: not save non interactive user properties 

### DIFF
--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -223,15 +223,17 @@ class JsonModule(ABC):
                     if interactive:
                         default_value = configuration._input_default
                         user_choice = configuration.ask_user_for_input(default_value, logger, hide_input=hide_input)
-
-                        if not isinstance(configuration, BrokerageEnvConfiguration):
-                            self._save_property({f"{configuration._id}": user_choice})
                     else:
                         if configuration._input_default != None and configuration._optional:
                             # if optional and we have a default input value and the user didn't provider it we use it
                             user_choice = configuration._input_default
                         else:
                             missing_options.append(f"--{configuration._id}")
+
+            if not isinstance(configuration, BrokerageEnvConfiguration):
+                logger.debug(f"Retaining configuration ID '{configuration._id}' as '{user_choice}' "
+                             f"in the configuration file.")
+                self._save_property({f"{configuration._id}": user_choice})
 
             configuration._value = user_choice
 


### PR DESCRIPTION
### Description
This PR addresses an issue where the configuration parameter passed in non-interactive mode, such as `--tradier-environment paper`, is not saved in the `lean.json` file. The fix ensures that these parameters are properly recorded, regardless of whether Lean is run in interactive or non-interactive mode.

### Related Issue
Closes #461 

### Motivation and Context
The issue was identified when running Lean in non-interactive mode. Users who passed configuration parameters, like `--tradier-environment paper`, noticed that these were not being saved in the `lean.json` file. This behavior was inconsistent with the expected functionality, as in interactive mode, parameters were saved correctly.

This PR corrects the behavior, ensuring that configuration parameters are consistently saved across both interactive and non-interactive modes. This change improves the user experience by maintaining consistency and ensuring that user preferences are retained for future use.

### How Has This Been Tested?
run in 2 ways:
1. interactive -> `lean live deploy mynewalgo` -> save in configuration file;
2. non_interactive -> `lean live deploy mynewalgo --data-provider-live tradier --tradier-environment live` -> save in configuration file.