### PR TITLE
Update ubuntu GH actions image 20->24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14, windows-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 is not longer running