### PR TITLE
Feature: support new config type `account-id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -433,6 +435,8 @@ Options:
   --bybit-api-secret TEXT         Your Bybit API secret
   --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
                                   Your Bybit VIP Level
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -912,6 +916,8 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -1390,6 +1396,8 @@ Options:
                                   Your Bybit VIP Level
   --bybit-use-testnet [live|paper]
                                   Whether the testnet should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -1803,6 +1811,8 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]
@@ -1975,6 +1985,8 @@ Options:
                                   The Open FIGI API key to use for mapping options
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --trade-station-account-type [Cash|Margin|Futures|DVP]

--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ Options:
                                   The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
-  --trade-station-account-type [Cash|Margin|Futures|DVP]
-                                  Specifies the type of account on TradeStation
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
@@ -439,8 +437,6 @@ Options:
                                   The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
-  --trade-station-account-type [Cash|Margin|Futures|DVP]
-                                  Specifies the type of account on TradeStation
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --polygon-api-key TEXT          Your Polygon.io API Key
@@ -920,8 +916,6 @@ Options:
                                   The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
-  --trade-station-account-type [Cash|Margin|Futures|DVP]
-                                  Specifies the type of account on TradeStation
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --dataset TEXT                  The name of the dataset to download non-interactively
@@ -1400,8 +1394,6 @@ Options:
                                   The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
-  --trade-station-account-type [Cash|Margin|Futures|DVP]
-                                  Specifies the type of account on TradeStation
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --ib-enable-delayed-streaming-data BOOLEAN
@@ -1815,8 +1807,6 @@ Options:
                                   The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
-  --trade-station-account-type [Cash|Margin|Futures|DVP]
-                                  Specifies the type of account on TradeStation
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
@@ -1989,8 +1979,6 @@ Options:
                                   The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
-  --trade-station-account-type [Cash|Margin|Futures|DVP]
-                                  Specifies the type of account on TradeStation
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias

--- a/README.md
+++ b/README.md
@@ -198,8 +198,6 @@ Options:
                                   Your ThetaData subscription price plan
   --terminal-link-connection-type [DAPI|SAPI]
                                   Terminal Link Connection Type [DAPI, SAPI]
-  --terminal-link-server-auth-id TEXT
-                                  The Auth ID of the TerminalLink server
   --terminal-link-environment [Production|Beta]
                                   The environment to run in
   --terminal-link-server-host TEXT
@@ -208,12 +206,14 @@ Options:
                                   The port of the TerminalLink server
   --terminal-link-openfigi-api-key TEXT
                                   The Open FIGI API key to use for mapping options
+  --terminal-link-server-auth-id TEXT
+                                  The Auth ID of the TerminalLink server
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --trade-station-account-id TEXT
-                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
@@ -433,10 +433,10 @@ Options:
   --bybit-api-secret TEXT         Your Bybit API secret
   --bybit-vip-level [VIP0|VIP1|VIP2|VIP3|VIP4|VIP5|SupremeVIP|Pro1|Pro2|Pro3|Pro4|Pro5]
                                   Your Bybit VIP Level
-  --trade-station-account-id TEXT
-                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --polygon-api-key TEXT          Your Polygon.io API Key
@@ -900,8 +900,6 @@ Options:
                                   Your ThetaData subscription price plan
   --terminal-link-connection-type [DAPI|SAPI]
                                   Terminal Link Connection Type [DAPI, SAPI]
-  --terminal-link-server-auth-id TEXT
-                                  The Auth ID of the TerminalLink server
   --terminal-link-environment [Production|Beta]
                                   The environment to run in
   --terminal-link-server-host TEXT
@@ -910,12 +908,14 @@ Options:
                                   The port of the TerminalLink server
   --terminal-link-openfigi-api-key TEXT
                                   The Open FIGI API key to use for mapping options
+  --terminal-link-server-auth-id TEXT
+                                  The Auth ID of the TerminalLink server
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --trade-station-account-id TEXT
-                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --dataset TEXT                  The name of the dataset to download non-interactively
@@ -1341,8 +1341,6 @@ Options:
                                   commodities on MCX
   --terminal-link-connection-type [DAPI|SAPI]
                                   Terminal Link Connection Type [DAPI, SAPI]
-  --terminal-link-server-auth-id TEXT
-                                  The Auth ID of the TerminalLink server
   --terminal-link-environment [Production|Beta]
                                   The environment to run in
   --terminal-link-server-host TEXT
@@ -1356,20 +1354,22 @@ Options:
   --terminal-link-emsx-team TEXT  The EMSX team to receive order events from (Optional).
   --terminal-link-openfigi-api-key TEXT
                                   The Open FIGI API key to use for mapping options
+  --terminal-link-server-auth-id TEXT
+                                  The Auth ID of the TerminalLink server
   --tt-user-name TEXT             Your Trading Technologies username
   --tt-session-password TEXT      Your Trading Technologies session password
   --tt-account-name TEXT          Your Trading Technologies account name
   --tt-rest-app-key TEXT          Your Trading Technologies REST app key
   --tt-rest-app-secret TEXT       Your Trading Technologies REST app secret
   --tt-rest-environment TEXT      The REST environment to run in
+  --tt-order-routing-sender-comp-id TEXT
+                                  The order routing sender comp id to use
   --tt-market-data-sender-comp-id TEXT
                                   The market data sender comp id to use
   --tt-market-data-target-comp-id TEXT
                                   The market data target comp id to use
   --tt-market-data-host TEXT      The host of the market data server
   --tt-market-data-port TEXT      The port of the market data server
-  --tt-order-routing-sender-comp-id TEXT
-                                  The order routing sender comp id to use
   --tt-order-routing-target-comp-id TEXT
                                   The order routing target comp id to use
   --tt-order-routing-host TEXT    The host of the order routing server
@@ -1390,10 +1390,10 @@ Options:
                                   Your Bybit VIP Level
   --bybit-use-testnet [live|paper]
                                   Whether the testnet should be used
-  --trade-station-account-id TEXT
-                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --ib-enable-delayed-streaming-data BOOLEAN
@@ -1791,8 +1791,6 @@ Options:
                                   Your ThetaData subscription price plan
   --terminal-link-connection-type [DAPI|SAPI]
                                   Terminal Link Connection Type [DAPI, SAPI]
-  --terminal-link-server-auth-id TEXT
-                                  The Auth ID of the TerminalLink server
   --terminal-link-environment [Production|Beta]
                                   The environment to run in
   --terminal-link-server-host TEXT
@@ -1801,12 +1799,14 @@ Options:
                                   The port of the TerminalLink server
   --terminal-link-openfigi-api-key TEXT
                                   The Open FIGI API key to use for mapping options
+  --terminal-link-server-auth-id TEXT
+                                  The Auth ID of the TerminalLink server
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --trade-station-account-id TEXT
-                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
@@ -1963,8 +1963,6 @@ Options:
                                   Your ThetaData subscription price plan
   --terminal-link-connection-type [DAPI|SAPI]
                                   Terminal Link Connection Type [DAPI, SAPI]
-  --terminal-link-server-auth-id TEXT
-                                  The Auth ID of the TerminalLink server
   --terminal-link-environment [Production|Beta]
                                   The environment to run in
   --terminal-link-server-host TEXT
@@ -1973,12 +1971,14 @@ Options:
                                   The port of the TerminalLink server
   --terminal-link-openfigi-api-key TEXT
                                   The Open FIGI API key to use for mapping options
+  --terminal-link-server-auth-id TEXT
+                                  The Auth ID of the TerminalLink server
   --bybit-api-key TEXT            Your Bybit API key
   --bybit-api-secret TEXT         Your Bybit API secret
-  --trade-station-account-id TEXT
-                                  The TradeStation account Id (Optional).
   --trade-station-environment [live|paper]
                                   Whether Live or Paper environment should be used
+  --trade-station-account-id TEXT
+                                  The TradeStation account Id
   --alpaca-environment [live|paper]
                                   Whether Live or Paper environment should be used
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias

--- a/lean/components/api/auth0_client.py
+++ b/lean/components/api/auth0_client.py
@@ -45,7 +45,7 @@ class Auth0Client:
 
             data = self._api.post("live/auth0/read", payload)
             # Store in cache
-            result = QCAuth0Authorization(**data)
+            result = QCAuth0Authorization.from_raw(data)
             self._cache[brokerage_id] = result
             return result
         except RequestFailedError as e:

--- a/lean/components/api/auth0_client.py
+++ b/lean/components/api/auth0_client.py
@@ -45,7 +45,7 @@ class Auth0Client:
 
             data = self._api.post("live/auth0/read", payload)
             # Store in cache
-            result = QCAuth0Authorization.from_raw(data)
+            result = QCAuth0Authorization(**data)
             self._cache[brokerage_id] = result
             return result
         except RequestFailedError as e:

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -23,6 +23,7 @@ from lean.models.pydantic import WrappedBaseModel, validator
 
 class QCAuth0Authorization(WrappedBaseModel):
     authorization: Optional[Dict[str, str]]
+    accountIds: Optional[List[str]]
 
 class ProjectEncryptionKey(WrappedBaseModel):
     id: str

--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -21,9 +21,28 @@ from lean.models.pydantic import WrappedBaseModel, validator
 # The models in this module are all parts of responses from the QuantConnect API
 # The keys of properties are not changed, so they don't obey the rest of the project's naming conventions
 
+
+class Account(WrappedBaseModel):
+    id: str
+    name: str
+
+
 class QCAuth0Authorization(WrappedBaseModel):
     authorization: Optional[Dict[str, str]]
-    accountIds: Optional[List[str]]
+    accounts: Optional[List[Account]]
+
+    def get_account_ids(self) -> List[str]:
+        """
+        Retrieves a list of account IDs from the list of Account objects.
+
+        This method returns only the 'id' values from each account in the 'accounts' list.
+        If there are no accounts, it returns an empty list.
+
+        Returns:
+            List[str]: A list of account IDs.
+        """
+        return [account.id for account in self.accounts] if self.accounts else []
+
 
 class ProjectEncryptionKey(WrappedBaseModel):
     id: str

--- a/lean/models/click_options.py
+++ b/lean/models/click_options.py
@@ -56,6 +56,9 @@ def get_click_option_type(configuration: Configuration):
     if configuration._input_method == "confirm":
         return bool
     elif configuration._input_method == "choice":
+        # Skip validation if no predefined choices in config and user provided input manually
+        if not configuration._choices:
+            return str
         return Choice(configuration._choices, case_sensitive=False)
     elif configuration._input_method == "prompt":
         return configuration.get_input_type()

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -421,7 +421,7 @@ class AuthConfiguration(InternalInputUserInput):
         raise ValueError(f'user input not allowed with {self.__class__.__name__}')
 
 
-class AccountIdsConfiguration(InternalInputUserInput):
+class AccountIdsConfiguration(ChoiceUserInput):
 
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
@@ -447,7 +447,10 @@ class AccountIdsConfiguration(InternalInputUserInput):
         :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
-        raise ValueError(f'user input not allowed with {self.__class__.__name__}')
+        if self._input_method == "choice":
+            return ChoiceUserInput.ask_user_for_input(self, default_value, logger)
+        else:
+            raise ValueError(f"Undefined input method type {self._input_method}")
 
 
 class FilterEnvConfiguration(BrokerageEnvConfiguration):

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -421,7 +421,7 @@ class AuthConfiguration(InternalInputUserInput):
         raise ValueError(f'user input not allowed with {self.__class__.__name__}')
 
 
-class AccountIdsConfiguration(ChoiceUserInput):
+class AccountIdsConfiguration(PromptUserInput, ChoiceUserInput):
 
     def __init__(self, config_json_object):
         super().__init__(config_json_object)
@@ -447,7 +447,9 @@ class AccountIdsConfiguration(ChoiceUserInput):
         :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
         :return: The value provided by the user.
         """
-        if self._input_method == "choice":
+        if self._input_method == "prompt":
+            return PromptUserInput.ask_user_for_input(self, default_value, logger)
+        elif self._input_method == "choice":
             return ChoiceUserInput.ask_user_for_input(self, default_value, logger)
         else:
             raise ValueError(f"Undefined input method type {self._input_method}")

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -121,8 +121,6 @@ class Configuration(ABC):
             return BrokerageEnvConfiguration.factory(config_json_object)
         elif config_json_object["type"] == "oauth-token":
             return AuthConfiguration.factory(config_json_object)
-        elif config_json_object["type"] == "input-account-id":
-            return AccountIdsConfiguration.factory(config_json_object)
         else:
             raise ValueError(
                 f'Undefined input method type {config_json_object["type"]}')
@@ -419,40 +417,6 @@ class AuthConfiguration(InternalInputUserInput):
         :return: The value provided by the user.
         """
         raise ValueError(f'user input not allowed with {self.__class__.__name__}')
-
-
-class AccountIdsConfiguration(PromptUserInput, ChoiceUserInput):
-
-    def __init__(self, config_json_object):
-        super().__init__(config_json_object)
-
-    def factory(config_json_object) -> 'AccountIdsConfiguration':
-        """Creates an instance of the child classes.
-
-        :param config_json_object: the json object dict with configuration info
-        :return: An instance of AuthConfiguration.
-        """
-        if config_json_object["type"] == "input-account-id":
-            return AccountIdsConfiguration(config_json_object)
-        else:
-            raise ValueError(
-                f'Undefined input method type {config_json_object["type"]}')
-
-    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
-        """Prompts user to provide input while validating the type of input
-        against the expected type
-
-        :param default_value: The default to prompt to the user.
-        :param logger: The instance of logger class.
-        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
-        :return: The value provided by the user.
-        """
-        if self._input_method == "prompt":
-            return PromptUserInput.ask_user_for_input(self, default_value, logger)
-        elif self._input_method == "choice":
-            return ChoiceUserInput.ask_user_for_input(self, default_value, logger)
-        else:
-            raise ValueError(f"Undefined input method type {self._input_method}")
 
 
 class FilterEnvConfiguration(BrokerageEnvConfiguration):

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -121,6 +121,8 @@ class Configuration(ABC):
             return BrokerageEnvConfiguration.factory(config_json_object)
         elif config_json_object["type"] == "oauth-token":
             return AuthConfiguration.factory(config_json_object)
+        elif config_json_object["type"] == "input-account-id":
+            return AccountIdsConfiguration.factory(config_json_object)
         else:
             raise ValueError(
                 f'Undefined input method type {config_json_object["type"]}')
@@ -403,6 +405,35 @@ class AuthConfiguration(InternalInputUserInput):
         """
         if config_json_object["type"] == "oauth-token":
             return AuthConfiguration(config_json_object)
+        else:
+            raise ValueError(
+                f'Undefined input method type {config_json_object["type"]}')
+
+    def ask_user_for_input(self, default_value, logger: Logger, hide_input: bool = False):
+        """Prompts user to provide input while validating the type of input
+        against the expected type
+
+        :param default_value: The default to prompt to the user.
+        :param logger: The instance of logger class.
+        :param hide_input: Whether to hide the input (not used for this type of input, which is never hidden).
+        :return: The value provided by the user.
+        """
+        raise ValueError(f'user input not allowed with {self.__class__.__name__}')
+
+
+class AccountIdsConfiguration(InternalInputUserInput):
+
+    def __init__(self, config_json_object):
+        super().__init__(config_json_object)
+
+    def factory(config_json_object) -> 'AccountIdsConfiguration':
+        """Creates an instance of the child classes.
+
+        :param config_json_object: the json object dict with configuration info
+        :return: An instance of AuthConfiguration.
+        """
+        if config_json_object["type"] == "input-account-id":
+            return AccountIdsConfiguration(config_json_object)
         else:
             raise ValueError(
                 f'Undefined input method type {config_json_object["type"]}')

--- a/lean/models/configuration.py
+++ b/lean/models/configuration.py
@@ -96,10 +96,12 @@ class Configuration(ABC):
         self._is_required_from_user = False
         self._save_persistently_in_lean = False
         self._log_message: str = ""
+        self.has_filter_dependency: bool = False
         if "log-message" in config_json_object.keys():
             self._log_message = config_json_object["log-message"]
         if "filters" in config_json_object.keys():
             self._filter = Filter(config_json_object["filters"])
+            self.has_filter_dependency = Filter.has_conditions
         else:
             self._filter = Filter([])
         self._input_default = config_json_object["input-default"] if "input-default" in config_json_object else None
@@ -137,6 +139,10 @@ class Filter:
         self._conditions: List[BaseCondition] = [BaseCondition.factory(
             condition["condition"]) for condition in filter_conditions]
 
+    @property
+    def has_conditions(self) -> bool:
+        """Returns True if there are any conditions, False otherwise."""
+        return bool(self._conditions)
 
 class InfoConfiguration(Configuration):
     """Configuration class used for informational configurations.

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -60,13 +60,17 @@ class JsonModule(ABC):
 
     def sort_configs(self) -> List[Configuration]:
         sorted_configs = []
+        filter_configs = []
         brokerage_configs = []
         for config in self._lean_configs:
             if isinstance(config, BrokerageEnvConfiguration):
                 brokerage_configs.append(config)
             else:
-                sorted_configs.append(config)
-        return brokerage_configs + sorted_configs
+                if config.has_filter_dependency:
+                    filter_configs.append(config)
+                else:
+                    sorted_configs.append(config)
+        return brokerage_configs + sorted_configs + filter_configs
 
     def get_name(self) -> str:
         """Returns the user-friendly name which users can identify this object by.

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -21,8 +21,9 @@ from lean.components.util.auth0_helper import get_authorization
 from lean.components.util.logger import Logger
 from lean.constants import MODULE_TYPE, MODULE_PLATFORM, MODULE_CLI_PLATFORM
 from lean.container import container
+from lean.models.logger import Option
 from lean.models.configuration import BrokerageEnvConfiguration, Configuration, InternalInputUserInput, \
-    PathParameterUserInput, AuthConfiguration
+    PathParameterUserInput, AuthConfiguration, AccountIdsConfiguration
 from copy import copy
 from abc import ABC
 
@@ -211,6 +212,15 @@ class JsonModule(ABC):
                 auth_authorizations = get_authorization(container.api_client.auth0, self._display_name.lower(), logger)
                 logger.debug(f'auth: {auth_authorizations}')
                 configuration._value = auth_authorizations.authorization
+                continue
+            elif isinstance(configuration, AccountIdsConfiguration):
+                account_ids = get_authorization(container.api_client.auth0, self._display_name.lower(), logger).accountIds
+                if account_ids and len(account_ids) > 0:
+                    logger.debug(f'accountIds: {account_ids}')
+                    options = [Option(id=data_type, label=data_type) for data_type in account_ids]
+                    account_id = container.logger.prompt_list(f"Chosen {self._display_name.lower()} account ID", options)
+                    logger.debug(f'user choose account ID: {account_id}')
+                    configuration._value = account_id
                 continue
 
             property_name = self.convert_lean_key_to_variable(configuration._id)

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -218,14 +218,15 @@ class JsonModule(ABC):
                         config_dash = inner_config._id.replace('-', '_')
                         if user_provided_options and config_dash in user_provided_options:
                             user_provide_account_id = user_provided_options[config_dash]
-                            if any(account_id.lower() == user_provide_account_id.lower() for account_id in
-                                   api_account_ids):
+                            if (api_account_ids and len(api_account_ids) > 0 and
+                                any(account_id.lower() == user_provide_account_id.lower()
+                                    for account_id in api_account_ids)):
                                 logger.info(f'The account ID: {user_provide_account_id}')
                                 inner_config._value = user_provide_account_id
                             else:
                                 raise ValueError(f"The provided account id '{user_provide_account_id} is not valid, "
                                                  f"available: {api_account_ids}")
-                        if api_account_ids and len(api_account_ids) > 0:
+                        elif api_account_ids and len(api_account_ids) > 0:
                             if len(api_account_ids) == 1:
                                 logger.info(f'The account ID: {api_account_ids[0]}')
                                 inner_config._value = api_account_ids[0]

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -218,7 +218,7 @@ class JsonModule(ABC):
                 for inner_config in self._lean_configs:
                     if any(condition._dependent_config_id == configuration._id for condition in
                            inner_config._filter._conditions):
-                        api_account_ids = auth_authorizations.accountIds
+                        api_account_ids = auth_authorizations.get_account_ids()
                         config_dash = inner_config._id.replace('-', '_')
                         inner_config._choices = api_account_ids
                         if user_provided_options and config_dash in user_provided_options:

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -223,6 +223,10 @@ class JsonModule(ABC):
                                     for account_id in api_account_ids)):
                                 logger.info(f'The account ID: {user_provide_account_id}')
                                 inner_config._value = user_provide_account_id
+                            elif not api_account_ids:
+                                logger.warn(f"The '{self._display_name}' oauth authentication returned no account id, "
+                                            f"using provided account id: '{user_provide_account_id}'")
+                                inner_config._value = user_provide_account_id
                             else:
                                 raise ValueError(f"The provided account id '{user_provide_account_id} is not valid, "
                                                  f"available: {api_account_ids}")

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -21,7 +21,6 @@ from lean.components.util.auth0_helper import get_authorization
 from lean.components.util.logger import Logger
 from lean.constants import MODULE_TYPE, MODULE_PLATFORM, MODULE_CLI_PLATFORM
 from lean.container import container
-from lean.models.logger import Option
 from lean.models.configuration import BrokerageEnvConfiguration, Configuration, InternalInputUserInput, \
     PathParameterUserInput, AuthConfiguration
 from copy import copy

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -89,7 +89,7 @@ class JsonModule(ABC):
             if not target_value:
                 return False
             elif isinstance(target_value, dict):
-                    return all(condition.check(value) for value in target_value.values())
+                return all(condition.check(value) for value in target_value.values())
             elif not condition.check(target_value):
                 return False
         return True

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -217,11 +217,11 @@ class JsonModule(ABC):
             elif isinstance(configuration, AuthConfiguration):
                 auth_authorizations = get_authorization(container.api_client.auth0, self._display_name.lower(), logger)
                 logger.debug(f'auth: {auth_authorizations}')
-                configuration._value = auth_authorizations.authorization.client_info
+                configuration._value = auth_authorizations.get_authorization_config_without_account()
                 for inner_config in self._lean_configs:
                     if any(condition._dependent_config_id == configuration._id for condition in
                            inner_config._filter._conditions):
-                        api_account_ids = auth_authorizations.authorization.get_account_ids()
+                        api_account_ids = auth_authorizations.get_account_ids()
                         config_dash = inner_config._id.replace('-', '_')
                         inner_config._choices = api_account_ids
                         if user_provided_options and config_dash in user_provided_options:

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -223,9 +223,8 @@ class JsonModule(ABC):
                                 logger.info(f'The account ID: {user_provide_account_id}')
                                 inner_config._value = user_provide_account_id
                             else:
-                                raise ValueError(f"The account ID '{user_provide_account_id}' "
-                                                 f"you provided is not valid in the configuration '{inner_config._id}'."
-                                                 f"Please double-check the account ID and try again.")
+                                raise ValueError(f"The provided account id '{user_provide_account_id} is not valid, "
+                                                 f"available: {api_account_ids}")
                         if api_account_ids and len(api_account_ids) > 0:
                             if len(api_account_ids) == 1:
                                 logger.info(f'The account ID: {api_account_ids[0]}')
@@ -233,9 +232,12 @@ class JsonModule(ABC):
                             else:
                                 inner_config._input_method = "choice"
                                 inner_config._choices = api_account_ids
+                                inner_config._value = inner_config.ask_user_for_input(inner_config._input_default,
+                                                                                      logger,
+                                                                                      hide_input=hide_input)
                         break
                 continue
-            elif isinstance(configuration, AccountIdsConfiguration) and inner_config._input_method != "choice":
+            elif isinstance(configuration, AccountIdsConfiguration):
                 continue
 
             property_name = self.convert_lean_key_to_variable(configuration._id)

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -22,7 +22,7 @@ from lean.components.util.logger import Logger
 from lean.constants import MODULE_TYPE, MODULE_PLATFORM, MODULE_CLI_PLATFORM
 from lean.container import container
 from lean.models.configuration import BrokerageEnvConfiguration, Configuration, InternalInputUserInput, \
-    PathParameterUserInput, AuthConfiguration
+    PathParameterUserInput, AuthConfiguration, ChoiceUserInput
 from copy import copy
 from abc import ABC
 
@@ -210,6 +210,9 @@ class JsonModule(ABC):
                     # make sure we log these messages once, we could use the same module for different functionalities
                     _logged_messages.add(log_message)
             if type(configuration) is InternalInputUserInput:
+                continue
+            if isinstance(configuration, ChoiceUserInput) and len(configuration._choices) == 0:
+                logger.debug(f"skipping configuration '{configuration._id}': no choices available.")
                 continue
             elif isinstance(configuration, AuthConfiguration):
                 auth_authorizations = get_authorization(container.api_client.auth0, self._display_name.lower(), logger)

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -212,13 +212,16 @@ class JsonModule(ABC):
                 auth_authorizations = get_authorization(container.api_client.auth0, self._display_name.lower(), logger)
                 logger.debug(f'auth: {auth_authorizations}')
                 configuration._value = auth_authorizations.authorization
+                for config in self._lean_configs:
+                    if isinstance(config, AccountIdsConfiguration):
+                        account_ids = auth_authorizations.accountIds
+                        if account_ids and len(account_ids) > 0:
+                            config._choices = account_ids
+                        break
                 continue
-            elif isinstance(configuration, AccountIdsConfiguration):
-                account_ids = get_authorization(container.api_client.auth0, self._display_name.lower(), logger).accountIds
-                if account_ids and len(account_ids) > 0:
-                    configuration._choices = account_ids
-                elif configuration._optional:
-                    continue
+            elif (isinstance(configuration, AccountIdsConfiguration) and configuration._optional
+                  and not configuration._choices):
+                continue
 
             property_name = self.convert_lean_key_to_variable(configuration._id)
             # Only ask for user input if the config wasn't given as an option

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -216,12 +216,9 @@ class JsonModule(ABC):
             elif isinstance(configuration, AccountIdsConfiguration):
                 account_ids = get_authorization(container.api_client.auth0, self._display_name.lower(), logger).accountIds
                 if account_ids and len(account_ids) > 0:
-                    logger.debug(f'accountIds: {account_ids}')
-                    options = [Option(id=data_type, label=data_type) for data_type in account_ids]
-                    account_id = container.logger.prompt_list(f"Chosen {self._display_name.lower()} account ID", options)
-                    logger.debug(f'user choose account ID: {account_id}')
-                    configuration._value = account_id
-                continue
+                    configuration._choices = account_ids
+                elif configuration._optional:
+                    continue
 
             property_name = self.convert_lean_key_to_variable(configuration._id)
             # Only ask for user input if the config wasn't given as an option

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -23,7 +23,7 @@ from lean.constants import MODULE_TYPE, MODULE_PLATFORM, MODULE_CLI_PLATFORM
 from lean.container import container
 from lean.models.logger import Option
 from lean.models.configuration import BrokerageEnvConfiguration, Configuration, InternalInputUserInput, \
-    PathParameterUserInput, AuthConfiguration, AccountIdsConfiguration
+    PathParameterUserInput, AuthConfiguration
 from copy import copy
 from abc import ABC
 

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -87,7 +87,11 @@ class JsonModule(ABC):
                     # skip, we want all configurations that match type and platform, for help
                     continue
                 target_value = self.get_config_value_from_name(condition._dependent_config_id)
-            if not target_value or not condition.check(target_value):
+            if not target_value:
+                return False
+            elif isinstance(target_value, dict):
+                    return all(condition.check(value) for value in target_value.values())
+            elif not condition.check(target_value):
                 return False
         return True
 

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -217,11 +217,11 @@ class JsonModule(ABC):
             elif isinstance(configuration, AuthConfiguration):
                 auth_authorizations = get_authorization(container.api_client.auth0, self._display_name.lower(), logger)
                 logger.debug(f'auth: {auth_authorizations}')
-                configuration._value = auth_authorizations.authorization
+                configuration._value = auth_authorizations.authorization.client_info
                 for inner_config in self._lean_configs:
                     if any(condition._dependent_config_id == configuration._id for condition in
                            inner_config._filter._conditions):
-                        api_account_ids = auth_authorizations.get_account_ids()
+                        api_account_ids = auth_authorizations.authorization.get_account_ids()
                         config_dash = inner_config._id.replace('-', '_')
                         inner_config._choices = api_account_ids
                         if user_provided_options and config_dash in user_provided_options:

--- a/tests/components/api/test_auth0_client.py
+++ b/tests/components/api/test_auth0_client.py
@@ -19,7 +19,7 @@ from lean.components.util.http_client import HTTPClient
 
 
 @responses.activate
-def test_auth0client() -> None:
+def test_auth0client_trade_station() -> None:
     api_clint = APIClient(mock.Mock(), HTTPClient(mock.Mock()), user_id="123", api_token="abc")
 
     responses.add(
@@ -45,4 +45,32 @@ def test_auth0client() -> None:
     assert result
     assert result.authorization
     assert len(result.authorization) > 0
+    assert len(result.get_authorization_config_without_account()) > 0
+    assert len(result.get_account_ids()) > 0
+
+
+@responses.activate
+def test_auth0client_alpaca() -> None:
+    api_clint = APIClient(mock.Mock(), HTTPClient(mock.Mock()), user_id="123", api_token="abc")
+
+    responses.add(
+        responses.POST,
+        f"{API_BASE_URL}live/auth0/read",
+        json={
+            "authorization": {
+                "alpaca-access-token": "XXXX-XXX-XXX-XXX-XXXXX-XX",
+                "accounts": [{"id": "XXXX-XXX-XXX-XXX-XXXXX-XX", "name": " |USD"}]
+            },
+            "success": "true"},
+        status=200
+    )
+
+    brokerage_id = "TestBrokerage"
+
+    result = api_clint.auth0.read(brokerage_id)
+
+    assert result
+    assert result.authorization
+    assert len(result.authorization) > 0
+    assert len(result.get_authorization_config_without_account()) > 0
     assert len(result.get_account_ids()) > 0

--- a/tests/components/api/test_auth0_client.py
+++ b/tests/components/api/test_auth0_client.py
@@ -11,16 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import responses
+from unittest import mock
 from lean.constants import API_BASE_URL
-from components.api.test_clients import create_api_client
+from lean.components.api.api_client import APIClient
+from lean.components.util.http_client import HTTPClient
 
 
 @responses.activate
 def test_auth0client() -> None:
-    os.environ.setdefault("QC_API", "local")
-    api_clint = create_api_client()
+    api_clint = APIClient(mock.Mock(), HTTPClient(mock.Mock()), user_id="123", api_token="abc")
 
     responses.add(
         responses.POST,

--- a/tests/components/api/test_auth0_client.py
+++ b/tests/components/api/test_auth0_client.py
@@ -27,15 +27,14 @@ def test_auth0client() -> None:
         f"{API_BASE_URL}live/auth0/read",
         json={
             "authorization": {
-                "test-brokerage-client-id": "123",
-                "test-brokerage-refresh-token": "123"
+                "trade-station-client-id": "123",
+                "trade-station-refresh-token": "456",
+                "accounts": [
+                    {"id": "11223344", "name": "11223344 | Margin | USD"},
+                    {"id": "55667788", "name": "55667788 | Futures | USD"}
+                ]
             },
-            "accounts": [
-                {"name": "account_1", "id": "123"},
-                {"name": "account_2", "id": "456"}
-            ],
-            "success": "true"
-        },
+            "success": "true"},
         status=200
     )
 
@@ -45,7 +44,6 @@ def test_auth0client() -> None:
 
     assert result
     assert result.authorization
-    assert len(result.authorization) > 0
-    assert result.accounts
-    assert len(result.accounts) > 0
-    assert len(result.get_account_ids()) > 0
+    assert len(result.authorization.client_info) > 0
+    assert len(result.authorization.accounts) > 0
+    assert len(result.authorization.get_account_ids()) > 0

--- a/tests/components/api/test_auth0_client.py
+++ b/tests/components/api/test_auth0_client.py
@@ -44,6 +44,5 @@ def test_auth0client() -> None:
 
     assert result
     assert result.authorization
-    assert len(result.authorization.client_info) > 0
-    assert len(result.authorization.accounts) > 0
-    assert len(result.authorization.get_account_ids()) > 0
+    assert len(result.authorization) > 0
+    assert len(result.get_account_ids()) > 0

--- a/tests/components/api/test_auth0_client.py
+++ b/tests/components/api/test_auth0_client.py
@@ -30,7 +30,10 @@ def test_auth0client() -> None:
                 "test-brokerage-client-id": "123",
                 "test-brokerage-refresh-token": "123"
             },
-            "accountIds": ["123", "321"],
+            "accounts": [
+                {"name": "account_1", "id": "123"},
+                {"name": "account_2", "id": "456"}
+            ],
             "success": "true"
         },
         status=200
@@ -43,5 +46,6 @@ def test_auth0client() -> None:
     assert result
     assert result.authorization
     assert len(result.authorization) > 0
-    assert result.accountIds
-    assert len(result.accountIds) > 0
+    assert result.accounts
+    assert len(result.accounts) > 0
+    assert len(result.get_account_ids()) > 0

--- a/tests/components/api/test_auth0_client.py
+++ b/tests/components/api/test_auth0_client.py
@@ -1,0 +1,47 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import responses
+from lean.constants import API_BASE_URL
+from components.api.test_clients import create_api_client
+
+
+@responses.activate
+def test_auth0client() -> None:
+    os.environ.setdefault("QC_API", "local")
+    api_clint = create_api_client()
+
+    responses.add(
+        responses.POST,
+        f"{API_BASE_URL}live/auth0/read",
+        json={
+            "authorization": {
+                "test-brokerage-client-id": "123",
+                "test-brokerage-refresh-token": "123"
+            },
+            "accountIds": ["123", "321"],
+            "success": "true"
+        },
+        status=200
+    )
+
+    brokerage_id = "TestBrokerage"
+
+    result = api_clint.auth0.read(brokerage_id)
+
+    assert result
+    assert result.authorization
+    assert len(result.authorization) > 0
+    assert result.accountIds
+    assert len(result.accountIds) > 0


### PR DESCRIPTION
#### Related PR
- https://github.com/QuantConnect/Lean.Brokerages.TradeStation/pull/27

#### How Has This Been Tested?
##### Valid `account-id`
`lean live deploy mynewalgo --brokerage TradeStation --trade-station-account-id "SIMXXXXXXXM"`
![image](https://github.com/user-attachments/assets/ee512dcc-dcfe-4b0f-b998-52b628edd583)

##### Invalid `account-id`
`lean live deploy mynewalgo --brokerage tradestation --data-provider-live tradestation --trade-station-account-id SIMXXX`
![image](https://github.com/user-attachments/assets/8bf186e5-641d-4697-a0fa-b7901c926919)


