### PR TITLE
Add temporary directory to verbose output

### DIFF
--- a/lean/click.py
+++ b/lean/click.py
@@ -59,6 +59,21 @@ def get_whoami_message() -> str:
 
     return f"logged in as {member.name} ({member.email})"
 
+def get_disk_space_info(path: Path) -> str:
+    try:
+        from shutil import disk_usage
+        usage = disk_usage(str(path))
+        total, used, free = usage.total, usage.used, usage.free
+
+        return (
+            f"Space in temporary location - "
+            f"Total: {total / (1024 ** 3):.2f} GB, "
+            f"Used: {used / (1024 ** 3):.2f} GB, "
+            f"Free: {free / (1024 ** 3):.2f} GB"
+        )
+    except Exception as e:
+        return f"Error getting disk space: {str(e)}"
+
 class VerboseOption(ClickOption):
     def __init__(self, *args, **kwargs):
         super().__init__(["--verbose"],
@@ -130,12 +145,21 @@ class VerboseOption(ClickOption):
             docker_version = run("docker --version", shell=True, capture_output=True).stdout.decode("utf").replace("Docker version ", "")
         except:
             docker_version = "Not installed"
+        
+        try:
+            temp_dir = container.temp_manager.create_temporary_directory().parent
+            space_info = get_disk_space_info(temp_dir)
+        except:
+            temp_dir = ""
+            space_info = ""
 
         logger.debug(f"Context information:\n" +
                      hostname +
                      username +
                      f"  Python version: {python_version}\n"
                      f"  OS: {platform()}\n"
+                     f"  Temporary directory: {temp_dir}\n"
+                     f"  {space_info}\n"
                      f"  Lean CLI version: {lean_cli_version}\n"
                      f"  .NET version: {dotnet_version}\n"
                      f"  VS Code version: {vscode_version}\n"

--- a/lean/components/util/temp_manager.py
+++ b/lean/components/util/temp_manager.py
@@ -12,14 +12,16 @@
 # limitations under the License.
 
 from pathlib import Path
+from lean.components.util.logger import Logger
 
 class TempManager:
     """The TempManager class provides access to temporary directories."""
 
-    def __init__(self) -> None:
+    def __init__(self, logger: Logger) -> None:
         """Creates a new TempManager instance."""
         self._temporary_directories = []
         self.delete_temporary_directories_when_done = True
+        self._logger = logger
 
     def create_temporary_directory(self) -> Path:
         """Returns the path to an empty temporary directory.
@@ -29,6 +31,7 @@ class TempManager:
         from tempfile import mkdtemp
         path = Path(mkdtemp(prefix="lean-cli-"))
         self._temporary_directories.append(path)
+        self._logger.debug(f"Created temporary directory: {path}")
         return path
 
     def delete_temporary_directories(self) -> None:

--- a/lean/container.py
+++ b/lean/container.py
@@ -68,7 +68,7 @@ class Container:
         self.platform_manager = PlatformManager()
         self.task_manager = TaskManager(self.logger)
         self.name_generator = NameGenerator()
-        self.temp_manager = TempManager()
+        self.temp_manager = TempManager(self.logger)
         self.xml_manager = XMLManager()
         self.http_client = HTTPClient(self.logger)
 

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -87,7 +87,7 @@ def create_lean_runner(docker_manager: mock.Mock) -> LeanRunner:
                       docker_manager,
                       module_manager,
                       project_manager,
-                      TempManager(),
+                      TempManager(logger),
                       xml_manager)
 
 

--- a/tests/components/util/test_temp_manager.py
+++ b/tests/components/util/test_temp_manager.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 
 from lean.components.util.temp_manager import TempManager
+from unittest import mock
 
 
 def test_create_temporary_directory_creates_empty_directory() -> None:
-    temp_manager = TempManager()
+    temp_manager = TempManager(mock.Mock())
 
     path = temp_manager.create_temporary_directory()
 
@@ -24,13 +25,13 @@ def test_create_temporary_directory_creates_empty_directory() -> None:
 
 
 def test_create_temporary_directory_creates_new_directory_every_time() -> None:
-    temp_manager = TempManager()
+    temp_manager = TempManager(mock.Mock())
 
     assert temp_manager.create_temporary_directory() != temp_manager.create_temporary_directory()
 
 
 def test_delete_temporary_directories_deletes_all_previously_created_directories() -> None:
-    temp_manager = TempManager()
+    temp_manager = TempManager(mock.Mock())
 
     paths = []
     for i in range(5):


### PR DESCRIPTION
Added temporary directory path and disk space metrics to the verbose debug output of lean data download

Closes #568 