### PR TITLE
Add macos 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-13, windows-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -99,7 +99,7 @@ def test_cloud_live_deploy() -> None:
                                                   mock.ANY)
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform =="darwin", reason="MacOS does not support IB tests."
 )
 def test_cloud_live_deploy_with_ib_using_hybrid_datafeed() -> None:
     create_fake_lean_cli_directory()

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -14,6 +14,7 @@
 from unittest import mock
 from click.testing import CliRunner
 import pytest
+import sys
 from lean.commands import lean
 from lean.container import container
 from lean.models.api import QCEmailNotificationMethod, QCWebhookNotificationMethod, QCSMSNotificationMethod, QCTelegramNotificationMethod
@@ -97,6 +98,9 @@ def test_cloud_live_deploy() -> None:
                                                   mock.ANY,
                                                   mock.ANY)
 
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_cloud_live_deploy_with_ib_using_hybrid_datafeed() -> None:
     create_fake_lean_cli_directory()
 
@@ -243,6 +247,9 @@ def test_cloud_live_deploy_with_notifications(notice_method: str, configs: str) 
                                             ("Zerodha", "USD:100"),
                                             ("TDAmeritrade", "USD:100")])
 def test_cloud_live_deploy_with_live_cash_balance(brokerage: str, cash: str) -> None:
+    if (brokerage == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
 
     cloud_project_manager = mock.Mock()
@@ -324,6 +331,9 @@ def test_cloud_live_deploy_with_live_cash_balance(brokerage: str, cash: str) -> 
                                                 ("TDAmeritrade", ""),
                                                 ("TDAmeritrade", "A:A 2T:1:145.1")])
 def test_cloud_live_deploy_with_live_holdings(brokerage: str, holdings: str) -> None:
+    if (brokerage == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
 
     cloud_project_manager = mock.Mock()

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -137,7 +137,7 @@ def _create_lean_data_download(data_provider_name: str,
 
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform =="darwin", reason="MacOS does not support IB tests."
 )
 @pytest.mark.parametrize("data_provider,market,is_crypto,security_type,ticker,data_provider_parameters",
                          [("Polygon", "NYSE", False, "Equity", ["AAPL"], ["--polygon-api-key", "123"]),

--- a/tests/commands/data/test_download.py
+++ b/tests/commands/data/test_download.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -135,6 +136,9 @@ def _create_lean_data_download(data_provider_name: str,
                 return CliRunner().invoke(lean, run_parameters)
 
 
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 @pytest.mark.parametrize("data_provider,market,is_crypto,security_type,ticker,data_provider_parameters",
                          [("Polygon", "NYSE", False, "Equity", ["AAPL"], ["--polygon-api-key", "123"]),
                           ("Binance", "Binance", True, "CryptoFuture", ["BTCUSDT"],
@@ -146,6 +150,9 @@ def _create_lean_data_download(data_provider_name: str,
                            ["--ib-user-name", "123", "--ib-account", "Individual", "--ib-password", "123"])])
 def test_download_data_non_interactive(data_provider: str, market: str, is_crypto: bool, security_type: str,
                                        ticker: List[str], data_provider_parameters: List[str]):
+    if (data_provider == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     run_data_download = _create_lean_data_download(
         data_provider, "Trade", "Minute", security_type, ticker, "20240101", "20240202",
         _get_data_provider_config(is_crypto), market, data_provider_parameters)

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -96,6 +96,9 @@ def create_fake_binance_environment(name: str, live_mode: bool) -> None:
 
     path.write_text(config, encoding="utf-8")
 
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_correct_algorithm_file() -> None:
     # TODO: currently it is not using the live-paper envrionment
     create_fake_lean_cli_directory()
@@ -119,7 +122,9 @@ def test_live_calls_lean_runner_with_correct_algorithm_file() -> None:
                                                  {},
                                                  {})
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_extra_docker_config() -> None:
     # TODO: currently it is not using the live-paper environment
     create_fake_lean_cli_directory()
@@ -154,7 +159,9 @@ def test_live_calls_lean_runner_with_extra_docker_config() -> None:
                                                            },
                                                            {})
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_paths_to_mount() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -198,7 +205,9 @@ def test_live_aborts_when_environment_has_live_mode_set_to_false() -> None:
 
     container.lean_runner.run_lean.assert_not_called()
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_default_output_directory() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -214,7 +223,9 @@ def test_live_calls_lean_runner_with_default_output_directory() -> None:
     # This will raise an error if the output directory is not relative to Python Project/backtests
     args[3].relative_to(Path("Python Project/live").resolve())
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_custom_output_directory() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -233,7 +244,9 @@ def test_live_calls_lean_runner_with_custom_output_directory() -> None:
     # This will raise an error if the output directory is not relative to Python Project/custom-backtests
     args[3].relative_to(Path("Python Project/custom").resolve())
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_release_mode() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -254,7 +267,9 @@ def test_live_calls_lean_runner_with_release_mode() -> None:
                                                  {},
                                                  {})
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_calls_lean_runner_with_detach() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -467,6 +482,9 @@ data_providers_required_options = {
 }
 
 
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 @pytest.mark.parametrize("data_provider", data_providers_required_options.keys())
 def test_live_calls_lean_runner_with_data_provider(data_provider: str) -> None:
     create_fake_lean_cli_directory()
@@ -868,7 +886,9 @@ def test_live_non_interactive_falls_back_to_lean_config_for_multiple_data_feed_s
                                                          {},
                                                          {})
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_forces_update_when_update_option_given() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -889,7 +909,9 @@ def test_live_forces_update_when_update_option_given() -> None:
                                                  {},
                                                  {})
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)
@@ -911,7 +933,9 @@ def test_live_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
                                                  {},
                                                  {})
 
