### PR TITLE
Fix research function to work without an algorithm file

### DIFF
--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -102,6 +102,9 @@ def research(project: Path,
 
     project_manager = container.project_manager
     algorithm_file = project_manager.find_algorithm_file(project, not_throw = True)
+
+    # We just need the algorithm file name to create the configurations for lean and
+    # the docker container. We do not need an algorithm file to run a research project
     if algorithm_file is None:
         algorithm_file = project / 'main.py'
     algorithm_name = convert_to_class_name(project)

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -101,7 +101,9 @@ def research(project: Path,
     logger = container.logger
 
     project_manager = container.project_manager
-    algorithm_file = project_manager.find_algorithm_file(project)
+    algorithm_file = project_manager.find_algorithm_file(project, not_throw = True)
+    if algorithm_file is None:
+        algorithm_file = project / 'main.py'
     algorithm_name = convert_to_class_name(project)
 
     environment_name = "backtesting"

--- a/lean/components/util/project_manager.py
+++ b/lean/components/util/project_manager.py
@@ -58,12 +58,14 @@ class ProjectManager:
         self._cli_config_manager = cli_config_manager
         self._docker_manager = docker_manager
 
-    def find_algorithm_file(self, input: Path) -> Path:
+    def find_algorithm_file(self, input: Path, not_throw: bool = False) -> Path:
         """Returns the path to the file containing the algorithm.
 
         Raises an error if the algorithm file cannot be found.
 
         :param input: the path to the algorithm or the path to the project
+        :param not_throw: a flag indicating whether this method should
+        raise an exception if the file is not found
         :return: the path to the file containing the algorithm
         """
         if input.is_file():
@@ -74,6 +76,8 @@ class ProjectManager:
             if target_file.exists():
                 return target_file
 
+        if not_throw:
+            return None
         raise ValueError("The specified project does not contain a main.py or Main.cs file")
 
     def get_project_by_id(self, local_id: int) -> Path:


### PR DESCRIPTION
The algorithm name is just used to create the configurations for lean and the docker container in the `research()` function. The content of the file is never used, and it doesn't even need to exist. Thus, I added an optional argument in `project_manager.find_algorithm_file` to not throw an exception when the file is not found but instead return `None`. Then, if the result is `None` we just use a default python algorithm file name for the variable `algorithm_file` so that we can create the configs we need.