### PR TITLE
Fix camel case bug

### DIFF
--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -389,8 +389,8 @@ def optimize(project: Path,
                                               created=datetime.now(),
                                               completed=True,
                                               progress=1.0,
-                                              runtimeStatistics=optimal_results["RuntimeStatistics"],
-                                              statistics=optimal_results["Statistics"])
+                                              runtimeStatistics=optimal_results["runtimeStatistics"],
+                                              statistics=optimal_results["statistics"])
 
                 logger.info(f"Optimal parameters: {optimal_parameters.replace(':', ': ').replace(',', ', ')}")
                 logger.info(f"Optimal backtest results:")


### PR DESCRIPTION
Some months ago we refactored LEAN to use camel case (https://github.com/QuantConnect/Lean/commit/d40ec77379c38b99622eacca2d963c42f941380f#diff-61ef02f06dedc5d14baa64cdc98d1341bd9b991ca4c6fef3f7b42743d31819bd). Thus, the json backtest result was also changed to be in camel case too. Still, we forgot to update some of its references in lean-cli, as it is the case for `optimize.py`. This PR aims to fix that bug.

Related #507 
Related https://github.com/QuantConnect/Lean/pull/8382