### PR TITLE
feature: add webull brokerage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Options:
   -d, --detach                    Run the backtest in a detached Docker container and return immediately
   --debug [pycharm|ptvsd|debugpy|vsdbg|rider|local-platform]
                                   Enable a certain debugging method (see --help for more information)
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -248,6 +248,9 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
+  --webull-app-key TEXT           Your Webull app key
+  --webull-app-secret TEXT        Your Webull app secret
+  --webull-account-id TEXT        Your Webull account ID
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the backtest when using
@@ -382,9 +385,9 @@ Usage: lean cloud live deploy [OPTIONS] PROJECT
   --notify-insights.
 
 Options:
-  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX]
+  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
                                   The brokerage to use
-  --data-provider-live [QuantConnect|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Polygon|CoinApi|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX]
+  --data-provider-live [QuantConnect|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Polygon|CoinApi|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
                                   The live data provider to use
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -492,6 +495,11 @@ Options:
                                   Your dYdX subaccount number
   --dydx-environment [live|paper]
                                   Whether the developer sandbox should be used
+  --webull-app-key TEXT           Your Webull app key
+  --webull-app-secret TEXT        Your Webull app secret
+  --webull-account-id TEXT        Your Webull account ID
+  --webull-environment [live|paper]
+                                  Whether the paper trading environment should be used
   --polygon-api-key TEXT          Your Polygon.io API Key
   --polygon-license-type [Individual|Business]
                                   Select your Polygon.io subscription plan (Optional).
@@ -903,7 +911,7 @@ Usage: lean data download [OPTIONS]
   https://www.quantconnect.com/datasets
 
 Options:
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   The name of the downloader data provider.
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -986,6 +994,9 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
+  --webull-app-key TEXT           Your Webull app key
+  --webull-app-secret TEXT        Your Webull app secret
+  --webull-account-id TEXT        Your Webull account ID
   --dataset TEXT                  The name of the dataset to download non-interactively
   --overwrite                     Overwrite existing local data
   -y, --yes                       Automatically confirm payment confirmation prompts
@@ -1354,11 +1365,11 @@ Options:
   --environment TEXT              The environment to use
   --output DIRECTORY              Directory to store results in (defaults to PROJECT/live/TIMESTAMP)
   -d, --detach                    Run the live deployment in a detached Docker container and return immediately
-  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX]
+  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
                                   The brokerage to use
