### PR TITLE
Fix: missed installing extra modules

### DIFF
--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -405,7 +405,7 @@ def backtest(project: Path,
 
     # Configure addon modules
     build_and_configure_modules(addon_module, cli_addon_modules, organization_id, lean_config,
-                                kwargs, logger, environment_name)
+                                kwargs, logger, environment_name, container_module_version)
 
     lean_runner = container.lean_runner
     lean_runner.run_lean(lean_config,

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -352,7 +352,7 @@ def deploy(project: Path,
 
     # Configure addon modules
     build_and_configure_modules(addon_module, cli_addon_modules, organization_id, lean_config,
-                                kwargs, logger, environment_name)
+                                kwargs, logger, environment_name, container_module_version)
 
     if container.platform_manager.is_host_arm():
         if "InteractiveBrokersBrokerage" in lean_config["environments"][environment_name]["live-mode-brokerage"] \

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -340,7 +340,7 @@ def optimize(project: Path,
 
     # Configure addon modules
     build_and_configure_modules(addon_module, cli_addon_modules, organization_id, lean_config,
-                                kwargs, logger, environment_name)
+                                kwargs, logger, environment_name, container_module_version)
 
     container.update_manager.pull_docker_image_if_necessary(engine_image, update, no_update)
 

--- a/lean/components/util/json_modules_handler.py
+++ b/lean/components/util/json_modules_handler.py
@@ -34,6 +34,7 @@ def build_and_configure_modules(target_modules: List[str], module_list: List[Jso
     for target_module_name in target_modules:
         module = non_interactive_config_build_for_name(lean_config, target_module_name, module_list, properties,
                                                        logger, environment_name)
+        # Ensures extra modules (not brokerage or data feeds) are installed.
         module.ensure_module_installed(organization_id, module_version)
         lean_config["environments"][environment_name].update(module.get_settings())
 

--- a/lean/components/util/json_modules_handler.py
+++ b/lean/components/util/json_modules_handler.py
@@ -19,7 +19,7 @@ from lean.models.logger import Option
 
 def build_and_configure_modules(target_modules: List[str], module_list: List[JsonModule], organization_id: str,
                                 lean_config: Dict[str, Any], properties: Dict[str, Any], logger: Logger,
-                                environment_name: str):
+                                environment_name: str, module_version: str):
     """Builds and configures the given modules
 
     :param target_modules: the requested modules
@@ -29,10 +29,12 @@ def build_and_configure_modules(target_modules: List[str], module_list: List[Jso
     :param properties: the user provided arguments
     :param logger: the logger instance
     :param environment_name: the environment name to use
+    :param module_version: The version of the module to install. If not provided, the latest version will be installed.
     """
     for target_module_name in target_modules:
         module = non_interactive_config_build_for_name(lean_config, target_module_name, module_list, properties,
                                                        logger, environment_name)
+        module.ensure_module_installed(organization_id, module_version)
         lean_config["environments"][environment_name].update(module.get_settings())
 
 


### PR DESCRIPTION
#### Description
We have gotten that users cannot use extra modules with their algorithm.
![image](https://github.com/user-attachments/assets/b7e7b414-2759-4657-8765-2f3ed15a9d1d)

#### Related PRs
- #485. Removed crucial part to install **extra** modules. - [code](https://github.com/QuantConnect/lean-cli/pull/485/files#diff-fb286f5b13547a8f650fc4c6fcf636673177e04bd316083faeae1b0c3afd5b7aL36)

#### How Has This Been Tested?
- `lean backtest <algo_name> --addon-module "Gui Messaging Handler"`
![image](https://github.com/user-attachments/assets/7a8dcc4f-e17c-401c-a6bc-b6075b0d1204)

- `lean live deploy <algo_name> --addon-module "Gui Messaging Handler"`
![image](https://github.com/user-attachments/assets/857f9a1e-f88e-4c47-bcf4-20534f349925)

