### PR TITLE
Fix: missed `project-id` in command `lean cloud live deploy ...`

### DIFF
--- a/lean/commands/cloud/live/deploy.py
+++ b/lean/commands/cloud/live/deploy.py
@@ -240,6 +240,7 @@ def deploy(project: str,
 
     live_data_provider_settings = {}
     lean_config = container.lean_config_manager.get_lean_config()
+    lean_config["project-id"] = cloud_project.projectId
 
     if brokerage is not None:
         ensure_options(["brokerage", "node", "auto_restart", "notify_order_events", "notify_insights"])


### PR DESCRIPTION
#### Description
When user run command `lean cloud live deploy ...` then he got thje exception: 
![1](https://github.com/user-attachments/assets/253ccf88-8e5f-4f6c-be85-10648c29ed0d)

#### Related PR
- https://github.com/QuantConnect/lean-cli/pull/517