### PR TITLE
Fix: don't downgrade map/factor-file provider based only on USA equity data

### DIFF
--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -463,12 +463,14 @@ class LeanRunner:
                                                    "map-file-provider",
                                                    "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
                                                    "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider",
-                                                   data_dir / "equity" / "usa" / "map_files")
+                                                   data_dir,
+                                                   "map_files")
             self._force_disk_provider_if_necessary(lean_config,
                                                    "factor-file-provider",
                                                    "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
                                                    "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider",
-                                                   data_dir / "equity" / "usa" / "factor_files")
+                                                   data_dir,
+                                                   "factor_files")
 
     def set_up_python_options(self, project_dir: Path, run_options: Dict[str, Any], image: DockerImage) -> None:
         """Sets up Docker run options specific to Python projects.
@@ -838,14 +840,24 @@ for library_id, library_data in project_assets["targets"][project_target].items(
                                           config_key: str,
                                           zip_provider: str,
                                           disk_provider: str,
-                                          zip_dir: Path) -> None:
+                                          data_dir: Path,
+                                          auxiliary_dir_name: str) -> None:
         """Updates the Lean config to use the disk provider instead of the zip one if there are no zips to use.
+
+        The map-file/factor-file provider is a single global engine setting that applies to every market.
+        The zip providers read per-market '<securityType>/<market>/<auxiliary_dir_name>/<name>_yyyyMMdd.zip'
+        archives, while the disk providers can only read loose '.csv' files and silently ignore those zip
+        archives. We must therefore only downgrade to the disk provider when there is no recent zip to lose
+        for *any* market, not just 'equity/usa'. Otherwise a futures-only data folder (whose map files ship
+        only inside the zip) would have its zip provider swapped out and silently stop resolving, e.g.
+        continuous futures would never map (Mapped: None) with no error raised.
 
         :param lean_config: the Lean config to update
         :param config_key: the key of the configuration property
         :param zip_provider: the fully classified name of the zip provider for this property
         :param disk_provider: the fully classified name of the disk provider for this property
