### PR TITLE
Handle missing object-store without throwing exceptions

### DIFF
--- a/lean/commands/cloud/object_store/list.py
+++ b/lean/commands/cloud/object_store/list.py
@@ -33,14 +33,18 @@ def list(key: str):
     try:
         headers = ["key", "size", "folder", "name"]
         display_headers = ["Key", "Bytes", "Folder", "Filename"]
-        rows = [[str(obj.get(header, "")) for header in headers] for obj in data['objects']]
+        objects = data.get('objects')
+
+        if objects is None or not objects:
+            logger.info(f"No objects found at '{key}'.")
+            return
+
+        rows = [[str(obj.get(header, "")) for header in headers] for obj in objects]
         # sort rows by key
         rows.sort(key=lambda x: x[0])
         all_rows = [display_headers] + rows
         column_widths = [max(len(row[i]) for row in all_rows) for i in range(len(all_rows[0]))]
         for row in all_rows:
             logger.info("  ".join(value.ljust(width) for value, width in zip(row, column_widths)))
-    except KeyError as e:
-        logger.error(f"Key {key} not found.")
     except Exception as e:
         logger.error(f"Error: {e}")

--- a/tests/commands/cloud/object_store/test_list.py
+++ b/tests/commands/cloud/object_store/test_list.py
@@ -13,6 +13,7 @@
 
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 
 from lean.commands import lean
@@ -28,3 +29,22 @@ def test_list_gets_value_when_key_is_given() -> None:
     result = CliRunner().invoke(lean, ["cloud", "object-store", "list", "test-key"])
     assert result.exit_code == 0
     container.api_client.object_store.list.assert_called_once_with('test-key', 'abc')
+
+@pytest.mark.parametrize("objects_value", [None, []])
+def test_list_handles_empty_or_none_objects(objects_value) -> None:
+    api_client = mock.Mock()
+    api_client.is_authenticated.return_value = True
+    api_client.object_store.list.return_value = {
+        'objects': objects_value,
+        'success': True,
+        'path': 'test'
+    }
+    initialize_container(api_client_to_use=api_client)
+
+    result = CliRunner().invoke(lean, ["cloud", "object-store", "list", "test"])
+
+    assert result.exit_code == 0
+    assert "No objects found at 'test'." in result.output
+    container.api_client.object_store.list.assert_called_once_with('test', 'abc')
+
+


### PR DESCRIPTION
Replace unhandled exceptions with informative messages for missing object store

Closes #599 