### PR TITLE
fix: running `IQFeed` client locally

### DIFF
--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -17,7 +17,6 @@ from docker.types import Mount
 from typing import Any, Dict, Iterable, List, Optional
 from click import command, option, confirm, pass_context, Context, Choice, prompt
 from lean.click import LeanCommand, ensure_options
-from lean.commands.live.deploy import _start_iqconnect_if_necessary
 from lean.components.util.json_modules_handler import config_build_for_name
 from lean.constants import DEFAULT_ENGINE_IMAGE
 from lean.container import container
@@ -721,9 +720,6 @@ def download(ctx: Context,
                   type="bind",
                   read_only=True)
         )
-
-        # Run IQConnect if using the IQFeed data downloader
-        _start_iqconnect_if_necessary(lean_config, data_downloader_provider.get_settings()["data-downloader"])
 
         success = container.docker_manager.run_image(engine_image, **run_options)
 

--- a/lean/commands/data/download.py
+++ b/lean/commands/data/download.py
@@ -17,6 +17,7 @@ from docker.types import Mount
 from typing import Any, Dict, Iterable, List, Optional
 from click import command, option, confirm, pass_context, Context, Choice, prompt
 from lean.click import LeanCommand, ensure_options
+from lean.commands.live.deploy import _start_iqconnect_if_necessary
 from lean.components.util.json_modules_handler import config_build_for_name
 from lean.constants import DEFAULT_ENGINE_IMAGE
 from lean.container import container
@@ -720,6 +721,9 @@ def download(ctx: Context,
                   type="bind",
                   read_only=True)
         )
+
+        # Run IQConnect if using the IQFeed data downloader
+        _start_iqconnect_if_necessary(lean_config, data_downloader_provider.get_settings()["data-downloader"])
 
         success = container.docker_manager.run_image(engine_image, **run_options)
 

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -233,7 +233,7 @@ class LeanRunner:
                 lean_config[key] = "host.docker.internal"
 
         # Set up modules