-
+@pytest.mark.skipif(
+    sys.platform !="darwin", reason="MacOS does not support IB tests."
+)
 def test_live_passes_custom_image_to_lean_runner_when_given_as_option() -> None:
     create_fake_lean_cli_directory()
     create_fake_environment("live-paper", True)

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import itertools
+import sys
 import json
 from pathlib import Path
 import traceback
@@ -501,6 +502,9 @@ def test_live_calls_lean_runner_with_data_provider(data_provider: str) -> None:
 
 @pytest.mark.parametrize("brokerage", brokerage_required_options.keys() - ["Paper Trading"])
 def test_live_non_interactive_aborts_when_missing_brokerage_options(brokerage: str) -> None:
+    if (brokerage == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
 
     required_options = brokerage_required_options[brokerage].items()
@@ -540,6 +544,8 @@ def test_live_non_interactive_aborts_when_missing_brokerage_options(brokerage: s
 
 @pytest.mark.parametrize("data_feed", data_feed_required_options.keys())
 def test_live_non_interactive_aborts_when_missing_data_feed_options(data_feed: str) -> None:
+    if (data_feed == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
     create_fake_lean_cli_directory()
 
     container.initialize(docker_manager=mock.Mock(), lean_runner=mock.Mock())
@@ -568,6 +574,9 @@ def test_live_non_interactive_aborts_when_missing_data_feed_options(data_feed: s
 @pytest.mark.parametrize("brokerage,data_feed",
                          itertools.product(brokerage_required_options.keys(), data_feed_required_options.keys()))
 def test_live_non_interactive_do_not_store_non_persistent_properties_in_lean_config(brokerage: str, data_feed: str) -> None:
+    if ((brokerage == "Interactive Brokers" or data_feed == "Interactive Brokers") and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
     lean_runner = container.lean_runner
 
@@ -611,6 +620,9 @@ def test_live_non_interactive_do_not_store_non_persistent_properties_in_lean_con
 @pytest.mark.parametrize("brokerage,data_feed",
                          itertools.product(brokerage_required_options.keys(), data_feed_required_options.keys()))
 def test_live_non_interactive_calls_run_lean_when_all_options_given(brokerage: str, data_feed: str) -> None:
+    if ((brokerage == "Interactive Brokers" or data_feed == "Interactive Brokers") and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
     lean_runner = container.lean_runner
 
@@ -648,6 +660,9 @@ def test_live_non_interactive_calls_run_lean_when_all_options_given(brokerage: s
 @pytest.mark.parametrize("brokerage,data_feed1,data_feed2",[(brokerage, *data_feeds) for brokerage, data_feeds in
                          itertools.product(brokerage_required_options.keys(), itertools.combinations(data_feed_required_options.keys(), 2))])
 def test_live_non_interactive_calls_run_lean_when_all_options_given_with_multiple_data_feeds(brokerage: str, data_feed1: str, data_feed2: str) -> None:
+    if ((brokerage == "Interactive Brokers" or data_feed1 == "Interactive Brokers" or data_feed2 == "Interactive Brokers") and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
     lean_runner = container.lean_runner
 
@@ -689,6 +704,9 @@ def test_live_non_interactive_calls_run_lean_when_all_options_given_with_multipl
 
 @pytest.mark.parametrize("brokerage", brokerage_required_options.keys() - ["Paper Trading"])
 def test_live_non_interactive_falls_back_to_lean_config_for_brokerage_settings(brokerage: str) -> None:
+    if (brokerage == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
 
     required_options = brokerage_required_options[brokerage].items()
@@ -748,6 +766,9 @@ def test_live_non_interactive_falls_back_to_lean_config_for_brokerage_settings(b
 
 @pytest.mark.parametrize("data_feed", data_feed_required_options.keys())
 def test_live_non_interactive_falls_back_to_lean_config_for_data_feed_settings(data_feed: str) -> None:
+    if (data_feed == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
 
     required_options = data_feed_required_options[data_feed].items()
@@ -796,6 +817,9 @@ def test_live_non_interactive_falls_back_to_lean_config_for_data_feed_settings(d
 
 @pytest.mark.parametrize("data_feed1,data_feed2", itertools.combinations(data_feed_required_options.keys(), 2))
 def test_live_non_interactive_falls_back_to_lean_config_for_multiple_data_feed_settings(data_feed1: str, data_feed2: str) -> None:
+    if ((data_feed1 == "Interactive Brokers" or data_feed2 == "Interactive Brokers") and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
 
     required_options = list(data_feed_required_options[data_feed1].items()) + list(data_feed_required_options[data_feed2].items())
@@ -962,6 +986,9 @@ def test_live_passes_custom_python_venv_to_lean_runner_when_given_as_option(pyth
                                             ("TDAmeritrade", ""),
                                             ("TDAmeritrade", "USD:100")])
 def test_live_passes_live_cash_balance_to_lean_runner_when_given_as_option(brokerage: str, cash: str) -> None:
+    if (brokerage == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
     lean_runner= container.lean_runner
 
@@ -1026,6 +1053,9 @@ def test_live_passes_live_cash_balance_to_lean_runner_when_given_as_option(broke
                                                 ("TDAmeritrade", ""),
                                                 ("TDAmeritrade", "A:A 2T:1:145.1")])
 def test_live_passes_live_holdings_to_lean_runner_when_given_as_option(brokerage: str, holdings: str) -> None:
+    if (brokerage == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     create_fake_lean_cli_directory()
     lean_runner= container.lean_runner
 
@@ -1182,6 +1212,9 @@ def create_lean_option(brokerage_name: str, data_provider_live_name: str, data_p
                           ("Tradier", "IEX", "AlphaVantage", "185", "333", "334"),
                           ("Paper Trading", "IEX", "Local", None, "333", "222")])
 def test_live_deploy_with_different_brokerage_and_different_live_data_provider_and_historical_data_provider(brokerage_name: str, data_provider_live_name: str, data_provider_historical_name: str, brokerage_product_id: str, data_provider_live_product_id: str, data_provider_historical_id: str) -> None:
+    if (brokerage_name == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     api_client = mock.MagicMock()
     create_lean_option(brokerage_name, data_provider_live_name, data_provider_historical_name, api_client)
 
@@ -1211,6 +1244,9 @@ def test_live_deploy_with_different_brokerage_and_different_live_data_provider_a
                          [("Interactive Brokers", "IEX", "181", "333"),
                           ("Tradier", "IEX", "185", "333")])
 def test_live_non_interactive_deploy_with_different_brokerage_and_different_live_data_provider(brokerage_name: str, data_provider_live_name: str, brokerage_product_id: str, data_provider_live_product_id: str) -> None:
+    if (brokerage_name == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     api_client = mock.MagicMock()
     create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
 
@@ -1229,6 +1265,9 @@ def test_live_non_interactive_deploy_with_different_brokerage_and_different_live
                           ("Interactive Brokers", "Interactive Brokers", "181"),
                           ("Tradier", "Tradier", "185")])
 def test_live_non_interactive_deploy_with_different_brokerage_with_the_same_live_data_provider(brokerage_name: str, data_provider_live_name: str, brokerage_product_id: str) -> None:
+    if (brokerage_name == "Interactive Brokers" and sys.platform == "darwin"):
+        pytest.skip("MacOS does not support IB tests")
+
     api_client = mock.MagicMock()
     create_lean_option(brokerage_name, data_provider_live_name, None, api_client)
 

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -97,7 +97,7 @@ def create_fake_binance_environment(name: str, live_mode: bool) -> None:
     path.write_text(config, encoding="utf-8")
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_correct_algorithm_file() -> None:
     # TODO: currently it is not using the live-paper envrionment
@@ -123,7 +123,7 @@ def test_live_calls_lean_runner_with_correct_algorithm_file() -> None:
                                                  {})
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_extra_docker_config() -> None:
     # TODO: currently it is not using the live-paper environment
@@ -160,7 +160,7 @@ def test_live_calls_lean_runner_with_extra_docker_config() -> None:
                                                            {})
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_paths_to_mount() -> None:
     create_fake_lean_cli_directory()
@@ -206,7 +206,7 @@ def test_live_aborts_when_environment_has_live_mode_set_to_false() -> None:
     container.lean_runner.run_lean.assert_not_called()
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_default_output_directory() -> None:
     create_fake_lean_cli_directory()
@@ -224,7 +224,7 @@ def test_live_calls_lean_runner_with_default_output_directory() -> None:
     args[3].relative_to(Path("Python Project/live").resolve())
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_custom_output_directory() -> None:
     create_fake_lean_cli_directory()
@@ -245,7 +245,7 @@ def test_live_calls_lean_runner_with_custom_output_directory() -> None:
     args[3].relative_to(Path("Python Project/custom").resolve())
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_release_mode() -> None:
     create_fake_lean_cli_directory()
@@ -268,7 +268,7 @@ def test_live_calls_lean_runner_with_release_mode() -> None:
                                                  {})
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_calls_lean_runner_with_detach() -> None:
     create_fake_lean_cli_directory()
@@ -483,7 +483,7 @@ data_providers_required_options = {
 
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 @pytest.mark.parametrize("data_provider", data_providers_required_options.keys())
 def test_live_calls_lean_runner_with_data_provider(data_provider: str) -> None:
@@ -887,7 +887,7 @@ def test_live_non_interactive_falls_back_to_lean_config_for_multiple_data_feed_s
                                                          {})
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_forces_update_when_update_option_given() -> None:
     create_fake_lean_cli_directory()
@@ -910,7 +910,7 @@ def test_live_forces_update_when_update_option_given() -> None:
                                                  {})
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
     create_fake_lean_cli_directory()
@@ -934,7 +934,7 @@ def test_live_passes_custom_image_to_lean_runner_when_set_in_config() -> None:
                                                  {})
 
 @pytest.mark.skipif(
-    sys.platform !="darwin", reason="MacOS does not support IB tests."
+    sys.platform == "darwin", reason="MacOS does not support IB tests."
 )
 def test_live_passes_custom_image_to_lean_runner_when_given_as_option() -> None:
     create_fake_lean_cli_directory()

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -958,7 +958,9 @@ def test_live_passes_custom_image_to_lean_runner_when_given_as_option() -> None:
                                                  {},
                                                  {})
 
-
+@pytest.mark.skipif(
+    sys.platform =="darwin", reason="MacOS does not support IB tests."
+)
 @pytest.mark.parametrize("python_venv", ["Custom-venv",
                                         "/Custom-venv",
                                         None])


### PR DESCRIPTION
Add macos 14 to CI and skipped IB related tests since it's not supported `<Result RuntimeError('InteractiveBrokers is currently not supported for ARM hosts')>.exit_code`.

Closes #523 