### PR TITLE
feature: add public brokerage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Options:
   -d, --detach                    Run the backtest in a detached Docker container and return immediately
   --debug [pycharm|ptvsd|debugpy|vsdbg|rider|local-platform]
                                   Enable a certain debugging method (see --help for more information)
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull|Public]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -255,6 +255,9 @@ Options:
   --webull-app-key TEXT           Your Webull App Key
   --webull-app-secret TEXT        Your Webull App Secret
   --webull-account-id TEXT        Your Webull account id
+  --public-secret-key TEXT        Your Public.com API secret key
+  --public-account-number TEXT    Your Public.com account number. Public lets you have more than one account, so this
+                                  picks which one to trade.
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the backtest when using
@@ -389,7 +392,7 @@ Usage: lean cloud live deploy [OPTIONS] PROJECT
   --notify-insights.
 
 Options:
-  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
+  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull|Public]
                                   The brokerage to use
   --data-provider-live [QuantConnect|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Polygon|CoinApi|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX]
                                   The live data provider to use
@@ -504,6 +507,9 @@ Options:
   --webull-app-key TEXT           Your Webull App Key
   --webull-app-secret TEXT        Your Webull App Secret
   --webull-account-id TEXT        Your Webull account id
+  --public-secret-key TEXT        Your Public.com API secret key
+  --public-account-number TEXT    Your Public.com account number. Public lets you have more than one account, so this
+                                  picks which one to trade.
   --polygon-api-key TEXT          Your Polygon.io API Key
   --polygon-license-type [Individual|Business]
                                   Select your Polygon.io subscription plan (Optional).
@@ -915,7 +921,7 @@ Usage: lean data download [OPTIONS]
   https://www.quantconnect.com/datasets
 
 Options:
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull|Public]
                                   The name of the downloader data provider.
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -1003,6 +1009,9 @@ Options:
   --webull-app-key TEXT           Your Webull App Key
   --webull-app-secret TEXT        Your Webull App Secret
   --webull-account-id TEXT        Your Webull account id
+  --public-secret-key TEXT        Your Public.com API secret key
+  --public-account-number TEXT    Your Public.com account number. Public lets you have more than one account, so this
+                                  picks which one to trade.
   --dataset TEXT                  The name of the dataset to download non-interactively
   --overwrite                     Overwrite existing local data
   -y, --yes                       Automatically confirm payment confirmation prompts
@@ -1372,11 +1381,11 @@ Options:
   --environment TEXT              The environment to use
   --output DIRECTORY              Directory to store results in (defaults to PROJECT/live/TIMESTAMP)
   -d, --detach                    Run the live deployment in a detached Docker container and return immediately
-  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull]
+  --brokerage [Paper Trading|Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Webull|Public]
                                   The brokerage to use
   --data-provider-live [Interactive Brokers|Tradier|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Zerodha|Samco|Terminal Link|Trading Technologies|Kraken|CharlesSchwab|IQFeed|Polygon|CoinApi|ThetaData|Custom data only|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento]
                                   The live data provider to use
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull|Public]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -1502,6 +1511,9 @@ Options:
   --webull-app-key TEXT           Your Webull App Key
   --webull-app-secret TEXT        Your Webull App Secret
   --webull-account-id TEXT        Your Webull account id
+  --public-secret-key TEXT        Your Public.com API secret key
+  --public-account-number TEXT    Your Public.com account number. Public lets you have more than one account, so this
+                                  picks which one to trade.
   --ib-enable-delayed-streaming-data BOOLEAN
                                   Whether delayed data may be used when your algorithm subscribes to a security you
                                   don't have a market data subscription for (Optional).
@@ -1840,7 +1852,7 @@ Options:
   --parameter <TEXT FLOAT FLOAT FLOAT>...
                                   The 'parameter min max step' pairs configuring the parameters to optimize
   --constraint TEXT               The 'statistic operator value' pairs configuring the constraints of the optimization
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull|Public]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
@@ -1941,6 +1953,9 @@ Options:
   --webull-app-key TEXT           Your Webull App Key
   --webull-app-secret TEXT        Your Webull App Secret
   --webull-account-id TEXT        Your Webull account id
+  --public-secret-key TEXT        Your Public.com API secret key
+  --public-account-number TEXT    Your Public.com account number. Public lets you have more than one account, so this
+                                  picks which one to trade.
   --lean-config FILE              The Lean configuration file that should be used (defaults to the nearest lean.json)
   --verbose                       Enable debug logging
   --help                          Show this message and exit.
@@ -2118,7 +2133,7 @@ Usage: lean research [OPTIONS] PROJECT
 
 Options:
   --port INTEGER                  The port to run Jupyter Lab on (defaults to 8888)
-  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull]
+  --data-provider-historical [Interactive Brokers|Oanda|Bitfinex|Coinbase Advanced Trade|Binance|Kraken|CharlesSchwab|IQFeed|Polygon|FactSet|AlphaVantage|CoinApi|ThetaData|QuantConnect|Local|Terminal Link|Bybit|TradeStation|Alpaca|Tastytrade|Eze|dYdX|Databento|Webull|Public]
                                   Update the Lean configuration file to retrieve data from the given historical provider
   --ib-user-name TEXT             Your Interactive Brokers username
   --ib-account TEXT               Your Interactive Brokers account id
@@ -2206,6 +2221,9 @@ Options:
   --webull-app-key TEXT           Your Webull App Key
   --webull-app-secret TEXT        Your Webull App Secret
   --webull-account-id TEXT        Your Webull account id
+  --public-secret-key TEXT        Your Public.com API secret key
+  --public-account-number TEXT    Your Public.com account number. Public lets you have more than one account, so this
+                                  picks which one to trade.
   --download-data                 Update the Lean configuration file to download data from the QuantConnect API, alias
                                   for --data-provider-historical QuantConnect
   --data-purchase-limit INTEGER   The maximum amount of QCC to spend on downloading data during the research session


### PR DESCRIPTION
#### Description
Adds the Public.com brokerage to the CLI command reference (`README.md`). The change is the `scripts/readme.py` output regenerated from the updated `modules-1.14.json`: `Public` is added to the `--brokerage` and `--data-provider-historical` choice lists, and the `--public-secret-key` / `--public-account-number` options are documented for `lean live` and `lean cloud live deploy`.

#### Related PR(s)
- Brokerage plugin: https://github.com/QuantConnect/Lean.Brokerages.Public

#### Related Issue
N/A

#### Motivation and Context
The Public.com brokerage plugin is implemented and needs to be selectable from the CLI. This mirrors the Webull integration (#645), which added the brokerage to the same command reference.

#### Requires Documentation Change
This is the documentation change. The `modules-1.14.json` file is maintained separately (it is gitignored in this repo and shared with the team for review), so it is not part of this PR.

#### How Has This Been Tested?
- Ran `python scripts/readme.py`; the diff is limited to `README.md`.
- `Public` appears in `--brokerage` and `--data-provider-historical`.
- `Public` is absent from `--data-provider-live`: Public.com has no real-time market-data stream, so the brokerage advertises no `data-queue-handler` capability (`Subscribe`/`Unsubscribe` throw `NotSupportedException`).
- Prompted keys match `PublicBrokerageFactory.BrokerageData`: `public-secret-key`, `public-account-number`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
