### PR TITLE
Fix `datetime` parsing for cloud deployment timestamps

### DIFF
--- a/lean/components/util/live_utils.py
+++ b/lean/components/util/live_utils.py
@@ -45,9 +45,9 @@ def _get_last_portfolio(api_client: APIClient, project_id: str, project_name: Pa
         cloud_deployment = api_client.get("live/read", {"projectId": project_id})
         if cloud_deployment["success"] and cloud_deployment["status"] != "Undefined":
             if cloud_deployment["stopped"] is not None:
-                cloud_last_time = datetime.strptime(cloud_deployment["stopped"], "%Y-%m-%d %H:%M:%S")
+                cloud_last_time = datetime.strptime(cloud_deployment["stopped"], "%Y-%m-%dT%H:%M:%SZ")
             else:
-                cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%d %H:%M:%S")
+                cloud_last_time = datetime.strptime(cloud_deployment["launched"], "%Y-%m-%dT%H:%M:%SZ")
     cloud_last_time = datetime(cloud_last_time.year, cloud_last_time.month,
                                cloud_last_time.day, cloud_last_time.hour,
                                cloud_last_time.minute,

--- a/tests/commands/cloud/live/test_cloud_live_commands.py
+++ b/tests/commands/cloud/live/test_cloud_live_commands.py
@@ -70,7 +70,7 @@ def test_cloud_live_deploy() -> None:
     api_client.nodes.get_all.return_value = create_qc_nodes()
     api_client.get.return_value = {
         "status": "stopped",
-        "stopped": "2024-07-10 19:12:20",
+        "stopped": "2024-07-10T19:12:20Z",
         "success": True,
         "portfolio": {"holdings": {}, "cash": {}, "success": True}}
     container.api_client = api_client
@@ -171,7 +171,7 @@ def test_cloud_live_deploy_with_notifications(notice_method: str, configs: str) 
     api_client.nodes.get_all.return_value = create_qc_nodes()
     api_client.get.return_value = {
         "status": "stopped",
-        "stopped": "2024-07-10 19:12:20",
+        "stopped": "2024-07-10T19:12:20Z",
         "success": True,
         "portfolio": {"holdings": {}, "cash": {}, "success": True}}
     container.api_client = api_client
@@ -261,7 +261,7 @@ def test_cloud_live_deploy_with_live_cash_balance(brokerage: str, cash: str) -> 
     api_client.nodes.get_all.return_value = create_qc_nodes()
     api_client.get.return_value = {
         "status": "stopped",
-        "stopped": "2024-07-10 19:12:20",
+        "stopped": "2024-07-10T19:12:20Z",
         "success": True,
         "portfolio": {"cash": {}, "holdings": {}}}
     container.api_client = api_client
@@ -351,7 +351,7 @@ def test_cloud_live_deploy_with_live_holdings(brokerage: str, holdings: str) -> 
     api_client.nodes.get_all.return_value = create_qc_nodes()
     api_client.get.return_value = {
         "status": "stopped",
-        "stopped": "2024-07-10 19:12:20",
+        "stopped": "2024-07-10T19:12:20Z",
         "success": True,
         "portfolio": {"cash": {}, "holdings": {}}}
     container.api_client = api_client


### PR DESCRIPTION
#### Description:
This PR updates the handling of `cloud_deployment["stopped"]` and `cloud_deployment["launched"]` fields to correctly parse ISO 8601 UTC strings (e.g., `2025-09-06T12:05:33Z`).

Previously, parsing failed because the format string (`%Y-%m-%d %H:%M:%S`) did not match the `T` separator and `Z` suffix.
New format scrennshot:

##### Screenshots
📸 Updated timestamp format shown in `cloud_deployment` live/read view:
<img width="1817" height="114" alt="image" src="https://github.com/user-attachments/assets/5ed7c08d-3581-4583-b22d-f334da601637" />


#### Motivation and Context
- Fixes runtime errors when reading cloud deployment timestamps.
- Ensures reliable extraction of last deployment time from `stopped` or fallback `launched`.

#### How Has This Been Tested?
- Verified parsing with both `stopped` and `launched` timestamps in ISO 8601 UTC format.
- Confirmed no errors are raised when `stopped` is `None`.