### PR TITLE
Fix win32 & Python 3.12 failing unit test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
-        run: pytest -s -rs
+        run: python -m pytest -s -rs
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -27,10 +27,10 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run normal tests
-        run: pytest -s -rs
+        run: python -m pytest -s -rs
 
       - name: Run API tests
-        run: pytest -s tests/components/api/test_clients.py
+        run: python -m pytest -s tests/components/api/test_clients.py
         env:
           QC_USER_ID: ${{ secrets.QC_USER_ID }}
           QC_API_TOKEN: ${{ secrets.QC_API_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
       # Before running the tests we free up some disk space to prevent issues.
       # Removing /usr/local/lib/android frees up ~10GB, which we can safely do because we don't use Android.
       - name: Run CLI tests
-        run: sudo rm -rf /usr/local/lib/android && pytest -s tests/test_cli.py
+        run: sudo rm -rf /usr/local/lib/android && python -m pytest -s tests/test_cli.py
         if: runner.os == 'Linux'
         env:
           QC_USER_ID: ${{ secrets.QC_USER_ID }}


### PR DESCRIPTION
After reviewing the logs from the failing unit tests, I found the exceptions were raised because certain file could not be found. Still, the path of that file was wrong since it tried to access a file `__main__.py` from an `.exe` file. Apparently, in order to solve this bug and make pytest work with Python 3.12, we needed to invoke testing through the Python interpreter from the command line.  That way, we would be adding the current directory to `sys.path`.

![image](https://github.com/user-attachments/assets/0e506bf2-b092-4553-af16-7de34688c9c7)