-  --data-provider-live [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|IQFeed|Polygon|CoinApi|ThetaData|Custom data only|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
+  --data-provider-live [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|IQFeed|Polygon|CoinApi|ThetaData|Custom data only|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   The live data provider to use
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -1479,6 +1490,11 @@ Options:
                                   Your dYdX subaccount number
   --dydx-environment [live|paper]
                                   Whether the developer sandbox should be used
+  --webull-app-key TEXT           Your Webull app key
+  --webull-app-secret TEXT        Your Webull app secret
+  --webull-account-id TEXT        Your Webull account ID
+  --webull-environment [live|paper]
+                                  Whether the paper trading environment should be used
   --ib-enable-delayed-streaming-data BOOLEAN
                                   Whether delayed data may be used when your algorithm subscribes to a security you
                                   don't have a market data subscription for (Optional).
@@ -1817,7 +1833,7 @@ Options:
   --parameter <TEXT FLOAT FLOAT FLOAT>...
                                   The 'parameter min max step' pairs configuring the parameters to optimize
   --constraint TEXT               The 'statistic operator value' pairs configuring the constraints of the optimization
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
@@ -1913,6 +1929,9 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
+  --webull-app-key TEXT           Your Webull app key
+  --webull-app-secret TEXT        Your Webull app secret
+  --webull-account-id TEXT        Your Webull account ID
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
@@ -2090,7 +2109,7 @@ Usage: lean research [OPTIONS] PROJECT
 
 Options:
   --port INTEGER                  The port to run Jupyter Lab on (defaults to 8888)
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -2173,6 +2192,9 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
+  --webull-app-key TEXT           Your Webull app key
+  --webull-app-secret TEXT        Your Webull app secret
+  --webull-account-id TEXT        Your Webull account ID
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the research session

--- a/README.md
+++ b/README.md
@@ -248,9 +248,11 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
-  --webull-app-key TEXT           Your Webull app key
-  --webull-app-secret TEXT        Your Webull app secret
-  --webull-account-id TEXT        Your Webull account ID
+  --webull-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --webull-app-key TEXT           Your Webull App Key
+  --webull-app-secret TEXT        Your Webull App Secret
+  --webull-account-id TEXT        Your Webull account id
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the backtest when using
@@ -387,7 +389,7 @@ Usage: lean cloud live deploy [OPTIONS] PROJECT
 Options:
   --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
                                   The brokerage to use
-  --data-provider-live [QuantConnect|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Polygon|CoinApi|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
+  --data-provider-live [QuantConnect|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Polygon|CoinApi|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX]
                                   The live data provider to use
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -495,11 +497,11 @@ Options:
                                   Your dYdX subaccount number
   --dydx-environment [live|paper]
                                   Whether the developer sandbox should be used
-  --webull-app-key TEXT           Your Webull app key
-  --webull-app-secret TEXT        Your Webull app secret
-  --webull-account-id TEXT        Your Webull account ID
   --webull-environment [live|paper]
-                                  Whether the paper trading environment should be used
+                                  Whether Live or Paper environment should be used
+  --webull-app-key TEXT           Your Webull App Key
+  --webull-app-secret TEXT        Your Webull App Secret
+  --webull-account-id TEXT        Your Webull account id
   --polygon-api-key TEXT          Your Polygon.io API Key
   --polygon-license-type [Individual|Business]
                                   Select your Polygon.io subscription plan (Optional).
@@ -994,9 +996,11 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
-  --webull-app-key TEXT           Your Webull app key
-  --webull-app-secret TEXT        Your Webull app secret
-  --webull-account-id TEXT        Your Webull account ID
+  --webull-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --webull-app-key TEXT           Your Webull App Key
+  --webull-app-secret TEXT        Your Webull App Secret
+  --webull-account-id TEXT        Your Webull account id
   --dataset TEXT                  The name of the dataset to download non-interactively
   --overwrite                     Overwrite existing local data
   -y, --yes                       Automatically confirm payment confirmation prompts
@@ -1367,7 +1371,7 @@ Options:
   -d, --detach                    Run the live deployment in a detached Docker container and return immediately
   --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
                                   The brokerage to use
-  --data-provider-live [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|IQFeed|Polygon|CoinApi|ThetaData|Custom data only|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
+  --data-provider-live [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|IQFeed|Polygon|CoinApi|ThetaData|Custom data only|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
                                   The live data provider to use
   --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
                                   Update the Lean configuration file to retrieve data from the given historical provider
@@ -1490,11 +1494,11 @@ Options:
                                   Your dYdX subaccount number
   --dydx-environment [live|paper]
                                   Whether the developer sandbox should be used
-  --webull-app-key TEXT           Your Webull app key
-  --webull-app-secret TEXT        Your Webull app secret
-  --webull-account-id TEXT        Your Webull account ID
   --webull-environment [live|paper]
-                                  Whether the paper trading environment should be used
+                                  Whether Live or Paper environment should be used
+  --webull-app-key TEXT           Your Webull App Key
+  --webull-app-secret TEXT        Your Webull App Secret
+  --webull-account-id TEXT        Your Webull account id
   --ib-enable-delayed-streaming-data BOOLEAN
                                   Whether delayed data may be used when your algorithm subscribes to a security you
                                   don't have a market data subscription for (Optional).
@@ -1929,9 +1933,11 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
-  --webull-app-key TEXT           Your Webull app key
-  --webull-app-secret TEXT        Your Webull app secret
-  --webull-account-id TEXT        Your Webull account ID
+  --webull-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --webull-app-key TEXT           Your Webull App Key
+  --webull-app-secret TEXT        Your Webull App Secret
+  --webull-account-id TEXT        Your Webull account id
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
@@ -2192,9 +2198,11 @@ Options:
   --dydx-subaccount-number INTEGER
                                   Your dYdX subaccount number
   --databento-api-key TEXT        Your Databento.com API Key
-  --webull-app-key TEXT           Your Webull app key
-  --webull-app-secret TEXT        Your Webull app secret
-  --webull-account-id TEXT        Your Webull account ID
+  --webull-environment [live|paper]
+                                  Whether Live or Paper environment should be used
+  --webull-app-key TEXT           Your Webull App Key
+  --webull-app-secret TEXT        Your Webull App Secret
+  --webull-account-id TEXT        Your Webull account id
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the research session


### PR DESCRIPTION
#### Description
Adds Webull brokerage support to LEAN CLI — registers the `WebullBrokerage` module entry with prompted credentials and live/paper environment switching.

#### Related PR(s)
- https://github.com/QuantConnect/Lean/pull/9362
- https://github.com/QuantConnect/Lean.Brokerages.WeBull/pull/1
#### Related Issue
N/A

#### Motivation and Context
Webull brokerage plugin (`Lean.Brokerages.Webull`) is ready for CLI integration. This PR registers it in `modules-1.14.json` and regenerates the README.

#### Requires Documentation Change
No

#### How Has This Been Tested?
Verified `modules-1.14.json` entry is valid JSON and README was regenerated via `python scripts/readme.py`.

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `feature-add-new-brokerage-webull`