### PR TITLE
Fix issues #544 and #364: Add --extra-docker-config-file and --docker…

### DIFF
--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -284,7 +284,7 @@ def _migrate_csharp_csproj(project_dir: Path) -> None:
                    "This is recommended over --extra-docker-config on Windows to avoid shell quote issues.")
 @option("--docker-timeout",
               type=int,
-              help="Docker client timeout in seconds (default: 60). "
+              help="Timeout in seconds for Docker operations (default: 60). "
                    "Increase this for slow connections or large image pulls. "
                    "Can also be set via DOCKER_CLIENT_TIMEOUT environment variable.")
 @option("--no-update",
@@ -333,7 +333,8 @@ def backtest(project: Path,
     
     # Set Docker timeout if specified
     if docker_timeout is not None:
-        container.docker_manager._timeout = docker_timeout
+        container.docker_manager.set_timeout(docker_timeout)
+    
     project_manager = container.project_manager
     algorithm_file = project_manager.find_algorithm_file(Path(project))
     lean_config_manager = container.lean_config_manager

--- a/lean/commands/backtest.py
+++ b/lean/commands/backtest.py
@@ -278,6 +278,15 @@ def _migrate_csharp_csproj(project_dir: Path) -> None:
               default="{}",
               help="Extra docker configuration as a JSON string. "
                    "For more information https://docker-py.readthedocs.io/en/stable/containers.html")
+@option("--extra-docker-config-file",
+              type=PathParameter(exists=True, file_okay=True, dir_okay=False),
+              help="Path to a JSON file with extra docker configuration. "
+                   "This is recommended over --extra-docker-config on Windows to avoid shell quote issues.")
+@option("--docker-timeout",
+              type=int,
+              help="Docker client timeout in seconds (default: 60). "
+                   "Increase this for slow connections or large image pulls. "
+                   "Can also be set via DOCKER_CLIENT_TIMEOUT environment variable.")
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -298,6 +307,8 @@ def backtest(project: Path,
              addon_module: Optional[List[str]],
              extra_config: Optional[Tuple[str, str]],
              extra_docker_config: Optional[str],
+             extra_docker_config_file: Optional[Path],
+             docker_timeout: Optional[int],
              no_update: bool,
              parameter: List[Tuple[str, str]],
              **kwargs) -> None:
@@ -316,9 +327,13 @@ def backtest(project: Path,
     Alternatively you can set the default engine image for all commands using `lean config set engine-image <image>`.
     """
     from datetime import datetime
-    from json import loads
+    from lean.components.util.json_parser import load_json_from_file_or_string
 
     logger = container.logger
+    
+    # Set Docker timeout if specified
+    if docker_timeout is not None:
+        container.docker_manager._timeout = docker_timeout
     project_manager = container.project_manager
     algorithm_file = project_manager.find_algorithm_file(Path(project))
     lean_config_manager = container.lean_config_manager
@@ -402,6 +417,12 @@ def backtest(project: Path,
         # Override existing parameters if any are provided via --parameter
         lean_config["parameters"] = lean_config_manager.get_parameters(parameter)
 
+    # Parse extra Docker configuration from string or file
+    parsed_extra_docker_config = load_json_from_file_or_string(
+        json_string=extra_docker_config if extra_docker_config != "{}" else None,
+        json_file=extra_docker_config_file
+    )
+    
     lean_runner = container.lean_runner
     lean_runner.run_lean(lean_config,
                          environment_name,
@@ -411,5 +432,5 @@ def backtest(project: Path,
                          debugging_method,
                          release,
                          detach,
-                         loads(extra_docker_config),
+                         parsed_extra_docker_config,
                          paths_to_mount)

--- a/lean/commands/live/deploy.py
+++ b/lean/commands/live/deploy.py
@@ -172,8 +172,8 @@ def deploy(project: Path,
     
     # Set Docker timeout if specified
     if docker_timeout is not None:
-        container.docker_manager._timeout = docker_timeout
-
+        container.docker_manager.set_timeout(docker_timeout)
+    
     project_manager = container.project_manager
     algorithm_file = project_manager.find_algorithm_file(Path(project))
 

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -139,6 +139,15 @@ def _get_latest_backtest_runtime(algorithm_directory: Path) -> timedelta:
               default="{}",
               help="Extra docker configuration as a JSON string. "
                    "For more information https://docker-py.readthedocs.io/en/stable/containers.html")
+@option("--extra-docker-config-file",
+              type=PathParameter(exists=True, file_okay=True, dir_okay=False),
+              help="Path to a JSON file with extra docker configuration. "
+                   "This is recommended over --extra-docker-config on Windows to avoid shell quote issues.")
+@option("--docker-timeout",
+              type=int,
+              help="Timeout in seconds for Docker operations (default: 60). "
+                   "Increase this for slow connections or large image pulls. "
+                   "Can also be set via DOCKER_CLIENT_TIMEOUT environment variable.")
 @option("--no-update",
               is_flag=True,
               default=False,
@@ -164,6 +173,8 @@ def optimize(project: Path,
              addon_module: Optional[List[str]],
              extra_config: Optional[Tuple[str, str]],
              extra_docker_config: Optional[str],
+             extra_docker_config_file: Optional[Path],
+             docker_timeout: Optional[int],
              no_update: bool,
              **kwargs) -> None:
     """Optimize a project's parameters locally using Docker.
@@ -207,7 +218,12 @@ def optimize(project: Path,
     from docker.types import Mount
     from re import findall, search
     from os import cpu_count
+    from lean.components.util.json_parser import load_json_from_file_or_string
     from math import floor
+
+    # Set Docker timeout if specified
+    if docker_timeout is not None:
+        container.docker_manager._timeout = docker_timeout
 
     should_detach = detach and not estimate
     environment_name = "backtesting"
@@ -343,7 +359,12 @@ def optimize(project: Path,
     )
 
     # Add known additional run options from the extra docker config
-    LeanRunner.parse_extra_docker_config(run_options, loads(extra_docker_config))
+    # Parse extra Docker configuration from string or file
+    parsed_extra_docker_config = load_json_from_file_or_string(
+        json_string=extra_docker_config if extra_docker_config != "{}" else None,
+        json_file=extra_docker_config_file
+    )
+    LeanRunner.parse_extra_docker_config(run_options, parsed_extra_docker_config)
 
     project_manager.copy_code(algorithm_file.parent, output / "code")
 

--- a/lean/commands/optimize.py
+++ b/lean/commands/optimize.py
@@ -223,7 +223,7 @@ def optimize(project: Path,
 
     # Set Docker timeout if specified
     if docker_timeout is not None:
-        container.docker_manager._timeout = docker_timeout
+        container.docker_manager.set_timeout(docker_timeout)
 
     should_detach = detach and not estimate
     environment_name = "backtesting"

--- a/lean/commands/research.py
+++ b/lean/commands/research.py
@@ -113,8 +113,8 @@ def research(project: Path,
     
     # Set Docker timeout if specified
     if docker_timeout is not None:
-        container.docker_manager._timeout = docker_timeout
-
+        container.docker_manager.set_timeout(docker_timeout)
+    
     project_manager = container.project_manager
     algorithm_file = project_manager.find_algorithm_file(project, not_throw = True)
 

--- a/lean/components/docker/docker_manager.py
+++ b/lean/components/docker/docker_manager.py
@@ -40,6 +40,13 @@ class DockerManager:
         self._platform_manager = platform_manager
         self._timeout = timeout
 
+    def set_timeout(self, timeout: int) -> None:
+        """Set the timeout for Docker client operations.
+        
+        :param timeout: The timeout in seconds for Docker client operations
+        """
+        self._timeout = timeout
+
     def get_image_labels(self, image: str) -> str:
         docker_image = self._get_docker_client().images.get(image)
         return docker_image.labels.items()
@@ -575,7 +582,11 @@ class DockerManager:
             from os import environ
             
             # Check for environment variable override
-            timeout = int(environ.get("DOCKER_CLIENT_TIMEOUT", self._timeout))
+            try:
+                timeout = int(environ.get("DOCKER_CLIENT_TIMEOUT", self._timeout))
+            except ValueError:
+                # Fall back to instance timeout on invalid value
+                timeout = self._timeout
             
             docker_client = from_env(timeout=timeout)
         except Exception:

--- a/lean/components/util/json_parser.py
+++ b/lean/components/util/json_parser.py
@@ -1,0 +1,94 @@
+# QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+# Lean CLI v1.0. Copyright 2021 QuantConnect Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, Any, Optional
+from json import loads, JSONDecodeError
+
+
+def parse_json_safely(json_string: str) -> Dict[str, Any]:
+    """
+    Attempts to parse a JSON string with multiple fallback strategies.
+    
+    This function is designed to handle JSON strings that may have been
+    mangled by Windows shells (PowerShell/CMD) which strip or escape quotes.
+    
+    :param json_string: The JSON string to parse
+    :return: Parsed dictionary
+    :raises ValueError: If all parsing attempts fail
+    """
+    if not json_string or json_string.strip() == "":
+        return {}
+    
+    # Try standard JSON parsing first
+    try:
+        return loads(json_string)
+    except JSONDecodeError as e:
+        original_error = str(e)
+    
+    # Try fixing common Windows shell issues
+    # 1. Try adding back quotes that may have been stripped
+    attempts = [
+        json_string,
+        json_string.replace("'", '"'),  # Single quotes to double quotes
+        '{"' + json_string.strip('{}').replace(':', '":').replace(',', ',"') + '}',  # Add missing quotes
+    ]
+    
+    for attempt in attempts[1:]:  # Skip first as we already tried it
+        try:
+            return loads(attempt)
+        except JSONDecodeError:
+            continue
+    
+    # If all attempts fail, provide helpful error message
+    raise ValueError(
+        f"Failed to parse JSON configuration. Original error: {original_error}\n"
+        f"Input: {json_string}\n\n"
+        f"On Windows, JSON strings may be mangled by the shell. Consider using --extra-docker-config-file instead.\n"
+        f"Example: Create a file 'docker-config.json' with your configuration and use:\n"
+        f"  --extra-docker-config-file docker-config.json"
+    )
+
+
+def load_json_from_file_or_string(
+    json_string: Optional[str] = None,
+    json_file: Optional[Path] = None
+) -> Dict[str, Any]:
+    """
+    Loads JSON configuration from either a string or a file.
+    
+    :param json_string: JSON string to parse (optional)
+    :param json_file: Path to JSON file (optional)
+    :return: Parsed dictionary
+    :raises ValueError: If both parameters are None or if parsing fails
+    """
+    if json_file is not None:
+        if not json_file.exists():
+            raise ValueError(f"Configuration file not found: {json_file}")
+        
+        try:
+            with open(json_file, 'r', encoding='utf-8') as f:
+                content = f.read()
+                return loads(content)
+        except JSONDecodeError as e:
+            raise ValueError(
+                f"Failed to parse JSON from file {json_file}: {e}\n"
+                f"Please ensure the file contains valid JSON."
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to read file {json_file}: {e}")
+    
+    if json_string is not None:
+        return parse_json_safely(json_string)
+    
+    return {}

--- a/lean/container.py
+++ b/lean/container.py
@@ -102,7 +102,10 @@ class Container:
 
         self.docker_manager = docker_manager
         if not self.docker_manager:
-            self.docker_manager = DockerManager(self.logger, self.temp_manager, self.platform_manager)
+            from os import environ
+            # Get timeout from environment variable, default to 60 seconds
+            timeout = int(environ.get("DOCKER_CLIENT_TIMEOUT", 60))
+            self.docker_manager = DockerManager(self.logger, self.temp_manager, self.platform_manager, timeout)
 
         self.project_manager = ProjectManager(self.logger,
                                               self.project_config_manager,


### PR DESCRIPTION
…-timeout options

Issue #544: Fix Windows Argument Parsing for --extra-docker-config
- Added --extra-docker-config-file option to all commands that support --extra-docker-config
- Created lean/components/util/json_parser.py with robust JSON parsing
- Handles Windows shell quote mangling with fallback strategies
- Provides helpful error messages for JSON parsing failures
- Updated commands: backtest, research, optimize, live/deploy

Issue #364: Add Docker Client Timeout Configuration
- Added timeout parameter to DockerManager.__init__() with default of 60 seconds
- Modified _get_docker_client() to use configurable timeout
- Added --docker-timeout option to all relevant commands
- Supports DOCKER_CLIENT_TIMEOUT environment variable
- Updated container.py to read environment variable on initialization
- Updated commands: backtest, research, optimize, live/deploy

All changes are backward compatible - existing usage continues to work. Tested with Python 3.12 - all tests pass successfully.