### PR TITLE
feat: add `--charles-schwab-user-name` option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
+  --charles-schwab-user-name TEXT
+                                  Your Charles Schwab username used for OAuth authentication
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary
@@ -461,6 +463,8 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
+  --charles-schwab-user-name TEXT
+                                  Your Charles Schwab username used for OAuth authentication
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --bybit-api-key TEXT            Your Bybit API key
@@ -927,6 +931,8 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
+  --charles-schwab-user-name TEXT
+                                  Your Charles Schwab username used for OAuth authentication
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary
@@ -1444,6 +1450,8 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
+  --charles-schwab-user-name TEXT
+                                  Your Charles Schwab username used for OAuth authentication
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --bybit-api-key TEXT            Your Bybit API key
@@ -1850,6 +1858,8 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
+  --charles-schwab-user-name TEXT
+                                  Your Charles Schwab username used for OAuth authentication
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary
@@ -2108,6 +2118,8 @@ Options:
   --kraken-api-secret TEXT        Your Kraken API secret
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
+  --charles-schwab-user-name TEXT
+                                  Your Charles Schwab username used for OAuth authentication
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Options:
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
   --charles-schwab-user-name TEXT
-                                  Your Charles Schwab username used for OAuth authentication
+                                  Your Charles Schwab login ID
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary
@@ -464,7 +464,7 @@ Options:
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
   --charles-schwab-user-name TEXT
-                                  Your Charles Schwab username used for OAuth authentication
+                                  Your Charles Schwab login ID
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --bybit-api-key TEXT            Your Bybit API key
@@ -932,7 +932,7 @@ Options:
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
   --charles-schwab-user-name TEXT
-                                  Your Charles Schwab username used for OAuth authentication
+                                  Your Charles Schwab login ID
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary
@@ -1451,7 +1451,7 @@ Options:
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
   --charles-schwab-user-name TEXT
-                                  Your Charles Schwab username used for OAuth authentication
+                                  Your Charles Schwab login ID
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --bybit-api-key TEXT            Your Bybit API key
@@ -1859,7 +1859,7 @@ Options:
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
   --charles-schwab-user-name TEXT
-                                  Your Charles Schwab username used for OAuth authentication
+                                  Your Charles Schwab login ID
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary
@@ -2119,7 +2119,7 @@ Options:
   --kraken-verification-tier [Starter|Intermediate|Pro]
                                   Your Kraken Verification Tier
   --charles-schwab-user-name TEXT
-                                  Your Charles Schwab username used for OAuth authentication
+                                  Your Charles Schwab login ID
   --charles-schwab-account-number TEXT
                                   The CharlesSchwab account number
   --iqfeed-iqconnect TEXT         The path to the IQConnect binary

--- a/lean/models/json_module.py
+++ b/lean/models/json_module.py
@@ -175,13 +175,15 @@ class JsonModule(ABC):
         """
         return variable_key.replace('_', '-')
 
-    def get_user_name(self, lean_config: Dict[str, Any], configuration, user_provided_options: Dict[str, Any], require_user_name: bool) -> str:
+    def get_user_name(self, lean_config: Dict[str, Any], configuration, user_provided_options: Dict[str, Any],
+                      require_user_name: bool, interactive: bool) -> str:
         """Retrieve the user name, prompting the user if required and not already set.
 
         :param lean_config: The Lean config dict to read defaults from.
         :param configuration: The AuthConfiguration instance.
         :param user_provided_options: Options passed as command-line arguments.
         :param require_user_name: Flag to determine if prompting is necessary.