-        :param zip_dir: the directory where the zip provider looks for zip files
+        :param data_dir: the root data directory
+        :param auxiliary_dir_name: the auxiliary subdirectory the zip provider reads ("map_files"/"factor_files")
         """
         from re import sub
         from datetime import datetime
@@ -853,14 +865,22 @@ for library_id, library_data in project_assets["targets"][project_target].items(
         if lean_config.get(config_key, None) != zip_provider:
             return
 
-        if not zip_dir.exists():
-            lean_config[config_key] = disk_provider
-            return
+        # Find the newest dated zip across every market's <securityType>/<market>/<auxiliary_dir_name>/ folder.
+        newest_zip_date = None
+        for auxiliary_dir in data_dir.glob(f"*/*/{auxiliary_dir_name}"):
+            if not auxiliary_dir.is_dir():
+                continue
+            for file in auxiliary_dir.iterdir():
+                if not file.name.endswith(".zip"):
+                    continue
+                try:
+                    zip_date = datetime.strptime(sub(r"[^\d]", "", file.name), "%Y%m%d")
+                except ValueError:
+                    continue
+                if newest_zip_date is None or zip_date > newest_zip_date:
+                    newest_zip_date = zip_date
 
-        zip_names = sorted([f.name for f in zip_dir.iterdir() if f.name.endswith(".zip")], reverse=True)
-        zip_names = [sub(r"[^\d]", "", name) for name in zip_names]
-
-        if len(zip_names) == 0 or (datetime.now() - datetime.strptime(zip_names[0], "%Y%m%d")).days > 7:
+        if newest_zip_date is None or (datetime.now() - newest_zip_date).days > 7:
             lean_config[config_key] = disk_provider
 
     def setup_language_specific_run_options(self, run_options, project_dir, algorithm_file,

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -866,7 +866,7 @@ for library_id, library_data in project_assets["targets"][project_target].items(
             return
 
         # Find the newest dated zip across every market's <securityType>/<market>/<auxiliary_dir_name>/ folder.
-        newest_zip_date = None
+        newest_zip_date = datetime.min
         for auxiliary_dir in data_dir.glob(f"*/*/{auxiliary_dir_name}"):
             if not auxiliary_dir.is_dir():
                 continue
@@ -877,10 +877,10 @@ for library_id, library_data in project_assets["targets"][project_target].items(
                     zip_date = datetime.strptime(sub(r"[^\d]", "", file.name), "%Y%m%d")
                 except ValueError:
                     continue
-                if newest_zip_date is None or zip_date > newest_zip_date:
+                if zip_date > newest_zip_date:
                     newest_zip_date = zip_date
 
-        if newest_zip_date is None or (datetime.now() - newest_zip_date).days > 7:
+        if (datetime.now() - newest_zip_date).days > 7:
             lean_config[config_key] = disk_provider
 
     def setup_language_specific_run_options(self, run_options, project_dir, algorithm_file,

--- a/lean/components/docker/lean_runner.py
+++ b/lean/components/docker/lean_runner.py
@@ -865,23 +865,25 @@ for library_id, library_data in project_assets["targets"][project_target].items(
         if lean_config.get(config_key, None) != zip_provider:
             return
 
-        # Find the newest dated zip across every market's <securityType>/<market>/<auxiliary_dir_name>/ folder.
-        newest_zip_date = datetime.min
-        for auxiliary_dir in data_dir.glob(f"*/*/{auxiliary_dir_name}"):
-            if not auxiliary_dir.is_dir():
+        # Keep the zip provider as long as any market has a recent map/factor file zip: the disk
+        # provider only reads loose csv, so downgrading would silently drop zip-shipped files (e.g.
+        # futures map files). We only need to know a recent zip exists, so we stop at the first one.
+        now = datetime.now()
+        for zip_file in data_dir.glob(f"*/*/{auxiliary_dir_name}/*.zip"):
+            try:
+                zip_date = datetime.strptime(sub(r"[^\d]", "", zip_file.name), "%Y%m%d")
+            except ValueError:
                 continue
-            for file in auxiliary_dir.iterdir():
-                if not file.name.endswith(".zip"):
-                    continue
-                try:
-                    zip_date = datetime.strptime(sub(r"[^\d]", "", file.name), "%Y%m%d")
-                except ValueError:
-                    continue
-                if zip_date > newest_zip_date:
-                    newest_zip_date = zip_date
+            if (now - zip_date).days <= 7:
+                self._logger.debug(
+                    f"LeanRunner._force_disk_provider_if_necessary(): found recent '{auxiliary_dir_name}' zip "
+                    f"'{zip_file.name}', keeping '{zip_provider}' for '{config_key}'")
+                return
 
-        if (datetime.now() - newest_zip_date).days > 7:
-            lean_config[config_key] = disk_provider
+        self._logger.debug(
+            f"LeanRunner._force_disk_provider_if_necessary(): no '{auxiliary_dir_name}' zip newer than 7 days, "
+            f"using '{disk_provider}' for '{config_key}'")
+        lean_config[config_key] = disk_provider
 
     def setup_language_specific_run_options(self, run_options, project_dir, algorithm_file,
                                             set_up_common_csharp_options_called, release, image: DockerImage) -> None:

--- a/tests/components/docker/test_lean_runner.py
+++ b/tests/components/docker/test_lean_runner.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
@@ -89,6 +90,70 @@ def create_lean_runner(docker_manager: mock.Mock) -> LeanRunner:
                       project_manager,
                       TempManager(logger),
                       xml_manager)
+
+
+def test_handle_data_providers_keeps_zip_providers_for_futures_only_data() -> None:
+    # Regression: a futures-only data folder has fresh map/factor file zips under future/cme but no
+    # equity/usa data. The global zip providers must be kept; downgrading to the disk providers would
+    # silently break futures map-file resolution (continuous futures would never map, Mapped: None).
+    lean_runner = create_lean_runner(mock.Mock())
+
+    data_dir = Path.cwd() / "data"
+    fresh = datetime.now().strftime("%Y%m%d")
+    for auxiliary_dir_name in ["map_files", "factor_files"]:
+        directory = data_dir / "future" / "cme" / auxiliary_dir_name
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / f"{auxiliary_dir_name}_{fresh}.zip").touch()
+
+    lean_config = {
+        "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
+        "map-file-provider": "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
+        "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
+    }
+    lean_runner._handle_data_providers(lean_config, data_dir)
+
+    assert lean_config["map-file-provider"] == "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider"
+    assert lean_config["factor-file-provider"] == "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider"
+
+
+def test_handle_data_providers_downgrades_to_disk_providers_without_any_zip() -> None:
+    # When the data folder only has loose csv auxiliary files (e.g. the free sample data) and no zips
+    # for any market, fall back to the disk providers which read those loose files.
+    lean_runner = create_lean_runner(mock.Mock())
+
+    data_dir = Path.cwd() / "data"
+    directory = data_dir / "equity" / "usa" / "map_files"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "spy.csv").touch()
+
+    lean_config = {
+        "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
+        "map-file-provider": "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
+        "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
+    }
+    lean_runner._handle_data_providers(lean_config, data_dir)
+
+    assert lean_config["map-file-provider"] == "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider"
+    assert lean_config["factor-file-provider"] == "QuantConnect.Data.Auxiliary.LocalDiskFactorFileProvider"
+
+
+def test_handle_data_providers_downgrades_to_disk_providers_when_zips_are_stale() -> None:
+    # If the newest zip for every market is older than the freshness window, fall back to disk.
+    lean_runner = create_lean_runner(mock.Mock())
+
+    data_dir = Path.cwd() / "data"
+    directory = data_dir / "future" / "cme" / "map_files"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "map_files_20200101.zip").touch()
+
+    lean_config = {
+        "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
+        "map-file-provider": "QuantConnect.Data.Auxiliary.LocalZipMapFileProvider",
+        "factor-file-provider": "QuantConnect.Data.Auxiliary.LocalZipFactorFileProvider",
+    }
+    lean_runner._handle_data_providers(lean_config, data_dir)
+
+    assert lean_config["map-file-provider"] == "QuantConnect.Data.Auxiliary.LocalDiskMapFileProvider"
 
 
 @pytest.mark.parametrize("release", [False, True])


### PR DESCRIPTION
## Problem

A CME-futures-only backtest (e.g. a continuous future `/NQ`) silently produces `future.Mapped == None` for every bar, selects no contract, makes no trades, and ends with `Sequence contains no elements` in result analysis — with **no error raised**.

Root cause is in lean-cli (not LEAN). `LeanRunner._handle_data_providers` downgrades the **global** `map-file-provider` (and `factor-file-provider`) from the Zip provider to the Disk provider based **solely** on the state of `equity/usa/map_files`:

```python
self._force_disk_provider_if_necessary(lean_config, "map-file-provider",
    "...LocalZipMapFileProvider", "...LocalDiskMapFileProvider",
    data_dir / "equity" / "usa" / "map_files")   # gate is USA-equity only
```

The provider is a single global engine setting applied to every market, and `LocalDiskMapFileProvider` reads only loose `.csv` files — it silently ignores `map_files_yyyyMMdd.zip` archives. Futures map files (e.g. `nq.csv`) ship only inside that zip. So a futures-only user (fresh `future/cme/map_files/*.zip`, but no fresh `equity/usa` data) has the global provider swapped to Disk, and the continuous future never maps.

## Fix

Gate the downgrade on **every** market's auxiliary folder (`<type>/<market>/{map_files,factor_files}/`) instead of just `equity/usa`. Only fall back to the Disk provider when there is no recent zip to lose for **any** market. Futures-only users keep `LocalZipMapFileProvider`; equity-sample users (loose csv, no zips) still downgrade as before.

## Testing

- Added regression tests in `tests/components/docker/test_lean_runner.py`: futures-only data keeps the Zip providers; loose-csv-only data downgrades to Disk; all-stale-zip data downgrades to Disk.
- Verified end-to-end: a CME continuous-future backtest with no USA-equity map files now maps correctly (`Mapped: NQ ...`) with the stock engine image; previously `Mapped: None`.
- Full `test_lean_runner.py` and `test_backtest.py` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)