-        set_up_common_csharp_options_called = self._setup_installed_packages(run_options, image)
+        set_up_common_csharp_options_called = self._setup_installed_packages(run_options, image, lean_config)
 
         # Set up language-specific run options
         self.setup_language_specific_run_options(run_options, project_dir, algorithm_file,
@@ -295,7 +295,7 @@ class LeanRunner:
                 lean_config[key] = "host.docker.internal"
 
         # Set up modules
-        self._setup_installed_packages(run_options, image, target_path)
+        self._setup_installed_packages(run_options, image, lean_config, target_path)
 
         self._mount_lean_config_and_finalize(run_options, lean_config, None, config_local_path)
 
@@ -340,7 +340,8 @@ class LeanRunner:
                 if "live-mode-brokerage" in environment:
                     output_config.set("brokerage", environment["live-mode-brokerage"].split(".")[-1])
 
-    def _setup_installed_packages(self, run_options: Dict[str, Any], image: DockerImage, target_path: str = "/Lean/Launcher/bin/Debug"):
+    def _setup_installed_packages(self, run_options: Dict[str, Any], image: DockerImage,
+                                  lean_config: Dict[str, Any], target_path: str = "/Lean/Launcher/bin/Debug"):
         """Sets up installed packages."""
         installed_packages = self._module_manager.get_installed_packages()
         if installed_packages:
@@ -364,6 +365,7 @@ class LeanRunner:
             for package in installed_packages:
                 self._logger.debug(f"LeanRunner._setup_installed_packages(): Adding module {package} to the project")
                 run_options["commands"].append(f"rm -rf /root/.nuget/packages/{package.name.lower()}")
+                self._ensure_iqconnect_running(lean_config, package.name)
                 run_options["commands"].append(f"dotnet add /ModulesProject package {package.name} --version {package.version}")
 
             # Copy all module files to /Lean/Launcher/bin/Debug, but don't overwrite anything that already exists
@@ -938,7 +940,7 @@ for library_id, library_data in project_assets["targets"][project_target].items(
 
             if "name" in extra_docker_config:
                 run_options["name"] = extra_docker_config["name"]
-            
+
             if "environment" in extra_docker_config:
                 target = run_options.get("environment")
                 if not target:
@@ -947,7 +949,7 @@ for library_id, library_data in project_assets["targets"][project_target].items(
                     target.update({item[0]: item[1] for item in [
                         item if not isinstance(item, str) else (item.split("=")[0], item.split("=")[1]) for item in extra_docker_config["environment"]
                     ]})
-                elif isinstance(extra_docker_config["environment"], dict): 
+                elif isinstance(extra_docker_config["environment"], dict):
                     target.update(extra_docker_config["environment"])
                 else:
                     raise ValueError("Additional environment variables can be passed to the container in a dictionary, list of '{key}={value}' strings, or list of '(key, value)' tuples.")
@@ -975,3 +977,54 @@ for library_id, library_data in project_assets["targets"][project_target].items(
                     if "read_only" in mount:
                         read_only = mount["read_only"]
                     target.append(Mount(target=mount["target"], source=mount["source"], type="bind", read_only=read_only))
+
+    def _ensure_iqconnect_running(self, lean_config: Dict[str, Any], data_provider_package_name: str) -> None:
+        """
+        Starts the IQConnect client if the given data provider is IQFeed.
+
+        :param lean_config: The LEAN configuration dictionary to use.
+        :param data_provider_package_name: The fully qualified name of the data provider or data downloader.
+        """
+
+        if data_provider_package_name != "QuantConnect.Lean.DataSource.IQFeed":
+            self._logger.debug(
+                f"Skipped starting IQConnect: data provider '{data_provider_package_name}' is not IQFeed."
+            )
+            return
+
+        args = [
+            lean_config["iqfeed-iqconnect"],
+            "-product", lean_config["iqfeed-productName"],
+            "-version", lean_config["iqfeed-version"],
+            "-autoconnect"
+        ]
+
+        username = lean_config.get("iqfeed-username", "")
+        if username != "":
+            args.extend(["-login", username])
+
+        password = lean_config.get("iqfeed-password", "")
+        if password != "":
+            args.extend(["-password", password])
+
+        from subprocess import Popen
+
+        try:
+            process = Popen(args)
+        except FileNotFoundError:
+            raise RuntimeError(
+                "IQFeed executable not found. Please check:\n"
+                " - The path in 'args' is correct.\n"
+                " - IQFeed is installed.\n"
+                " - You have permission to access the file."
+            )
+
+        self._logger.info("Waiting 10 seconds for IQFeed to start")
+        from time import sleep
+        sleep(10)
+
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"IQFeed failed to start (exit code {process.returncode}). "
+                "Check if IQFeed is installed, path is correct, and no other instance is running."
+            )

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -1012,7 +1012,7 @@ for library_id, library_data in project_assets["targets"][project_target].items(
         try:
             process = Popen(args)
         except FileNotFoundError:
-            raise RuntimeError(
+            self._logger.warn(
                 "IQFeed executable not found. Please check:\n"
                 " - The path in 'args' is correct.\n"
                 " - IQFeed is installed.\n"
@@ -1024,7 +1024,8 @@ for library_id, library_data in project_assets["targets"][project_target].items(
         sleep(10)
 
         if process.poll() is not None:
-            raise RuntimeError(
+            self._logger.warn(
                 f"IQFeed failed to start (exit code {process.returncode}). "
-                "Check if IQFeed is installed, path is correct, and no other instance is running."
+                "It might already be running, or there was an error starting it. "
+                "Check if IQFeed is installed, the path is correct, and no issues with permissions."
             )

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -1018,6 +1018,7 @@ for library_id, library_data in project_assets["targets"][project_target].items(
                 " - IQFeed is installed.\n"
                 " - You have permission to access the file."
             )
+            return
 
         self._logger.info("Waiting 10 seconds for IQFeed to start")
         from time import sleep


### PR DESCRIPTION
# Description


# Test
## Success 
### Download package and run iQFeed process
#### `lean live deploy`
```
lean live deploy TestHistoryProvider --brokerage "Paper Trading" --data-provider-live IQFeed
```
<img width="1488" height="374" alt="image" src="https://github.com/user-attachments/assets/99e156c5-c463-42f9-be5e-25dd73181a70" />

#### `lean data download`
```
lean data download --data-provider-historical IQFeed --data-type trade --security-type future --resolution daily --market cme --ticker nq --start 20250601 --end 20250701
```
<img width="1442" height="443" alt="image" src="https://github.com/user-attachments/assets/49cd2f82-7150-4189-9efa-6701970143ea" />

#### `lean backtest`
```
lean backtest TestHistoryProvider --data-provider-historical IQFeed
```
<img width="1084" height="394" alt="image" src="https://github.com/user-attachments/assets/17b05478-8abd-4168-9514-da91cf8f1fb5" />

## Failure
### Application isn't starting.
#### `lean live deploy`
```
lean live deploy TestHistoryProvider --brokerage "Paper Trading" --data-provider-live IQFeed
--
Error: IQFeed failed to start (exit code 0). Check if IQFeed is installed, path is correct, and no other instance is running.
```
<img width="1065" height="75" alt="image" src="https://github.com/user-attachments/assets/6cb17694-8393-4384-a7fb-6558c4958b63" />

#### `lean data download`
```
lean data download --data-provider-historical IQFeed --data-type trade --security-type future --resolution daily --market cme --ticker nq --start 20250601 --end 20250701
--
Error: IQFeed failed to start (exit code 0). Check if IQFeed is installed, path is correct, and no other instance is running.
```
<img width="1454" height="118" alt="image" src="https://github.com/user-attachments/assets/f55ed15c-1a26-43de-9195-b010a24fdc9a" />

### Application isn't installed.
Added a more graceful and user-friendly exception.
<img width="646" height="97" alt="image" src="https://github.com/user-attachments/assets/5344bed3-5217-47c4-9853-cf3bda5d4acf" />