+        :param interactive: ask user input parameter manually (interactively)
         :return: The user name, or None if not required.
         """
         if not require_user_name:
@@ -193,6 +195,8 @@ class JsonModule(ABC):
             return user_provided_options[user_name_variable]
         if lean_config and lean_config.get(user_name_key):
             return lean_config[user_name_key]
+        if not interactive:
+            raise RuntimeError(f"You are missing the following option {user_name_key}")
         user_name = prompt("Please enter your Login ID to proceed with Auth0 authentication",
                            show_default=False)
         if lean_config is not None:
@@ -263,7 +267,7 @@ class JsonModule(ABC):
                                                                 configuration.require_project_id)
                 logger.debug(f'project_id: {lean_config["project-id"]}')
                 user_name = self.get_user_name(lean_config, configuration, user_provided_options,
-                                               configuration.require_user_name)
+                                               configuration.require_user_name, interactive)
                 logger.debug(f'user_name: {user_name}')
                 auth_authorizations = get_authorization(container.api_client.auth0, self._display_name.lower(),
                                                         logger, lean_config["project-id"], no_browser=no_browser,

--- a/tests/commands/test_live.py
+++ b/tests/commands/test_live.py
@@ -432,7 +432,8 @@ brokerage_required_options = {
         "tt-log-fix-messages": "no"
     },
     "CharlesSchwab": {
-        "charles-schwab-account-number": "123"
+        "charles-schwab-account-number": "123",
+        "charles-schwab-user-name": "user"
     },
     "Bybit": {
         "bybit-api-key": "abc",

--- a/tests/components/util/test_json_modules_handler.py
+++ b/tests/components/util/test_json_modules_handler.py
@@ -81,7 +81,8 @@ def test_is_value_in_config(searching: str, expected: bool) -> None:
 def test_get_user_name_returns_none_when_not_required() -> None:
     module = JsonModule({"id": "test", "configurations": [], "display-id": "Test"},
                         MODULE_BROKERAGE, MODULE_CLI_PLATFORM)
-    result = module.get_user_name({}, mock.Mock(), {}, require_user_name=False)
+    result = module.get_user_name({}, mock.Mock(), {}, require_user_name=False,
+                                  interactive=False)
     assert result is None
 
 
@@ -92,7 +93,7 @@ def test_get_user_name_from_user_provided_options() -> None:
     config._id = "charles-schwab-oauth-token"
     result = module.get_user_name({}, config,
                                   {"charles_schwab_user_name": "cli_login"},
-                                  require_user_name=True)
+                                  require_user_name=True, interactive=False)
     assert result == "cli_login"
 
 
@@ -102,7 +103,7 @@ def test_get_user_name_from_lean_config() -> None:
     config = mock.Mock()
     config._id = "charles-schwab-oauth-token"
     lean_config = {"charles-schwab-user-name": "saved_login"}
-    result = module.get_user_name(lean_config, config, {}, require_user_name=True)
+    result = module.get_user_name(lean_config, config, {}, require_user_name=True, interactive=False)
     assert result == "saved_login"
 
 
@@ -113,7 +114,7 @@ def test_get_user_name_prompts_and_saves_to_lean_config() -> None:
     config._id = "charles-schwab-oauth-token"
     lean_config = {}
     with mock.patch("click.prompt", return_value="prompted_login") as mock_prompt:
-        result = module.get_user_name(lean_config, config, {}, require_user_name=True)
+        result = module.get_user_name(lean_config, config, {}, require_user_name=True, interactive=True)
     assert result == "prompted_login"
     assert lean_config["charles-schwab-user-name"] == "prompted_login"
     mock_prompt.assert_called_once()


### PR DESCRIPTION
Adds `charles-schwab-user-name` input config to `modules-1.14.json` so the user's
Charles Schwab login ID is collected and used during OAuth authentication.

Updates README to document `--charles-schwab-user-name` across all relevant commands.

Closes #639

#### How Has This Been Tested?
- The normal running
```
lean live deploy CharlesSchwabTestAlgo --brokerage CharlesSchwab --data-provider-live CharlesSchwab --charles-schwab-user-name XXXXXX --charles-schwab-account-number XXXXXXX
```

- If the user inputs the wrong `account-number`
  <img width="1497" height="55" alt="image" src="https://github.com/user-attachments/assets/62186a8b-8e77-454b-a5c3-51210d5ea610" />

- If the user input does not exsist OAuth user name, he will be redirected to authorization page
  <img width="1554" height="84" alt="image" src="https://github.com/user-attachments/assets/aef95340-98a6-4be3-b0ef-473e855d1b14" />






