### PR TITLE
Switch from maskpass to getpass

### DIFF
--- a/lean/components/util/logger.py
+++ b/lean/components/util/logger.py
@@ -138,7 +138,7 @@ class Logger:
         """
         from platform import uname
         from sys import stdin
-        from maskpass import askpass
+        from getpass import getpass
 
         if default is not None:
             text = f"{text} [{'*' * len(default)}]"
@@ -148,7 +148,7 @@ class Logger:
             return prompt(text, default=default, show_default=False, hide_input=hide_input)
 
         while True:
-            user_input = askpass(f"{text}: ")
+            user_input = getpass(f"{text}: ")
 
             if len(user_input) == 0 and default is not None:
                 return default

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ install_requires = [
     "pydantic>=1.8.2",
     "python-dateutil>=2.8.2",
     "lxml>=4.9.0",
-    "maskpass>=0.3.6",
     "joblib>=1.1.0",
     "setuptools",
     f"quantconnect-stubs{get_stubs_version_range()}",


### PR DESCRIPTION
Switch from maskpass to getpass, as maskpass requirements have a conflict with Python 3.8 and getpass is built into Python so it's cross-platform and works on Windows, Linux and macOS
![image](https://github.com/user-attachments/assets/fba3f109-86e7-4e86-a968-ea0c243364b4)
