### PR TITLE
Fix minor bug in lean configuration duplication

### DIFF
--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from os.path import normcase
 from pathlib import Path
 from typing import Any, Dict, Optional, List
 
@@ -98,9 +98,10 @@ class LeanConfigManager:
         """
         lean_config_paths = self._cache_storage.get("known-lean-config-paths", [])
         lean_config_paths = [Path(p) for p in lean_config_paths]
+        lean_config_paths = list(set(lean_config_paths))
         lean_config_paths = [p for p in lean_config_paths if p.is_file()]
 
-        self._cache_storage.set("known-lean-config-paths", [str(p) for p in lean_config_paths])
+        self._cache_storage.set("known-lean-config-paths", [normcase(p) for p in lean_config_paths])
 
         return lean_config_paths
 

--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os.path import normcase
+from os.path import normcase, normpath
 from pathlib import Path
 from typing import Any, Dict, Optional, List
 
@@ -98,7 +98,7 @@ class LeanConfigManager:
         :return: a list of paths to Lean config files that were used in the past
         """
         lean_config_paths = self._cache_storage.get("known-lean-config-paths", [])
-        lean_config_paths = [Path(normcase(p)) for p in lean_config_paths if Path(p).is_file()]
+        lean_config_paths = [Path(normpath(normcase(p))) for p in lean_config_paths if Path(p).is_file()]
         lean_config_paths = list(set(lean_config_paths))
 
         self._cache_storage.set("known-lean-config-paths", [str(p) for p in lean_config_paths])

--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -98,11 +98,10 @@ class LeanConfigManager:
         :return: a list of paths to Lean config files that were used in the past
         """
         lean_config_paths = self._cache_storage.get("known-lean-config-paths", [])
-        lean_config_paths = [Path(p) for p in lean_config_paths]
+        lean_config_paths = [Path(normcase(p)) for p in lean_config_paths if Path(p).is_file()]
         lean_config_paths = list(set(lean_config_paths))
-        lean_config_paths = [p for p in lean_config_paths if p.is_file()]
 
-        self._cache_storage.set("known-lean-config-paths", [normcase(p) for p in lean_config_paths])
+        self._cache_storage.set("known-lean-config-paths", [str(p) for p in lean_config_paths])
 
         return lean_config_paths
 

--- a/lean/components/config/lean_config_manager.py
+++ b/lean/components/config/lean_config_manager.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from os.path import normcase
 from pathlib import Path
 from typing import Any, Dict, Optional, List

--- a/tests/components/config/test_lean_config_manager.py
+++ b/tests/components/config/test_lean_config_manager.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 from unittest import mock
@@ -100,6 +101,9 @@ def test_get_known_lean_config_path_with_duplicated_paths() -> None:
 
     assert manager.get_known_lean_config_paths() == [Path.cwd() / "custom-lean.json"]
 
+@pytest.mark.skipif(
+    sys.platform !="win32", reason="Custom config path is only valid for Windows."
+)
 def test_get_known_lean_config_path_normalizes_path_and_case() -> None:
     custom_config_path = Path.cwd() / "/folder/../custom-lean.json/"
     custom_config_path.touch()

--- a/tests/components/config/test_lean_config_manager.py
+++ b/tests/components/config/test_lean_config_manager.py
@@ -100,6 +100,16 @@ def test_get_known_lean_config_path_with_duplicated_paths() -> None:
 
     assert manager.get_known_lean_config_paths() == [Path.cwd() / "custom-lean.json"]
 
+def test_get_known_lean_config_path_normalizes_path_and_case() -> None:
+    custom_config_path = Path.cwd() / "//folder//..//custom-lean.json//"
+    custom_config_path.touch()
+    custom_config_path.write_text("{}", encoding="utf-8")
+
+    manager = _create_lean_config_manager()
+    manager.set_default_lean_config_path(custom_config_path)
+
+    assert manager.get_known_lean_config_paths() == [Path(os.path.normcase(Path.cwd() / "/custom-lean.json"))]
+
 def test_get_cli_root_directory_returns_path_to_directory_containing_config_file() -> None:
     create_fake_lean_cli_directory()
 

--- a/tests/components/config/test_lean_config_manager.py
+++ b/tests/components/config/test_lean_config_manager.py
@@ -30,18 +30,11 @@ from tests.test_helpers import create_fake_lean_cli_directory
 
 
 def _create_lean_config_manager(cli_config_manager: Optional[CLIConfigManager] = None, storage: Storage = None) -> LeanConfigManager:
-    if storage is None:
-        return LeanConfigManager(mock.Mock(),
-                             cli_config_manager or mock.Mock(),
-                             ProjectConfigManager(XMLManager()),
-                             mock.Mock(),
-                             Storage(str(Path("~/.lean/cache").expanduser())))
-
     return LeanConfigManager(mock.Mock(),
                              cli_config_manager or mock.Mock(),
                              ProjectConfigManager(XMLManager()),
                              mock.Mock(),
-                             storage)
+                             Storage(str(Path("~/.lean/cache").expanduser())) if storage is None else storage)
 
 def test_get_lean_config_path_returns_closest_config_file() -> None:
     lean_config_path = Path.cwd() / "lean.json"

--- a/tests/components/config/test_lean_config_manager.py
+++ b/tests/components/config/test_lean_config_manager.py
@@ -86,6 +86,9 @@ def test_get_known_lean_config_path_returns_previously_used_custom_default() -> 
 
     assert manager.get_known_lean_config_paths() == [Path.cwd() / "custom-lean.json"]
 
+@pytest.mark.skipif(
+    sys.platform !="win32", reason="Custom config path is only valid for Windows."
+)
 def test_get_known_lean_config_path_with_duplicated_paths() -> None:
     custom_config_path = Path.cwd() / "custom-Lean.json"
     custom_config_path.touch()

--- a/tests/components/config/test_lean_config_manager.py
+++ b/tests/components/config/test_lean_config_manager.py
@@ -101,7 +101,7 @@ def test_get_known_lean_config_path_with_duplicated_paths() -> None:
     assert manager.get_known_lean_config_paths() == [Path.cwd() / "custom-lean.json"]
 
 def test_get_known_lean_config_path_normalizes_path_and_case() -> None:
-    custom_config_path = Path.cwd() / "//folder//..//custom-lean.json//"
+    custom_config_path = Path.cwd() / "/folder/../custom-lean.json/"
     custom_config_path.touch()
     custom_config_path.write_text("{}", encoding="utf-8")
 


### PR DESCRIPTION
This PR aims to update `get_known_lean_config_paths()` method to remove duplicated entries and normalize the path and case in config files' paths. See #508 