### PR TITLE
Fix projects CRUD regression test

### DIFF
--- a/tests/components/api/test_clients.py
+++ b/tests/components/api/test_clients.py
@@ -137,7 +137,8 @@ def test_projects_crud() -> None:
     project_client.delete(created_project.projectId)
 
     # Test the project is really deleted
-    projects = project_client.get_all(None)
+    # The API soft deletes projects (moves them to "Recycle Bin/..."), so exclude those
+    projects = [p for p in project_client.get_all(None) if not p.name.startswith("Recycle Bin/")]
     assert not any([p.projectId == created_project.projectId for p in projects])
 
 


### PR DESCRIPTION
The API now soft deletes projects into a Recycle Bin, so the test filters those out before asserting deletion