### PR TITLE
fix: change uid field in QCCollaborator to Optional[int]

### DIFF
--- a/lean/models/api.py
+++ b/lean/models/api.py
@@ -55,7 +55,7 @@ class ProjectEncryptionKey(WrappedBaseModel):
     name: str
 
 class QCCollaborator(WrappedBaseModel):
-    uid: int
+    uid: Optional[int]
     liveControl: bool
     permission: str
     profileImage: str


### PR DESCRIPTION
Fxing error after doing lean cloud pull


Error: 1 validation error for QCProject
collaborators -> 1 -> uid
  none is not an allowed value (type=type_error.none.not_allowed)
