### PR TITLE
Feat: More informative exception message in `lean logs` command

### DIFF
--- a/lean/commands/logs.py
+++ b/lean/commands/logs.py
@@ -89,6 +89,7 @@ def logs(backtest: bool, live: bool, optimization: bool, project: Optional[Path]
                 most_recent_timestamp = log_file_timestamp
 
     if most_recent_file is None:
-        raise RuntimeError(f"No {mode} log file exists")
+        raise RuntimeError(f"Unable to locate the {mode} log file."
+                           f"Please ensure the '--project' argument is specified, e.g., --project '.\\<Project_name>'.")
 
     print(most_recent_file.read_text(encoding="utf-8").strip())

--- a/lean/commands/logs.py
+++ b/lean/commands/logs.py
@@ -89,7 +89,7 @@ def logs(backtest: bool, live: bool, optimization: bool, project: Optional[Path]
                 most_recent_timestamp = log_file_timestamp
 
     if most_recent_file is None:
-        raise RuntimeError(f"Unable to locate the {mode} log file."
-                           f"Please ensure the '--project' argument is specified, e.g., --project '.\\<Project_name>'.")
+        raise RuntimeError(f"Unable to locate the {mode} log file, no recent run was found. "
+                           "Please provide the '--project' argument, e.g., --project '<Project_path>'.")
 
     print(most_recent_file.read_text(encoding="utf-8").strip())


### PR DESCRIPTION
### Description
This pull request addresses an issue where the script could not locate the most recent log file for the specified mode, leading to a `RuntimeError`. The error message has been made more user-friendly by providing clearer instructions to the user on how to resolve the issue.

#### Changes Made:
- Updated the `RuntimeError` exception message to be more descriptive and user-friendly.
- The new message now suggests specifying the `--project` argument explicitly if the log file cannot be found.

### Related Issue
Closes #463 

### Motivation and Context
The previous error message was less informative and could be confusing for users who are unfamiliar with the specific requirements of the script. By improving the clarity of the message, we aim to reduce the potential for user error and enhance the overall usability of the script. This change is particularly important for new users who might not be aware of the necessity of the `--project` argument when the log file is not found.

### How Has This Been Tested?
![image](https://github.com/user-attachments/assets/f1d4f0e3-63a8-4e95-96ae-45559d3163e2)
