### PR TITLE
Fix misleading "Invalid credentials" error when requested data is not available

### DIFF
--- a/lean/components/api/api_client.py
+++ b/lean/components/api/api_client.py
@@ -158,7 +158,7 @@ class APIClient:
             return self._request(method, endpoint, options, False)
 
         if response.status_code == 500:
-            raise AuthenticationError()
+            raise AuthenticationError(response)
 
         if response.status_code < 200 or response.status_code >= 300:
             raise RequestFailedError(response)

--- a/lean/components/api/data_client.py
+++ b/lean/components/api/data_client.py
@@ -13,6 +13,7 @@
 
 from lean.components.api.api_client import *
 from lean.models.api import QCDataInformation
+from lean.models.errors import AuthenticationError
 from typing import List, Callable, cast
 
 
@@ -110,9 +111,15 @@ class DataClient:
         if prefix in DataClient._list_files_cache:
             return DataClient._list_files_cache[prefix]
 
-        data = self._api.post("data/list", {
-            "filePath": prefix
-        })
+        try:
+            data = self._api.post("data/list", {
+                "filePath": prefix
+            })
+        except AuthenticationError:
+            # The API returns a 500 response (which the API client translates into an AuthenticationError)
+            # when the given prefix does not exist, credential issues would have surfaced in earlier requests
+            raise RuntimeError(f"The requested data with prefix '{prefix}' is not available, "
+                               "please contact support@quantconnect.com")
 
         first_part = prefix.split("/")[0]
         files = sorted(f"{first_part}/{obj}" for obj in data["objects"])

--- a/lean/components/api/data_client.py
+++ b/lean/components/api/data_client.py
@@ -115,9 +115,12 @@ class DataClient:
             data = self._api.post("data/list", {
                 "filePath": prefix
             })
-        except AuthenticationError:
-            # The API returns a 500 response (which the API client translates into an AuthenticationError)
-            # when the given prefix does not exist, credential issues would have surfaced in earlier requests
+        except AuthenticationError as error:
+            # The API returns a 500 response with an empty body (which the API client translates into
+            # an AuthenticationError) when the given prefix does not exist, errors caused by genuinely
+            # invalid credentials don't originate from such a response and are re-raised unchanged
+            if error.response is None or error.response.status_code != 500:
+                raise
             raise RuntimeError(f"The requested data with prefix '{prefix}' is not available, "
                                "please contact support@quantconnect.com")
 

--- a/lean/models/errors.py
+++ b/lean/models/errors.py
@@ -51,7 +51,12 @@ class MoreInfoError(Exception):
 class AuthenticationError(MoreInfoError):
     """An error indicating that a request has failed because the used credentials were invalid."""
 
-    def __init__(self) -> None:
-        """Creates a new AuthenticationError instance."""
+    def __init__(self, response=None) -> None:
+        """Creates a new AuthenticationError instance.
+
+        :param response: the data of the failed response, if the error was inferred from an HTTP response
+        """
         super().__init__("Invalid credentials, please log in using `lean login`",
                          "https://www.lean.io/docs/v2/lean-cli/initialization/authenticating-accounts#02-Log-In")
+
+        self.response = response

--- a/tests/components/api/test_clients.py
+++ b/tests/components/api/test_clients.py
@@ -270,7 +270,7 @@ def test_data_client_list_files() -> None:
 
 def test_data_client_list_files_raises_data_not_available_error_when_api_returns_500() -> None:
     api_client = mock.Mock()
-    api_client.post.side_effect = AuthenticationError()
+    api_client.post.side_effect = AuthenticationError(mock.Mock(status_code=500))
     data_client = DataClient(api_client, HTTPClient(mock.Mock()))
 
     with pytest.raises(RuntimeError) as error:
@@ -279,6 +279,17 @@ def test_data_client_list_files_raises_data_not_available_error_when_api_returns
     assert "setup/forex/oanda/202" in str(error.value)
     assert "is not available" in str(error.value)
     assert "support@quantconnect.com" in str(error.value)
+
+
+def test_data_client_list_files_raises_authentication_error_when_credentials_are_invalid() -> None:
+    api_client = mock.Mock()
+    api_client.post.side_effect = AuthenticationError()
+    data_client = DataClient(api_client, HTTPClient(mock.Mock()))
+
+    with pytest.raises(AuthenticationError) as error:
+        data_client.list_files("equity/usa/daily")
+
+    assert "Invalid credentials" in str(error.value)
 
 
 def test_data_client_get_info() -> None:

--- a/tests/components/api/test_clients.py
+++ b/tests/components/api/test_clients.py
@@ -33,6 +33,7 @@ from lean.components.api.project_client import ProjectClient
 from lean.components.util.http_client import HTTPClient
 from lean.constants import API_BASE_URL
 from lean.models.api import QCCompileState, QCLanguage, QCParameter, QCProject
+from lean.models.errors import AuthenticationError
 
 # These tests require a QuantConnect user id and API token
 # The credentials can also be provided using the QC_USER_ID and QC_API_TOKEN environment variables
@@ -265,6 +266,19 @@ def test_data_client_list_files() -> None:
     # Test all files start with the requested prefix
     for file in files:
         assert file.startswith("crypto/coinbase/daily/")
+
+
+def test_data_client_list_files_raises_data_not_available_error_when_api_returns_500() -> None:
+    api_client = mock.Mock()
+    api_client.post.side_effect = AuthenticationError()
+    data_client = DataClient(api_client, HTTPClient(mock.Mock()))
+
+    with pytest.raises(RuntimeError) as error:
+        data_client.list_files("setup/forex/oanda/202")
+
+    assert "setup/forex/oanda/202" in str(error.value)
+    assert "is not available" in str(error.value)
+    assert "support@quantconnect.com" in str(error.value)
 
 
 def test_data_client_get_info() -> None:


### PR DESCRIPTION
## Description

When `lean data download` requests a data path that is not available, e.g.:

```
lean data download --dataset "FOREX Data" --data-type Bulk --resolution Second --start 20250101 --end 20260101
```

the `data/list` API endpoint responds with status code 500 and an empty body:

```
--> POST https://www.quantconnect.com/api/v2/data/list with data:
{
    "filePath": "setup/forex/oanda/202"
}
Request was not successful, status code 500, empty body
```

The API client maps any 500 response to an `AuthenticationError`, so the user sees `Invalid credentials, please log in using 'lean login'` — misleading, since the credentials are valid (earlier authenticated requests in the download flow such as `data/prices` have already succeeded by the time `data/list` is called).

This PR catches that error in `DataClient.list_files` and raises a clear message instead:

```
Error: The requested data with prefix 'setup/forex/oanda/202' is not available, please contact support@quantconnect.com
```

The response is now attached to `AuthenticationError` when it is inferred from a 500 status code, so `list_files` only replaces the message in that case — an `AuthenticationError` caused by genuinely invalid credentials (hash mismatch) is re-raised unchanged. Other failures are untouched: `success: false` responses keep the API's own error text, and other status codes keep the generic request-failed message.

## Testing

All `data/list` failure modes through the real `APIClient`/`DataClient` with a mocked HTTP layer:

| Scenario | Message shown to the user |
|---|---|
| 500, empty body | `The requested data with prefix '...' is not available, please contact support@quantconnect.com` |
| Hash mismatch (bad credentials) | `Invalid credentials, please log in using 'lean login'` (unchanged) |
| `success: false` with API error text | API's own message, e.g. `Directory not found: ...` (unchanged) |
| Other status codes (400, 502, ...) | `POST request to .../data/list failed with status code ...` (unchanged) |

Added unit tests covering the first two rows. No open issues were found tracking this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)